### PR TITLE
Phase 3: add WASAPI capture and device routing

### DIFF
--- a/EnviousWispr.Windows.slnx
+++ b/EnviousWispr.Windows.slnx
@@ -16,4 +16,7 @@
     <Project Path="src/Production/EnviousWispr.PostProcessing/EnviousWispr.PostProcessing.csproj" />
     <Project Path="src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj" />
   </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/audio-uat/EnviousWispr.Audio.Uat.csproj" />
+  </Folder>
 </Solution>

--- a/notes/phase-three-audio.md
+++ b/notes/phase-three-audio.md
@@ -12,6 +12,11 @@ hardware and fault-recovery exit in `docs/plans/windows-master-plan.md` is satis
 - The capture contract rejects overlap, supports cancellation, emits peak/RMS levels, and returns 16 kHz
   mono float samples. An unexpected stop returns buffered samples with a typed interruption error so a
   later pipeline can retry without losing the take.
+- The WASAPI boundary is isolated behind an internal recorder session interface. Production owns the
+  NAudio adapter, while tests can deterministically trigger startup failure, unexpected stop, and stop
+  timeout without exposing NAudio types to Core.
+- Capture-device notification classification is isolated from COM event delivery so add/remove/state and
+  default-device transitions can be verified even when the corresponding physical hardware is absent.
 - A pure converter covers IEEE single-precision and signed 16/24/32-bit PCM, channel mixing, clipping,
   level calculation, and linear conversion to 16 kHz mono.
 - `tools/audio-uat` is a content-free native harness built by the canonical validation command.
@@ -19,17 +24,22 @@ hardware and fault-recovery exit in `docs/plans/windows-master-plan.md` is satis
 ## Automated evidence
 
 - `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate.ps1` passed with zero build
-  warnings/errors, 34 portable proof tests, and 23 production tests.
+  warnings/errors, 34 portable proof tests, and 35 production tests.
 - Converter tests cover empty input, stereo mixing, clipping, 48 kHz downsampling, 8 kHz upsampling,
   signed PCM normalization, peak/RMS values, and malformed-frame rejection.
 - Device-catalog integration verifies that every returned endpoint has a stable identifier and local
   display name, is active, and that at most one endpoint is the current default.
+- Recorder state tests verify normal stop, buffered-audio preservation after unexpected stop, immediate
+  interruption during startup, overlap rejection, cancellation cleanup, unavailable-device mapping, and
+  timeout cleanup. Malformed callback data interrupts capture without corrupting previously buffered
+  audio. Notification tests verify capture-versus-render classification and identity tracking after an
+  endpoint disappears.
 
 ## Native Windows acceptance observed
 
 - Windows exposed one active capture endpoint and one default capture endpoint. The connected endpoint is
   `Microphone (Logitech BRIO)`, which Windows reports as a USB audio endpoint.
-- Default-route capture completed with 31,649 samples, 1,978 ms of 16 kHz mono audio, 396 level events,
+- Default-route capture completed with 31,809 samples, 1,988 ms of 16 kHz mono audio, 398 level events,
   and no error.
 - Explicit selected-device capture completed with 15,649 samples, 978 ms of 16 kHz mono audio, 196 level
   events, and no error.
@@ -44,5 +54,3 @@ hardware and fault-recovery exit in `docs/plans/windows-master-plan.md` is satis
   those two physical-device paths are unobserved.
 - Automatic route transfer during a real default-device change and buffered-audio preservation during a
   physical device removal remain unobserved because only one capture endpoint is connected.
-- Fault-injected tests for unexpected-stop preservation and notification transitions still need a
-  controllable backend seam before Phase 3 can close.

--- a/notes/phase-three-audio.md
+++ b/notes/phase-three-audio.md
@@ -1,0 +1,48 @@
+# Phase 3 audio evidence
+
+Measured on the founder's Windows rig on 2026-08-25. This phase remains in progress until the complete
+hardware and fault-recovery exit in `docs/plans/windows-master-plan.md` is satisfied.
+
+## Implemented so far
+
+- The production Audio module uses `NAudio.Wasapi` 3.0.1 and the current `WasapiRecorder` builder API in
+  shared mode. Default capture opts into Windows automatic default-device stream routing.
+- Active capture endpoints have stable typed identifiers, display names for local UI, default state, and
+  event-based add/remove/state/default change notifications. Device names do not enter normal diagnostics.
+- The capture contract rejects overlap, supports cancellation, emits peak/RMS levels, and returns 16 kHz
+  mono float samples. An unexpected stop returns buffered samples with a typed interruption error so a
+  later pipeline can retry without losing the take.
+- A pure converter covers IEEE single-precision and signed 16/24/32-bit PCM, channel mixing, clipping,
+  level calculation, and linear conversion to 16 kHz mono.
+- `tools/audio-uat` is a content-free native harness built by the canonical validation command.
+
+## Automated evidence
+
+- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate.ps1` passed with zero build
+  warnings/errors, 34 portable proof tests, and 23 production tests.
+- Converter tests cover empty input, stereo mixing, clipping, 48 kHz downsampling, 8 kHz upsampling,
+  signed PCM normalization, peak/RMS values, and malformed-frame rejection.
+- Device-catalog integration verifies that every returned endpoint has a stable identifier and local
+  display name, is active, and that at most one endpoint is the current default.
+
+## Native Windows acceptance observed
+
+- Windows exposed one active capture endpoint and one default capture endpoint. The connected endpoint is
+  `Microphone (Logitech BRIO)`, which Windows reports as a USB audio endpoint.
+- Default-route capture completed with 31,649 samples, 1,978 ms of 16 kHz mono audio, 396 level events,
+  and no error.
+- Explicit selected-device capture completed with 15,649 samples, 978 ms of 16 kHz mono audio, 196 level
+  events, and no error.
+- A second start during active capture was rejected with the typed `CaptureAlreadyActive` error. Cancel
+  then completed and left capture inactive.
+- The harness printed counts, format, duration, outcome, and aggregate levels only. It did not print or
+  persist audio samples.
+
+## Required evidence still missing
+
+- This rig has no active built-in microphone endpoint and no active Bluetooth microphone endpoint, so
+  those two physical-device paths are unobserved.
+- Automatic route transfer during a real default-device change and buffered-audio preservation during a
+  physical device removal remain unobserved because only one capture endpoint is connected.
+- Fault-injected tests for unexpected-stop preservation and notification transitions still need a
+  controllable backend seam before Phase 3 can close.

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -70,6 +70,9 @@ try {
     Write-Host "Building production WinUI app and module graph (Release, x64)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "src/Production/EnviousWispr.App/EnviousWispr.App.csproj", "-c", "Release", "--nologo", "-p:Platform=x64")
 
+    Write-Host "Building native audio UAT harness (Release)..."
+    Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/audio-uat/EnviousWispr.Audio.Uat.csproj", "-c", "Release", "--nologo")
+
     if ($IncludeLocalRuntime) {
         Write-Host "Running contract and local model runtime tests..."
         Invoke-DotNet -Executable $dotnet8Exe -Arguments @("test", "src/EnviousWispr.Tests/EnviousWispr.Tests.csproj", "-c", "Release", "--nologo")

--- a/src/Production/EnviousWispr.Architecture.Tests/AudioDeviceChangeTrackerTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/AudioDeviceChangeTrackerTests.cs
@@ -1,0 +1,54 @@
+using EnviousWispr.Audio;
+using EnviousWispr.Core.Audio;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class AudioDeviceChangeTrackerTests
+{
+    [Fact]
+    public void KnownCaptureRemovalRemainsClassifiedAfterEndpointDisappears()
+    {
+        var tracker = new AudioDeviceChangeTracker();
+        tracker.ReplaceKnownCaptureDevices(new[] { new AudioDeviceId("capture-one") });
+
+        var change = tracker.Removed("capture-one");
+
+        Assert.Equal(AudioDeviceChangeKind.Removed, change.Kind);
+        Assert.True(change.AffectsCapture);
+    }
+
+    [Fact]
+    public void RenderRemovalDoesNotAffectCapture()
+    {
+        var tracker = new AudioDeviceChangeTracker();
+
+        var change = tracker.Removed("render-one");
+
+        Assert.False(change.AffectsCapture);
+    }
+
+    [Fact]
+    public void InactiveTransitionRemovesKnownCaptureIdentity()
+    {
+        var tracker = new AudioDeviceChangeTracker();
+        tracker.Added("capture-one", isCapture: true);
+
+        var inactive = tracker.StateChanged("capture-one", isCapture: false, isActive: false);
+        var removedAfterInactive = tracker.Removed("capture-one");
+
+        Assert.True(inactive.AffectsCapture);
+        Assert.False(removedAfterInactive.AffectsCapture);
+    }
+
+    [Fact]
+    public void DefaultCaptureTransitionIsClassifiedWithoutDeviceIdentity()
+    {
+        var change = AudioDeviceChangeTracker.DefaultChanged(
+            deviceId: null,
+            affectsCapture: true);
+
+        Assert.Equal(string.Empty, change.Id.Value);
+        Assert.Equal(AudioDeviceChangeKind.DefaultChanged, change.Kind);
+        Assert.True(change.AffectsCapture);
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/AudioSampleConverterTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/AudioSampleConverterTests.cs
@@ -1,0 +1,85 @@
+using System.Buffers.Binary;
+using EnviousWispr.Audio;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class AudioSampleConverterTests
+{
+    [Fact]
+    public void EmptyInputProducesCanonicalEmptyAudio()
+    {
+        var result = AudioSampleConverter.ConvertToMono16Khz(
+            ReadOnlySpan<byte>.Empty,
+            new AudioBufferFormat(48_000, 2, AudioSampleEncoding.Ieee754Single));
+
+        Assert.Empty(result.Samples);
+        Assert.Equal(0, result.Peak);
+        Assert.Equal(0, result.RootMeanSquare);
+    }
+
+    [Fact]
+    public void StereoFloatIsMixedClippedAndDownsampled()
+    {
+        var bytes = new byte[480 * 2 * sizeof(float)];
+        for (var frame = 0; frame < 480; frame++)
+        {
+            WriteSingle(bytes.AsSpan((frame * 8), 4), 2f);
+            WriteSingle(bytes.AsSpan((frame * 8) + 4, 4), 0.5f);
+        }
+
+        var result = AudioSampleConverter.ConvertToMono16Khz(
+            bytes,
+            new AudioBufferFormat(48_000, 2, AudioSampleEncoding.Ieee754Single));
+
+        Assert.Equal(160, result.Samples.Length);
+        Assert.All(result.Samples, sample => Assert.Equal(0.75f, sample, precision: 5));
+        Assert.Equal(0.75f, result.Peak, precision: 5);
+        Assert.Equal(0.75f, result.RootMeanSquare, precision: 5);
+    }
+
+    [Fact]
+    public void Pcm16IsUpsampledAndNormalized()
+    {
+        var bytes = new byte[80 * sizeof(short)];
+        for (var sample = 0; sample < 80; sample++)
+        {
+            BinaryPrimitives.WriteInt16LittleEndian(bytes.AsSpan(sample * 2, 2), 16_384);
+        }
+
+        var result = AudioSampleConverter.ConvertToMono16Khz(
+            bytes,
+            new AudioBufferFormat(8_000, 1, AudioSampleEncoding.SignedPcm16));
+
+        Assert.Equal(160, result.Samples.Length);
+        Assert.All(result.Samples, sample => Assert.Equal(0.5f, sample, precision: 5));
+    }
+
+    [Theory]
+    [InlineData(AudioSampleEncoding.SignedPcm24, 3)]
+    [InlineData(AudioSampleEncoding.SignedPcm32, 4)]
+    public void SignedPcmMinimumMapsToNegativeOne(AudioSampleEncoding encoding, int bytesPerSample)
+    {
+        var bytes = new byte[bytesPerSample];
+        bytes[^1] = 0x80;
+
+        var result = AudioSampleConverter.ConvertToMono16Khz(
+            bytes,
+            new AudioBufferFormat(16_000, 1, encoding));
+
+        Assert.Equal(-1f, Assert.Single(result.Samples));
+        Assert.Equal(1f, result.Peak);
+        Assert.Equal(1f, result.RootMeanSquare);
+    }
+
+    [Fact]
+    public void PartialFrameIsRejected()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            AudioSampleConverter.ConvertToMono16Khz(
+                new byte[3],
+                new AudioBufferFormat(16_000, 1, AudioSampleEncoding.Ieee754Single)));
+    }
+
+    private static void WriteSingle(Span<byte> destination, float value) =>
+        BinaryPrimitives.WriteInt32LittleEndian(destination, BitConverter.SingleToInt32Bits(value));
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/EnviousWispr.Architecture.Tests.csproj
+++ b/src/Production/EnviousWispr.Architecture.Tests/EnviousWispr.Architecture.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <ProjectReference Include="..\EnviousWispr.Audio\EnviousWispr.Audio.csproj" />
     <ProjectReference Include="..\EnviousWispr.Services\EnviousWispr.Services.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Production/EnviousWispr.Architecture.Tests/ProjectDependencyTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/ProjectDependencyTests.cs
@@ -26,7 +26,7 @@ public sealed class ProjectDependencyTests
                 "EnviousWispr.PostProcessing",
                 "EnviousWispr.Services",
             ],
-            ["EnviousWispr.Architecture.Tests"] = ["EnviousWispr.Services"],
+            ["EnviousWispr.Architecture.Tests"] = ["EnviousWispr.Audio", "EnviousWispr.Services"],
         };
 
     [Fact]

--- a/src/Production/EnviousWispr.Architecture.Tests/WasapiAudioCaptureTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/WasapiAudioCaptureTests.cs
@@ -1,0 +1,232 @@
+using System.Buffers.Binary;
+using EnviousWispr.Audio;
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class WasapiAudioCaptureTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromMilliseconds(25);
+
+    [Fact]
+    public async Task ClientStopReturnsCompletedBufferedAudio()
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+        var sessionId = DictationSessionId.Create();
+
+        var started = await capture.StartAsync(new AudioCaptureRequest(sessionId));
+        recorder.Emit(0.25f, -0.5f);
+        var result = await capture.StopAsync();
+
+        Assert.True(started.Succeeded);
+        Assert.False(capture.IsCapturing);
+        Assert.Equal(sessionId, result.SessionId);
+        Assert.Equal(AudioCaptureOutcome.Completed, result.Outcome);
+        Assert.Null(result.Error);
+        Assert.Equal(new[] { 0.25f, -0.5f }, result.Samples.ToArray());
+        Assert.True(recorder.Disposed);
+    }
+
+    [Fact]
+    public async Task UnexpectedStopPreservesTakeAsRetryableInterruption()
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+        var sessionId = DictationSessionId.Create();
+
+        await capture.StartAsync(new AudioCaptureRequest(sessionId));
+        recorder.Emit(0.4f, -0.2f, 0.1f);
+        recorder.Interrupt();
+        var result = await capture.StopAsync();
+
+        Assert.False(capture.IsCapturing);
+        Assert.Equal(sessionId, result.SessionId);
+        Assert.Equal(AudioCaptureOutcome.Interrupted, result.Outcome);
+        Assert.Equal(AppErrorCode.AudioDeviceLost, result.Error?.Code);
+        Assert.True(result.Error?.CanRetry);
+        Assert.Equal(new[] { 0.4f, -0.2f, 0.1f }, result.Samples.ToArray());
+        Assert.True(recorder.Disposed);
+    }
+
+    [Fact]
+    public async Task OverlappingStartIsRejectedWithoutReplacingActiveRecorder()
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+
+        var first = await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+        var second = await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+
+        Assert.True(first.Succeeded);
+        Assert.False(second.Succeeded);
+        Assert.Equal(AppErrorCode.CaptureAlreadyActive, second.Error?.Code);
+        Assert.Equal(1, recorder.StartCount);
+        await capture.CancelAsync();
+    }
+
+    [Fact]
+    public async Task CancelClearsBufferedAudioAndEmitsSilentLevel()
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+        var levels = new List<AudioLevel>();
+        capture.LevelChanged += (_, level) => levels.Add(level);
+
+        await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+        recorder.Emit(0.75f);
+        var cancelled = await capture.CancelAsync();
+        var afterCancel = await capture.StopAsync();
+
+        Assert.True(cancelled.Succeeded);
+        Assert.False(capture.IsCapturing);
+        Assert.Equal(AudioLevel.Silent, levels[^1]);
+        Assert.Equal(AppErrorCode.InvalidTransition, afterCancel.Error?.Code);
+        Assert.Empty(afterCancel.Samples.ToArray());
+        Assert.True(recorder.Disposed);
+    }
+
+    [Fact]
+    public async Task StopTimeoutReturnsInterruptionAndStillDisposesRecorder()
+    {
+        var recorder = new FakeRecorderSession { CompleteWhenStopped = false };
+        await using var capture = CreateCapture(recorder);
+
+        await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+        recorder.Emit(0.6f);
+        var result = await capture.StopAsync();
+
+        Assert.Equal(AudioCaptureOutcome.Interrupted, result.Outcome);
+        Assert.Equal(AppErrorCode.AudioDeviceLost, result.Error?.Code);
+        Assert.Single(result.Samples.ToArray());
+        Assert.True(recorder.Disposed);
+    }
+
+    [Fact]
+    public async Task UnavailableDeviceIsReturnedAsTypedStartFailure()
+    {
+        var factory = new FakeRecorderFactory(
+            new InvalidOperationException("Synthetic unavailable endpoint."));
+        await using var capture = new WasapiAudioCapture(factory, TestTimeout);
+
+        var result = await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(AppErrorCode.AudioDeviceUnavailable, result.Error?.Code);
+        Assert.True(result.Error?.CanRetry);
+    }
+
+    [Fact]
+    public async Task ImmediateBackendStopDuringStartLeavesCaptureInactiveAndRecoverable()
+    {
+        var recorder = new FakeRecorderSession { InterruptWhenStarted = true };
+        await using var capture = CreateCapture(recorder);
+
+        var started = await capture.StartAsync(
+            new AudioCaptureRequest(DictationSessionId.Create()));
+        var result = await capture.StopAsync();
+
+        Assert.True(started.Succeeded);
+        Assert.False(capture.IsCapturing);
+        Assert.Equal(AudioCaptureOutcome.Interrupted, result.Outcome);
+        Assert.Equal(AppErrorCode.AudioDeviceLost, result.Error?.Code);
+    }
+
+    [Fact]
+    public async Task MalformedCallbackInterruptsCaptureWithoutCorruptingPriorAudio()
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+
+        await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+        recorder.Emit(0.3f);
+        recorder.EmitBytes(new byte[3]);
+        var result = await capture.StopAsync();
+
+        Assert.Equal(AudioCaptureOutcome.Interrupted, result.Outcome);
+        Assert.Equal(AppErrorCode.AudioDeviceLost, result.Error?.Code);
+        Assert.Equal(0.3f, Assert.Single(result.Samples.ToArray()), precision: 5);
+    }
+
+    private static WasapiAudioCapture CreateCapture(FakeRecorderSession recorder) =>
+        new(new FakeRecorderFactory(recorder), TestTimeout);
+
+    private sealed class FakeRecorderFactory : IAudioRecorderFactory
+    {
+        private readonly IAudioRecorderSession? _recorder;
+        private readonly Exception? _exception;
+
+        public FakeRecorderFactory(IAudioRecorderSession recorder) => _recorder = recorder;
+
+        public FakeRecorderFactory(Exception exception) => _exception = exception;
+
+        public Task<IAudioRecorderSession> CreateAsync(
+            AudioDeviceId? deviceId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return _exception is null
+                ? Task.FromResult(_recorder!)
+                : Task.FromException<IAudioRecorderSession>(_exception);
+        }
+    }
+
+    private sealed class FakeRecorderSession : IAudioRecorderSession
+    {
+        public event EventHandler<AudioRecorderData>? DataAvailable;
+
+        public event EventHandler<AudioRecorderStopped>? Stopped;
+
+        public bool CompleteWhenStopped { get; init; } = true;
+
+        public bool InterruptWhenStarted { get; init; }
+
+        public int StartCount { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public void Start()
+        {
+            StartCount++;
+            if (InterruptWhenStarted)
+            {
+                Interrupt();
+            }
+        }
+
+        public void Stop()
+        {
+            if (CompleteWhenStopped)
+            {
+                Stopped?.Invoke(this, new AudioRecorderStopped(Exception: null));
+            }
+        }
+
+        public void Emit(params float[] samples)
+        {
+            var bytes = new byte[samples.Length * sizeof(float)];
+            for (var index = 0; index < samples.Length; index++)
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(
+                    bytes.AsSpan(index * sizeof(float), sizeof(float)),
+                    BitConverter.SingleToInt32Bits(samples[index]));
+            }
+
+            EmitBytes(bytes);
+        }
+
+        public void EmitBytes(byte[] bytes) =>
+            DataAvailable?.Invoke(this, new AudioRecorderData(bytes, IsSilent: false));
+
+        public void Interrupt(Exception? exception = null) =>
+            Stopped?.Invoke(this, new AudioRecorderStopped(exception));
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/WasapiDeviceCatalogTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/WasapiDeviceCatalogTests.cs
@@ -1,0 +1,22 @@
+using EnviousWispr.Audio;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class WasapiDeviceCatalogTests
+{
+    [Fact]
+    public async Task EnumerationReturnsOnlyWellFormedActiveCaptureDevices()
+    {
+        using var catalog = new WasapiDeviceCatalog();
+
+        var devices = await catalog.GetCaptureDevicesAsync();
+
+        Assert.All(devices, device =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(device.Id.Value));
+            Assert.False(string.IsNullOrWhiteSpace(device.DisplayName));
+            Assert.True(device.IsActive);
+        });
+        Assert.InRange(devices.Count(device => device.IsDefault), 0, 1);
+    }
+}

--- a/src/Production/EnviousWispr.Audio/AudioDeviceChangeTracker.cs
+++ b/src/Production/EnviousWispr.Audio/AudioDeviceChangeTracker.cs
@@ -1,0 +1,77 @@
+using EnviousWispr.Core.Audio;
+
+namespace EnviousWispr.Audio;
+
+internal sealed class AudioDeviceChangeTracker
+{
+    private readonly object _gate = new();
+    private readonly HashSet<string> _knownCaptureDeviceIds = new(StringComparer.Ordinal);
+
+    public void ReplaceKnownCaptureDevices(IEnumerable<AudioDeviceId> deviceIds)
+    {
+        lock (_gate)
+        {
+            _knownCaptureDeviceIds.Clear();
+            foreach (var deviceId in deviceIds)
+            {
+                _knownCaptureDeviceIds.Add(deviceId.Value);
+            }
+        }
+    }
+
+    public AudioDeviceChange Added(string deviceId, bool isCapture)
+    {
+        if (isCapture)
+        {
+            lock (_gate)
+            {
+                _knownCaptureDeviceIds.Add(deviceId);
+            }
+        }
+
+        return Change(deviceId, AudioDeviceChangeKind.Added, isCapture);
+    }
+
+    public AudioDeviceChange Removed(string deviceId)
+    {
+        bool wasCapture;
+        lock (_gate)
+        {
+            wasCapture = _knownCaptureDeviceIds.Remove(deviceId);
+        }
+
+        return Change(deviceId, AudioDeviceChangeKind.Removed, wasCapture);
+    }
+
+    public AudioDeviceChange StateChanged(string deviceId, bool isCapture, bool isActive)
+    {
+        bool affectsCapture;
+        lock (_gate)
+        {
+            if (isCapture && isActive)
+            {
+                _knownCaptureDeviceIds.Add(deviceId);
+                affectsCapture = true;
+            }
+            else if (!isActive)
+            {
+                affectsCapture = _knownCaptureDeviceIds.Remove(deviceId) || isCapture;
+            }
+            else
+            {
+                affectsCapture = false;
+            }
+        }
+
+        return Change(deviceId, AudioDeviceChangeKind.StateChanged, affectsCapture);
+    }
+
+    public static AudioDeviceChange DefaultChanged(string? deviceId, bool affectsCapture) =>
+        Change(deviceId ?? string.Empty, AudioDeviceChangeKind.DefaultChanged, affectsCapture);
+
+    private static AudioDeviceChange Change(
+        string deviceId,
+        AudioDeviceChangeKind kind,
+        bool affectsCapture) =>
+        new(new AudioDeviceId(deviceId), kind, affectsCapture);
+}

--- a/src/Production/EnviousWispr.Audio/AudioRecorderBackend.cs
+++ b/src/Production/EnviousWispr.Audio/AudioRecorderBackend.cs
@@ -1,0 +1,114 @@
+using EnviousWispr.Core.Audio;
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace EnviousWispr.Audio;
+
+internal sealed record AudioRecorderData(ReadOnlyMemory<byte> Bytes, bool IsSilent);
+
+internal sealed record AudioRecorderStopped(Exception? Exception);
+
+internal interface IAudioRecorderSession : IAsyncDisposable
+{
+    event EventHandler<AudioRecorderData>? DataAvailable;
+
+    event EventHandler<AudioRecorderStopped>? Stopped;
+
+    void Start();
+
+    void Stop();
+}
+
+internal interface IAudioRecorderFactory
+{
+    Task<IAudioRecorderSession> CreateAsync(
+        AudioDeviceId? deviceId,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed class WasapiRecorderFactory : IAudioRecorderFactory
+{
+    private static readonly WaveFormat CaptureFormat = WaveFormat.CreateIeeeFloatWaveFormat(
+        AudioSampleConverter.TargetSampleRate,
+        channels: 1);
+
+    public async Task<IAudioRecorderSession> CreateAsync(
+        AudioDeviceId? deviceId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var builder = new WasapiRecorderBuilder()
+            .WithSharedMode()
+            .WithEventSync()
+            .WithBufferLength(50)
+            .WithFormat(CaptureFormat)
+            .WithMmcssThreadPriority("Audio");
+
+        WasapiRecorder recorder;
+        if (deviceId is null)
+        {
+            recorder = await builder
+                .WithDefaultDeviceStreamRouting()
+                .BuildAsync()
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            using var enumerator = new MMDeviceEnumerator();
+            using var device = enumerator.GetDevice(deviceId.Value.Value);
+            recorder = builder.WithDevice(device).Build();
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            await recorder.DisposeAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        return new NAudioRecorderSession(recorder);
+    }
+}
+
+internal sealed class NAudioRecorderSession : IAudioRecorderSession
+{
+    private readonly WasapiRecorder _recorder;
+
+    public NAudioRecorderSession(WasapiRecorder recorder)
+    {
+        _recorder = recorder;
+        _recorder.DataAvailable += OnDataAvailable;
+        _recorder.RecordingStopped += OnRecordingStopped;
+    }
+
+    public event EventHandler<AudioRecorderData>? DataAvailable;
+
+    public event EventHandler<AudioRecorderStopped>? Stopped;
+
+    public void Start() => _recorder.StartRecording();
+
+    public void Stop() => _recorder.StopRecording();
+
+    public async ValueTask DisposeAsync()
+    {
+        _recorder.DataAvailable -= OnDataAvailable;
+        _recorder.RecordingStopped -= OnRecordingStopped;
+        await _recorder.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void OnDataAvailable(
+        ReadOnlySpan<byte> data,
+        AudioClientBufferFlags flags,
+        long devicePosition,
+        long performanceCounterPosition)
+    {
+        var bytes = data.ToArray();
+        DataAvailable?.Invoke(
+            this,
+            new AudioRecorderData(bytes, (flags & AudioClientBufferFlags.Silent) != 0));
+    }
+
+    private void OnRecordingStopped(object? sender, StoppedEventArgs args) =>
+        Stopped?.Invoke(this, new AudioRecorderStopped(args.Exception));
+}

--- a/src/Production/EnviousWispr.Audio/AudioSampleConverter.cs
+++ b/src/Production/EnviousWispr.Audio/AudioSampleConverter.cs
@@ -1,0 +1,133 @@
+using System.Buffers.Binary;
+
+namespace EnviousWispr.Audio;
+
+public enum AudioSampleEncoding
+{
+    Ieee754Single,
+    SignedPcm16,
+    SignedPcm24,
+    SignedPcm32,
+}
+
+public readonly record struct AudioBufferFormat(
+    int SampleRate,
+    int Channels,
+    AudioSampleEncoding Encoding);
+
+public sealed record AudioConversionResult(float[] Samples, float Peak, float RootMeanSquare);
+
+public static class AudioSampleConverter
+{
+    public const int TargetSampleRate = 16_000;
+
+    public static AudioConversionResult ConvertToMono16Khz(
+        ReadOnlySpan<byte> source,
+        AudioBufferFormat format)
+    {
+        Validate(format);
+        var bytesPerSample = BytesPerSample(format.Encoding);
+        var bytesPerFrame = checked(bytesPerSample * format.Channels);
+        if (source.Length % bytesPerFrame != 0)
+        {
+            throw new ArgumentException("Audio data must contain complete frames.", nameof(source));
+        }
+
+        var frameCount = source.Length / bytesPerFrame;
+        if (frameCount == 0)
+        {
+            return new AudioConversionResult([], Peak: 0, RootMeanSquare: 0);
+        }
+
+        var mono = new float[frameCount];
+        double sumSquares = 0;
+        var peak = 0f;
+        for (var frame = 0; frame < frameCount; frame++)
+        {
+            double sum = 0;
+            var frameOffset = frame * bytesPerFrame;
+            for (var channel = 0; channel < format.Channels; channel++)
+            {
+                var sampleOffset = frameOffset + (channel * bytesPerSample);
+                sum += Decode(source.Slice(sampleOffset, bytesPerSample), format.Encoding);
+            }
+
+            var sample = Math.Clamp((float)(sum / format.Channels), -1f, 1f);
+            mono[frame] = sample;
+            peak = Math.Max(peak, Math.Abs(sample));
+            sumSquares += sample * sample;
+        }
+
+        var rms = (float)Math.Sqrt(sumSquares / frameCount);
+        return new AudioConversionResult(
+            Resample(mono, format.SampleRate),
+            peak,
+            rms);
+    }
+
+    private static float[] Resample(float[] source, int sourceSampleRate)
+    {
+        if (sourceSampleRate == TargetSampleRate || source.Length == 0)
+        {
+            return source;
+        }
+
+        var outputLength = Math.Max(
+            1,
+            (int)Math.Round(source.Length * (double)TargetSampleRate / sourceSampleRate));
+        var output = new float[outputLength];
+        var sourceStep = sourceSampleRate / (double)TargetSampleRate;
+
+        for (var index = 0; index < output.Length; index++)
+        {
+            var sourcePosition = index * sourceStep;
+            var lower = Math.Min((int)sourcePosition, source.Length - 1);
+            var upper = Math.Min(lower + 1, source.Length - 1);
+            var fraction = sourcePosition - lower;
+            output[index] = (float)(source[lower] + ((source[upper] - source[lower]) * fraction));
+        }
+
+        return output;
+    }
+
+    private static float Decode(ReadOnlySpan<byte> bytes, AudioSampleEncoding encoding) => encoding switch
+    {
+        AudioSampleEncoding.Ieee754Single => Math.Clamp(
+            BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(bytes)),
+            -1f,
+            1f),
+        AudioSampleEncoding.SignedPcm16 => BinaryPrimitives.ReadInt16LittleEndian(bytes) / 32768f,
+        AudioSampleEncoding.SignedPcm24 => DecodePcm24(bytes) / 8_388_608f,
+        AudioSampleEncoding.SignedPcm32 => BinaryPrimitives.ReadInt32LittleEndian(bytes) / 2_147_483_648f,
+        _ => throw new ArgumentOutOfRangeException(nameof(encoding)),
+    };
+
+    private static int DecodePcm24(ReadOnlySpan<byte> bytes)
+    {
+        var value = bytes[0] | (bytes[1] << 8) | (bytes[2] << 16);
+        return (value & 0x0080_0000) == 0 ? value : value | unchecked((int)0xFF00_0000);
+    }
+
+    private static int BytesPerSample(AudioSampleEncoding encoding) => encoding switch
+    {
+        AudioSampleEncoding.Ieee754Single or AudioSampleEncoding.SignedPcm32 => 4,
+        AudioSampleEncoding.SignedPcm24 => 3,
+        AudioSampleEncoding.SignedPcm16 => 2,
+        _ => throw new ArgumentOutOfRangeException(nameof(encoding)),
+    };
+
+    private static void Validate(AudioBufferFormat format)
+    {
+        if (format.SampleRate is < 8_000 or > 384_000)
+        {
+            throw new ArgumentOutOfRangeException(nameof(format), "Sample rate is outside the supported range.");
+        }
+
+        if (format.Channels is < 1 or > 32)
+        {
+            throw new ArgumentOutOfRangeException(nameof(format), "Channel count is outside the supported range.");
+        }
+
+        _ = BytesPerSample(format.Encoding);
+    }
+}

--- a/src/Production/EnviousWispr.Audio/EnviousWispr.Audio.csproj
+++ b/src/Production/EnviousWispr.Audio/EnviousWispr.Audio.csproj
@@ -2,4 +2,8 @@
   <ItemGroup>
     <ProjectReference Include="..\EnviousWispr.Core\EnviousWispr.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NAudio.Wasapi" Version="3.0.1" />
+  </ItemGroup>
 </Project>

--- a/src/Production/EnviousWispr.Audio/EnviousWispr.Audio.csproj
+++ b/src/Production/EnviousWispr.Audio/EnviousWispr.Audio.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="EnviousWispr.Architecture.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\EnviousWispr.Core\EnviousWispr.Core.csproj" />
   </ItemGroup>
 

--- a/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
+++ b/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
@@ -1,29 +1,48 @@
 using EnviousWispr.Core.Audio;
 using EnviousWispr.Core.Dictation;
 using EnviousWispr.Core.Errors;
-using NAudio.CoreAudioApi;
-using NAudio.Wave;
 using System.Runtime.InteropServices;
 
 namespace EnviousWispr.Audio;
 
 public sealed class WasapiAudioCapture : IAudioCapture
 {
-    private static readonly WaveFormat CaptureFormat = WaveFormat.CreateIeeeFloatWaveFormat(
+    private static readonly AudioBufferFormat CaptureFormat = new(
         AudioSampleConverter.TargetSampleRate,
-        channels: 1);
+        Channels: 1,
+        AudioSampleEncoding.Ieee754Single);
 
     private readonly object _bufferGate = new();
     private readonly SemaphoreSlim _transitionGate = new(1, 1);
     private readonly MemoryStream _capturedBytes = new();
-    private WasapiRecorder? _recorder;
+    private readonly IAudioRecorderFactory _recorderFactory;
+    private readonly TimeSpan _stopTimeout;
+    private IAudioRecorderSession? _recorder;
     private TaskCompletionSource<Exception?>? _recordingStopped;
     private AudioCaptureRequest? _request;
+    private volatile bool _isCapturing;
+    private volatile bool _clientRequestedStop;
+    private volatile bool _backendStopped;
+    private volatile bool _unexpectedStop;
     private bool _disposed;
+
+    public WasapiAudioCapture()
+        : this(new WasapiRecorderFactory(), TimeSpan.FromSeconds(2))
+    {
+    }
+
+    internal WasapiAudioCapture(IAudioRecorderFactory recorderFactory, TimeSpan stopTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(recorderFactory);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(stopTimeout, TimeSpan.Zero);
+
+        _recorderFactory = recorderFactory;
+        _stopTimeout = stopTimeout;
+    }
 
     public event EventHandler<AudioLevel>? LevelChanged;
 
-    public bool IsCapturing { get; private set; }
+    public bool IsCapturing => _isCapturing;
 
     public async Task<AudioOperationResult> StartAsync(
         AudioCaptureRequest request,
@@ -33,15 +52,17 @@ public sealed class WasapiAudioCapture : IAudioCapture
         try
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            if (IsCapturing)
+            if (_recorder is not null)
             {
                 return Failure(AppErrorCode.CaptureAlreadyActive, canRetry: false);
             }
 
-            WasapiRecorder recorder;
+            IAudioRecorderSession recorder;
             try
             {
-                recorder = await BuildRecorderAsync(request.DeviceId).ConfigureAwait(false);
+                recorder = await _recorderFactory
+                    .CreateAsync(request.DeviceId, cancellationToken)
+                    .ConfigureAwait(false);
             }
             catch (ArgumentException)
             {
@@ -69,21 +90,23 @@ public sealed class WasapiAudioCapture : IAudioCapture
             _recordingStopped = new TaskCompletionSource<Exception?>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             _recorder = recorder;
+            _clientRequestedStop = false;
+            _backendStopped = false;
+            _unexpectedStop = false;
             recorder.DataAvailable += OnDataAvailable;
-            recorder.RecordingStopped += OnRecordingStopped;
+            recorder.Stopped += OnRecordingStopped;
 
             try
             {
-                recorder.StartRecording();
-                IsCapturing = true;
+                _isCapturing = true;
+                recorder.Start();
                 return new AudioOperationResult(Succeeded: true);
             }
-            catch (Exception exception) when (exception is InvalidOperationException or ArgumentException)
+            catch (Exception exception) when (
+                exception is InvalidOperationException or ArgumentException or COMException)
             {
                 await ReleaseRecorderAsync(recorder).ConfigureAwait(false);
-                _recorder = null;
-                _request = null;
-                _recordingStopped = null;
+                ClearSession();
                 return Failure(AppErrorCode.AudioDeviceUnavailable, canRetry: true);
             }
         }
@@ -99,32 +122,44 @@ public sealed class WasapiAudioCapture : IAudioCapture
         try
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
-            if (!IsCapturing || _recorder is null || _request is null)
+            if (_recorder is null || _request is null || _recordingStopped is null)
             {
                 return EmptyFailure(AppErrorCode.InvalidTransition);
             }
 
-            IsCapturing = false;
             var recorder = _recorder;
             var request = _request;
-            var stopped = _recordingStopped!;
+            var stopped = _recordingStopped;
             Exception? stopException = null;
-            try
+            if (!_backendStopped)
             {
-                recorder.StopRecording();
-                stopException = await stopped.Task.WaitAsync(
-                    TimeSpan.FromSeconds(2),
-                    CancellationToken.None).ConfigureAwait(false);
-            }
-            catch (TimeoutException timeoutException)
-            {
-                stopException = timeoutException;
-            }
-            catch (Exception exception) when (exception is InvalidOperationException or COMException)
-            {
-                stopException = exception;
+                _clientRequestedStop = true;
+                _isCapturing = false;
+                try
+                {
+                    recorder.Stop();
+                }
+                catch (Exception exception) when (exception is InvalidOperationException or COMException)
+                {
+                    stopException = exception;
+                }
             }
 
+            if (stopException is null)
+            {
+                try
+                {
+                    stopException = await stopped.Task
+                        .WaitAsync(_stopTimeout, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (TimeoutException timeoutException)
+                {
+                    stopException = timeoutException;
+                }
+            }
+
+            var interrupted = _unexpectedStop || stopException is not null;
             var samples = SnapshotSamples();
             try
             {
@@ -133,25 +168,17 @@ public sealed class WasapiAudioCapture : IAudioCapture
             catch (Exception exception) when (exception is InvalidOperationException or COMException)
             {
                 stopException ??= exception;
+                interrupted = true;
             }
-            ClearSession();
 
-            return stopException is null
-                ? new CapturedAudio(
-                    request.SessionId,
-                    samples,
-                    AudioSampleConverter.TargetSampleRate,
-                    Channels: 1)
+            ClearSession();
+            return interrupted
+                ? Interrupted(request.SessionId, samples)
                 : new CapturedAudio(
                     request.SessionId,
                     samples,
                     AudioSampleConverter.TargetSampleRate,
-                    Channels: 1,
-                    AudioCaptureOutcome.Interrupted,
-                    new AppError(
-                        AppErrorCode.AudioDeviceLost,
-                        AppErrorStage.AudioCapture,
-                        CanRetry: samples.Length > 0));
+                    Channels: 1);
         }
         finally
         {
@@ -164,14 +191,37 @@ public sealed class WasapiAudioCapture : IAudioCapture
         await _transitionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            Exception? cleanupException = null;
             if (_recorder is not null)
             {
-                if (IsCapturing)
+                var recorder = _recorder;
+                var stopped = _recordingStopped;
+                if (stopped is not null && !_backendStopped)
                 {
-                    _recorder.StopRecording();
+                    _clientRequestedStop = true;
+                    _isCapturing = false;
+                    try
+                    {
+                        recorder.Stop();
+                        await stopped.Task
+                            .WaitAsync(_stopTimeout, CancellationToken.None)
+                            .ConfigureAwait(false);
+                    }
+                    catch (Exception exception) when (
+                        exception is InvalidOperationException or COMException or TimeoutException)
+                    {
+                        cleanupException = exception;
+                    }
                 }
 
-                await ReleaseRecorderAsync(_recorder).ConfigureAwait(false);
+                try
+                {
+                    await ReleaseRecorderAsync(recorder).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (exception is InvalidOperationException or COMException)
+                {
+                    cleanupException ??= exception;
+                }
             }
 
             lock (_bufferGate)
@@ -181,7 +231,9 @@ public sealed class WasapiAudioCapture : IAudioCapture
 
             ClearSession();
             LevelChanged?.Invoke(this, AudioLevel.Silent);
-            return new AudioOperationResult(Succeeded: true);
+            return cleanupException is null
+                ? new AudioOperationResult(Succeeded: true)
+                : Failure(AppErrorCode.AudioDeviceLost, canRetry: true);
         }
         finally
         {
@@ -202,62 +254,38 @@ public sealed class WasapiAudioCapture : IAudioCapture
         _transitionGate.Dispose();
     }
 
-    private static async Task<WasapiRecorder> BuildRecorderAsync(AudioDeviceId? deviceId)
+    private void OnDataAvailable(object? sender, AudioRecorderData args)
     {
-        var builder = new WasapiRecorderBuilder()
-            .WithSharedMode()
-            .WithEventSync()
-            .WithBufferLength(50)
-            .WithFormat(CaptureFormat)
-            .WithMmcssThreadPriority("Audio");
-
-        if (deviceId is null)
-        {
-            return await builder
-                .WithDefaultDeviceStreamRouting()
-                .BuildAsync()
-                .ConfigureAwait(false);
-        }
-
-        using var enumerator = new MMDeviceEnumerator();
-        using var device = enumerator.GetDevice(deviceId.Value.Value);
-        return builder.WithDevice(device).Build();
-    }
-
-    private void OnDataAvailable(
-        ReadOnlySpan<byte> data,
-        AudioClientBufferFlags flags,
-        long devicePosition,
-        long performanceCounterPosition)
-    {
-        if ((flags & AudioClientBufferFlags.Silent) != 0)
-        {
-            data = new byte[data.Length];
-        }
-
-        lock (_bufferGate)
-        {
-            _capturedBytes.Write(data);
-        }
-
+        var bytes = args.IsSilent ? new byte[args.Bytes.Length] : args.Bytes.ToArray();
         try
         {
-            var converted = AudioSampleConverter.ConvertToMono16Khz(
-                data,
-                new AudioBufferFormat(
-                    AudioSampleConverter.TargetSampleRate,
-                    Channels: 1,
-                    AudioSampleEncoding.Ieee754Single));
+            var converted = AudioSampleConverter.ConvertToMono16Khz(bytes, CaptureFormat);
+            lock (_bufferGate)
+            {
+                _capturedBytes.Write(bytes);
+            }
+
             LevelChanged?.Invoke(this, new AudioLevel(converted.Peak, converted.RootMeanSquare));
         }
         catch (ArgumentException exception)
         {
+            _unexpectedStop = true;
+            _isCapturing = false;
             _recordingStopped?.TrySetResult(exception);
         }
     }
 
-    private void OnRecordingStopped(object? sender, StoppedEventArgs args) =>
+    private void OnRecordingStopped(object? sender, AudioRecorderStopped args)
+    {
+        _backendStopped = true;
+        if (!_clientRequestedStop)
+        {
+            _unexpectedStop = true;
+            _isCapturing = false;
+        }
+
         _recordingStopped?.TrySetResult(args.Exception);
+    }
 
     private float[] SnapshotSamples()
     {
@@ -268,27 +296,25 @@ public sealed class WasapiAudioCapture : IAudioCapture
             _capturedBytes.SetLength(0);
         }
 
-        return AudioSampleConverter.ConvertToMono16Khz(
-            bytes,
-            new AudioBufferFormat(
-                AudioSampleConverter.TargetSampleRate,
-                Channels: 1,
-                AudioSampleEncoding.Ieee754Single)).Samples;
+        return AudioSampleConverter.ConvertToMono16Khz(bytes, CaptureFormat).Samples;
     }
 
-    private async ValueTask ReleaseRecorderAsync(WasapiRecorder recorder)
+    private async ValueTask ReleaseRecorderAsync(IAudioRecorderSession recorder)
     {
         recorder.DataAvailable -= OnDataAvailable;
-        recorder.RecordingStopped -= OnRecordingStopped;
+        recorder.Stopped -= OnRecordingStopped;
         await recorder.DisposeAsync().ConfigureAwait(false);
     }
 
     private void ClearSession()
     {
-        IsCapturing = false;
+        _isCapturing = false;
         _recorder = null;
         _recordingStopped = null;
         _request = null;
+        _clientRequestedStop = false;
+        _backendStopped = false;
+        _unexpectedStop = false;
     }
 
     private static AudioOperationResult Failure(AppErrorCode code, bool canRetry) => new(
@@ -296,10 +322,21 @@ public sealed class WasapiAudioCapture : IAudioCapture
         new AppError(code, AppErrorStage.AudioCapture, canRetry));
 
     private static CapturedAudio EmptyFailure(AppErrorCode code) => new(
-        DictationSessionId.Create(),
+        new DictationSessionId(Guid.Empty),
         ReadOnlyMemory<float>.Empty,
         AudioSampleConverter.TargetSampleRate,
         Channels: 1,
         AudioCaptureOutcome.Interrupted,
         new AppError(code, AppErrorStage.AudioCapture, CanRetry: false));
+
+    private static CapturedAudio Interrupted(DictationSessionId sessionId, float[] samples) => new(
+        sessionId,
+        samples,
+        AudioSampleConverter.TargetSampleRate,
+        Channels: 1,
+        AudioCaptureOutcome.Interrupted,
+        new AppError(
+            AppErrorCode.AudioDeviceLost,
+            AppErrorStage.AudioCapture,
+            CanRetry: samples.Length > 0));
 }

--- a/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
+++ b/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
@@ -1,0 +1,305 @@
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+using System.Runtime.InteropServices;
+
+namespace EnviousWispr.Audio;
+
+public sealed class WasapiAudioCapture : IAudioCapture
+{
+    private static readonly WaveFormat CaptureFormat = WaveFormat.CreateIeeeFloatWaveFormat(
+        AudioSampleConverter.TargetSampleRate,
+        channels: 1);
+
+    private readonly object _bufferGate = new();
+    private readonly SemaphoreSlim _transitionGate = new(1, 1);
+    private readonly MemoryStream _capturedBytes = new();
+    private WasapiRecorder? _recorder;
+    private TaskCompletionSource<Exception?>? _recordingStopped;
+    private AudioCaptureRequest? _request;
+    private bool _disposed;
+
+    public event EventHandler<AudioLevel>? LevelChanged;
+
+    public bool IsCapturing { get; private set; }
+
+    public async Task<AudioOperationResult> StartAsync(
+        AudioCaptureRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        await _transitionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (IsCapturing)
+            {
+                return Failure(AppErrorCode.CaptureAlreadyActive, canRetry: false);
+            }
+
+            WasapiRecorder recorder;
+            try
+            {
+                recorder = await BuildRecorderAsync(request.DeviceId).ConfigureAwait(false);
+            }
+            catch (ArgumentException)
+            {
+                return Failure(AppErrorCode.AudioFormatUnsupported, canRetry: true);
+            }
+            catch (InvalidOperationException)
+            {
+                return Failure(AppErrorCode.AudioDeviceUnavailable, canRetry: true);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Failure(AppErrorCode.AccessDenied, canRetry: true);
+            }
+            catch (COMException)
+            {
+                return Failure(AppErrorCode.AudioDeviceUnavailable, canRetry: true);
+            }
+
+            lock (_bufferGate)
+            {
+                _capturedBytes.SetLength(0);
+            }
+
+            _request = request;
+            _recordingStopped = new TaskCompletionSource<Exception?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _recorder = recorder;
+            recorder.DataAvailable += OnDataAvailable;
+            recorder.RecordingStopped += OnRecordingStopped;
+
+            try
+            {
+                recorder.StartRecording();
+                IsCapturing = true;
+                return new AudioOperationResult(Succeeded: true);
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or ArgumentException)
+            {
+                await ReleaseRecorderAsync(recorder).ConfigureAwait(false);
+                _recorder = null;
+                _request = null;
+                _recordingStopped = null;
+                return Failure(AppErrorCode.AudioDeviceUnavailable, canRetry: true);
+            }
+        }
+        finally
+        {
+            _transitionGate.Release();
+        }
+    }
+
+    public async Task<CapturedAudio> StopAsync(CancellationToken cancellationToken = default)
+    {
+        await _transitionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!IsCapturing || _recorder is null || _request is null)
+            {
+                return EmptyFailure(AppErrorCode.InvalidTransition);
+            }
+
+            IsCapturing = false;
+            var recorder = _recorder;
+            var request = _request;
+            var stopped = _recordingStopped!;
+            Exception? stopException = null;
+            try
+            {
+                recorder.StopRecording();
+                stopException = await stopped.Task.WaitAsync(
+                    TimeSpan.FromSeconds(2),
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (TimeoutException timeoutException)
+            {
+                stopException = timeoutException;
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or COMException)
+            {
+                stopException = exception;
+            }
+
+            var samples = SnapshotSamples();
+            try
+            {
+                await ReleaseRecorderAsync(recorder).ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or COMException)
+            {
+                stopException ??= exception;
+            }
+            ClearSession();
+
+            return stopException is null
+                ? new CapturedAudio(
+                    request.SessionId,
+                    samples,
+                    AudioSampleConverter.TargetSampleRate,
+                    Channels: 1)
+                : new CapturedAudio(
+                    request.SessionId,
+                    samples,
+                    AudioSampleConverter.TargetSampleRate,
+                    Channels: 1,
+                    AudioCaptureOutcome.Interrupted,
+                    new AppError(
+                        AppErrorCode.AudioDeviceLost,
+                        AppErrorStage.AudioCapture,
+                        CanRetry: samples.Length > 0));
+        }
+        finally
+        {
+            _transitionGate.Release();
+        }
+    }
+
+    public async Task<AudioOperationResult> CancelAsync(CancellationToken cancellationToken = default)
+    {
+        await _transitionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_recorder is not null)
+            {
+                if (IsCapturing)
+                {
+                    _recorder.StopRecording();
+                }
+
+                await ReleaseRecorderAsync(_recorder).ConfigureAwait(false);
+            }
+
+            lock (_bufferGate)
+            {
+                _capturedBytes.SetLength(0);
+            }
+
+            ClearSession();
+            LevelChanged?.Invoke(this, AudioLevel.Silent);
+            return new AudioOperationResult(Succeeded: true);
+        }
+        finally
+        {
+            _transitionGate.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await CancelAsync().ConfigureAwait(false);
+        _disposed = true;
+        _capturedBytes.Dispose();
+        _transitionGate.Dispose();
+    }
+
+    private static async Task<WasapiRecorder> BuildRecorderAsync(AudioDeviceId? deviceId)
+    {
+        var builder = new WasapiRecorderBuilder()
+            .WithSharedMode()
+            .WithEventSync()
+            .WithBufferLength(50)
+            .WithFormat(CaptureFormat)
+            .WithMmcssThreadPriority("Audio");
+
+        if (deviceId is null)
+        {
+            return await builder
+                .WithDefaultDeviceStreamRouting()
+                .BuildAsync()
+                .ConfigureAwait(false);
+        }
+
+        using var enumerator = new MMDeviceEnumerator();
+        using var device = enumerator.GetDevice(deviceId.Value.Value);
+        return builder.WithDevice(device).Build();
+    }
+
+    private void OnDataAvailable(
+        ReadOnlySpan<byte> data,
+        AudioClientBufferFlags flags,
+        long devicePosition,
+        long performanceCounterPosition)
+    {
+        if ((flags & AudioClientBufferFlags.Silent) != 0)
+        {
+            data = new byte[data.Length];
+        }
+
+        lock (_bufferGate)
+        {
+            _capturedBytes.Write(data);
+        }
+
+        try
+        {
+            var converted = AudioSampleConverter.ConvertToMono16Khz(
+                data,
+                new AudioBufferFormat(
+                    AudioSampleConverter.TargetSampleRate,
+                    Channels: 1,
+                    AudioSampleEncoding.Ieee754Single));
+            LevelChanged?.Invoke(this, new AudioLevel(converted.Peak, converted.RootMeanSquare));
+        }
+        catch (ArgumentException exception)
+        {
+            _recordingStopped?.TrySetResult(exception);
+        }
+    }
+
+    private void OnRecordingStopped(object? sender, StoppedEventArgs args) =>
+        _recordingStopped?.TrySetResult(args.Exception);
+
+    private float[] SnapshotSamples()
+    {
+        byte[] bytes;
+        lock (_bufferGate)
+        {
+            bytes = _capturedBytes.ToArray();
+            _capturedBytes.SetLength(0);
+        }
+
+        return AudioSampleConverter.ConvertToMono16Khz(
+            bytes,
+            new AudioBufferFormat(
+                AudioSampleConverter.TargetSampleRate,
+                Channels: 1,
+                AudioSampleEncoding.Ieee754Single)).Samples;
+    }
+
+    private async ValueTask ReleaseRecorderAsync(WasapiRecorder recorder)
+    {
+        recorder.DataAvailable -= OnDataAvailable;
+        recorder.RecordingStopped -= OnRecordingStopped;
+        await recorder.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void ClearSession()
+    {
+        IsCapturing = false;
+        _recorder = null;
+        _recordingStopped = null;
+        _request = null;
+    }
+
+    private static AudioOperationResult Failure(AppErrorCode code, bool canRetry) => new(
+        Succeeded: false,
+        new AppError(code, AppErrorStage.AudioCapture, canRetry));
+
+    private static CapturedAudio EmptyFailure(AppErrorCode code) => new(
+        DictationSessionId.Create(),
+        ReadOnlyMemory<float>.Empty,
+        AudioSampleConverter.TargetSampleRate,
+        Channels: 1,
+        AudioCaptureOutcome.Interrupted,
+        new AppError(code, AppErrorStage.AudioCapture, CanRetry: false));
+}

--- a/src/Production/EnviousWispr.Audio/WasapiDeviceCatalog.cs
+++ b/src/Production/EnviousWispr.Audio/WasapiDeviceCatalog.cs
@@ -1,0 +1,155 @@
+using EnviousWispr.Core.Audio;
+using NAudio.CoreAudioApi;
+
+namespace EnviousWispr.Audio;
+
+public sealed class WasapiDeviceCatalog : IAudioDeviceCatalog
+{
+    private readonly object _gate = new();
+    private readonly MMDeviceEnumerator _enumerator;
+    private readonly MMDeviceNotificationClient _notifications;
+    private readonly HashSet<string> _knownCaptureDeviceIds = new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    public WasapiDeviceCatalog()
+    {
+        _enumerator = new MMDeviceEnumerator();
+        _notifications = _enumerator.CreateNotificationClient(useSynchronizationContext: false);
+        _notifications.DeviceAdded += OnDeviceAdded;
+        _notifications.DeviceRemoved += OnDeviceRemoved;
+        _notifications.DeviceStateChanged += OnDeviceStateChanged;
+        _notifications.DefaultDeviceChanged += OnDefaultDeviceChanged;
+    }
+
+    public event EventHandler<AudioDeviceChange>? DevicesChanged;
+
+    public Task<IReadOnlyList<AudioDeviceInfo>> GetCaptureDevicesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string? defaultDeviceId = null;
+        try
+        {
+            using var defaultDevice = _enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Console);
+            defaultDeviceId = defaultDevice.ID;
+        }
+        catch
+        {
+            // Having no default capture endpoint is a normal, representable state.
+        }
+
+        var result = new List<AudioDeviceInfo>();
+        using var devices = _enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
+        foreach (var device in devices)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using (device)
+            {
+                result.Add(new AudioDeviceInfo(
+                    new AudioDeviceId(device.ID),
+                    device.FriendlyName,
+                    string.Equals(device.ID, defaultDeviceId, StringComparison.Ordinal),
+                    IsActive: true));
+            }
+        }
+
+        lock (_gate)
+        {
+            _knownCaptureDeviceIds.Clear();
+            foreach (var device in result)
+            {
+                _knownCaptureDeviceIds.Add(device.Id.Value);
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<AudioDeviceInfo>>(result);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _notifications.DeviceAdded -= OnDeviceAdded;
+        _notifications.DeviceRemoved -= OnDeviceRemoved;
+        _notifications.DeviceStateChanged -= OnDeviceStateChanged;
+        _notifications.DefaultDeviceChanged -= OnDefaultDeviceChanged;
+        _notifications.Dispose();
+        _enumerator.Dispose();
+    }
+
+    private void OnDeviceAdded(object? sender, DeviceNotificationEventArgs args)
+    {
+        var affectsCapture = TryIsCaptureDevice(args.DeviceId);
+        if (affectsCapture)
+        {
+            lock (_gate)
+            {
+                _knownCaptureDeviceIds.Add(args.DeviceId);
+            }
+        }
+
+        Raise(args.DeviceId, AudioDeviceChangeKind.Added, affectsCapture);
+    }
+
+    private void OnDeviceRemoved(object? sender, DeviceNotificationEventArgs args)
+    {
+        bool affectsCapture;
+        lock (_gate)
+        {
+            affectsCapture = _knownCaptureDeviceIds.Remove(args.DeviceId);
+        }
+
+        Raise(args.DeviceId, AudioDeviceChangeKind.Removed, affectsCapture);
+    }
+
+    private void OnDeviceStateChanged(object? sender, DeviceStateChangedEventArgs args)
+    {
+        var affectsCapture = TryIsCaptureDevice(args.DeviceId);
+        lock (_gate)
+        {
+            if (affectsCapture && args.NewState == DeviceState.Active)
+            {
+                _knownCaptureDeviceIds.Add(args.DeviceId);
+            }
+            else if (args.NewState != DeviceState.Active)
+            {
+                affectsCapture = _knownCaptureDeviceIds.Remove(args.DeviceId) || affectsCapture;
+            }
+        }
+
+        Raise(args.DeviceId, AudioDeviceChangeKind.StateChanged, affectsCapture);
+    }
+
+    private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs args)
+    {
+        var affectsCapture = args.Flow is DataFlow.Capture or DataFlow.All;
+        Raise(args.DeviceId ?? string.Empty, AudioDeviceChangeKind.DefaultChanged, affectsCapture);
+    }
+
+    private bool TryIsCaptureDevice(string deviceId)
+    {
+        try
+        {
+            using var device = _enumerator.GetDevice(deviceId);
+            return device.DataFlow == DataFlow.Capture;
+        }
+        catch
+        {
+            lock (_gate)
+            {
+                return _knownCaptureDeviceIds.Contains(deviceId);
+            }
+        }
+    }
+
+    private void Raise(string deviceId, AudioDeviceChangeKind kind, bool affectsCapture) =>
+        DevicesChanged?.Invoke(
+            this,
+            new AudioDeviceChange(new AudioDeviceId(deviceId), kind, affectsCapture));
+}

--- a/src/Production/EnviousWispr.Audio/WasapiDeviceCatalog.cs
+++ b/src/Production/EnviousWispr.Audio/WasapiDeviceCatalog.cs
@@ -5,10 +5,9 @@ namespace EnviousWispr.Audio;
 
 public sealed class WasapiDeviceCatalog : IAudioDeviceCatalog
 {
-    private readonly object _gate = new();
     private readonly MMDeviceEnumerator _enumerator;
     private readonly MMDeviceNotificationClient _notifications;
-    private readonly HashSet<string> _knownCaptureDeviceIds = new(StringComparer.Ordinal);
+    private readonly AudioDeviceChangeTracker _changeTracker = new();
     private bool _disposed;
 
     public WasapiDeviceCatalog()
@@ -55,14 +54,7 @@ public sealed class WasapiDeviceCatalog : IAudioDeviceCatalog
             }
         }
 
-        lock (_gate)
-        {
-            _knownCaptureDeviceIds.Clear();
-            foreach (var device in result)
-            {
-                _knownCaptureDeviceIds.Add(device.Id.Value);
-            }
-        }
+        _changeTracker.ReplaceKnownCaptureDevices(result.Select(device => device.Id));
 
         return Task.FromResult<IReadOnlyList<AudioDeviceInfo>>(result);
     }
@@ -86,50 +78,27 @@ public sealed class WasapiDeviceCatalog : IAudioDeviceCatalog
     private void OnDeviceAdded(object? sender, DeviceNotificationEventArgs args)
     {
         var affectsCapture = TryIsCaptureDevice(args.DeviceId);
-        if (affectsCapture)
-        {
-            lock (_gate)
-            {
-                _knownCaptureDeviceIds.Add(args.DeviceId);
-            }
-        }
-
-        Raise(args.DeviceId, AudioDeviceChangeKind.Added, affectsCapture);
+        Raise(_changeTracker.Added(args.DeviceId, affectsCapture));
     }
 
     private void OnDeviceRemoved(object? sender, DeviceNotificationEventArgs args)
     {
-        bool affectsCapture;
-        lock (_gate)
-        {
-            affectsCapture = _knownCaptureDeviceIds.Remove(args.DeviceId);
-        }
-
-        Raise(args.DeviceId, AudioDeviceChangeKind.Removed, affectsCapture);
+        Raise(_changeTracker.Removed(args.DeviceId));
     }
 
     private void OnDeviceStateChanged(object? sender, DeviceStateChangedEventArgs args)
     {
         var affectsCapture = TryIsCaptureDevice(args.DeviceId);
-        lock (_gate)
-        {
-            if (affectsCapture && args.NewState == DeviceState.Active)
-            {
-                _knownCaptureDeviceIds.Add(args.DeviceId);
-            }
-            else if (args.NewState != DeviceState.Active)
-            {
-                affectsCapture = _knownCaptureDeviceIds.Remove(args.DeviceId) || affectsCapture;
-            }
-        }
-
-        Raise(args.DeviceId, AudioDeviceChangeKind.StateChanged, affectsCapture);
+        Raise(_changeTracker.StateChanged(
+            args.DeviceId,
+            affectsCapture,
+            args.NewState == DeviceState.Active));
     }
 
     private void OnDefaultDeviceChanged(object? sender, DefaultDeviceChangedEventArgs args)
     {
         var affectsCapture = args.Flow is DataFlow.Capture or DataFlow.All;
-        Raise(args.DeviceId ?? string.Empty, AudioDeviceChangeKind.DefaultChanged, affectsCapture);
+        Raise(AudioDeviceChangeTracker.DefaultChanged(args.DeviceId, affectsCapture));
     }
 
     private bool TryIsCaptureDevice(string deviceId)
@@ -141,15 +110,9 @@ public sealed class WasapiDeviceCatalog : IAudioDeviceCatalog
         }
         catch
         {
-            lock (_gate)
-            {
-                return _knownCaptureDeviceIds.Contains(deviceId);
-            }
+            return false;
         }
     }
 
-    private void Raise(string deviceId, AudioDeviceChangeKind kind, bool affectsCapture) =>
-        DevicesChanged?.Invoke(
-            this,
-            new AudioDeviceChange(new AudioDeviceId(deviceId), kind, affectsCapture));
+    private void Raise(AudioDeviceChange change) => DevicesChanged?.Invoke(this, change);
 }

--- a/src/Production/EnviousWispr.Core/Audio/AudioContracts.cs
+++ b/src/Production/EnviousWispr.Core/Audio/AudioContracts.cs
@@ -1,0 +1,59 @@
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+
+namespace EnviousWispr.Core.Audio;
+
+public readonly record struct AudioDeviceId(string Value);
+
+public sealed record AudioDeviceInfo(
+    AudioDeviceId Id,
+    string DisplayName,
+    bool IsDefault,
+    bool IsActive);
+
+public enum AudioDeviceChangeKind
+{
+    Added,
+    Removed,
+    StateChanged,
+    DefaultChanged,
+}
+
+public sealed record AudioDeviceChange(
+    AudioDeviceId Id,
+    AudioDeviceChangeKind Kind,
+    bool AffectsCapture);
+
+public sealed record AudioCaptureRequest(
+    DictationSessionId SessionId,
+    AudioDeviceId? DeviceId = null);
+
+public readonly record struct AudioLevel(float Peak, float RootMeanSquare)
+{
+    public static AudioLevel Silent { get; } = new(0, 0);
+}
+
+public sealed record AudioOperationResult(bool Succeeded, AppError? Error = null);
+
+public interface IAudioCapture : IAsyncDisposable
+{
+    event EventHandler<AudioLevel>? LevelChanged;
+
+    bool IsCapturing { get; }
+
+    Task<AudioOperationResult> StartAsync(
+        AudioCaptureRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<CapturedAudio> StopAsync(CancellationToken cancellationToken = default);
+
+    Task<AudioOperationResult> CancelAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IAudioDeviceCatalog : IDisposable
+{
+    event EventHandler<AudioDeviceChange>? DevicesChanged;
+
+    Task<IReadOnlyList<AudioDeviceInfo>> GetCaptureDevicesAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/src/Production/EnviousWispr.Core/Dictation/DictationContracts.cs
+++ b/src/Production/EnviousWispr.Core/Dictation/DictationContracts.cs
@@ -1,3 +1,5 @@
+using EnviousWispr.Core.Errors;
+
 namespace EnviousWispr.Core.Dictation;
 
 public readonly record struct DictationSessionId(Guid Value)
@@ -5,26 +7,26 @@ public readonly record struct DictationSessionId(Guid Value)
     public static DictationSessionId Create() => new(Guid.NewGuid());
 }
 
+public enum AudioCaptureOutcome
+{
+    Completed,
+    Interrupted,
+    Cancelled,
+}
+
 public sealed record CapturedAudio(
     DictationSessionId SessionId,
     ReadOnlyMemory<float> Samples,
     int SampleRate,
-    int Channels);
+    int Channels,
+    AudioCaptureOutcome Outcome = AudioCaptureOutcome.Completed,
+    AppError? Error = null);
 
 public sealed record Transcript(DictationSessionId SessionId, string Text, string EngineId);
 
 public sealed record ProcessedText(DictationSessionId SessionId, string Text);
 
 public sealed record DeliveryResult(DictationSessionId SessionId, bool Delivered, bool ClipboardFallback);
-
-public interface IAudioCapture
-{
-    Task StartAsync(DictationSessionId sessionId, CancellationToken cancellationToken = default);
-
-    Task<CapturedAudio> StopAsync(CancellationToken cancellationToken = default);
-
-    Task CancelAsync(CancellationToken cancellationToken = default);
-}
 
 public interface ITranscriptionEngine
 {

--- a/src/Production/EnviousWispr.Core/Errors/AppError.cs
+++ b/src/Production/EnviousWispr.Core/Errors/AppError.cs
@@ -8,6 +8,10 @@ public enum AppErrorCode
     AccessDenied,
     Cancelled,
     InvalidTransition,
+    AudioDeviceUnavailable,
+    AudioDeviceLost,
+    AudioFormatUnsupported,
+    CaptureAlreadyActive,
 }
 
 public enum AppErrorStage
@@ -18,6 +22,8 @@ public enum AppErrorStage
     SettingsReset,
     ProfileImport,
     ProfileExport,
+    AudioDeviceEnumeration,
+    AudioCapture,
 }
 
 public sealed record AppError(AppErrorCode Code, AppErrorStage Stage, bool CanRetry);

--- a/tools/audio-uat/EnviousWispr.Audio.Uat.csproj
+++ b/tools/audio-uat/EnviousWispr.Audio.Uat.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Audio\EnviousWispr.Audio.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Core\EnviousWispr.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/audio-uat/Program.cs
+++ b/tools/audio-uat/Program.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using EnviousWispr.Audio;
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+
+using var catalog = new WasapiDeviceCatalog();
+var devices = await catalog.GetCaptureDevicesAsync();
+if (devices.Count == 0)
+{
+    Console.WriteLine(JsonSerializer.Serialize(new { captureDevices = 0, outcome = "NoDevice" }));
+    return 2;
+}
+
+var defaultCapture = await CaptureAsync(DeviceId: null, TimeSpan.FromSeconds(2));
+var selectedCapture = await CaptureAsync(devices[0].Id, TimeSpan.FromSeconds(1));
+
+await using var overlapCapture = new WasapiAudioCapture();
+var overlapRequest = new AudioCaptureRequest(DictationSessionId.Create());
+var firstStart = await overlapCapture.StartAsync(overlapRequest);
+var secondStart = await overlapCapture.StartAsync(overlapRequest);
+await Task.Delay(TimeSpan.FromMilliseconds(150));
+var cancel = await overlapCapture.CancelAsync();
+
+var summary = new
+{
+    captureDevices = devices.Count,
+    defaultDevices = devices.Count(device => device.IsDefault),
+    defaultCapture,
+    selectedCapture,
+    overlapRejected = firstStart.Succeeded &&
+        !secondStart.Succeeded &&
+        secondStart.Error?.Code == AppErrorCode.CaptureAlreadyActive,
+    cancelSucceeded = cancel.Succeeded && !overlapCapture.IsCapturing,
+};
+Console.WriteLine(JsonSerializer.Serialize(summary));
+
+return CapturePassed(defaultCapture, minimumDurationMilliseconds: 1_500) &&
+    CapturePassed(selectedCapture, minimumDurationMilliseconds: 750) &&
+    summary.overlapRejected &&
+    summary.cancelSucceeded
+    ? 0
+    : 4;
+
+static async Task<CaptureMetrics> CaptureAsync(AudioDeviceId? DeviceId, TimeSpan duration)
+{
+    await using var capture = new WasapiAudioCapture();
+    var levelGate = new object();
+    var observedPeak = 0f;
+    double rmsSum = 0;
+    var levelEvents = 0;
+    capture.LevelChanged += (_, level) =>
+    {
+        lock (levelGate)
+        {
+            observedPeak = Math.Max(observedPeak, level.Peak);
+            rmsSum += level.RootMeanSquare;
+            levelEvents++;
+        }
+    };
+
+    var started = await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create(), DeviceId));
+    if (!started.Succeeded)
+    {
+        return new CaptureMetrics(
+            SampleRate: 0,
+            Channels: 0,
+            SampleCount: 0,
+            DurationMilliseconds: 0,
+            Outcome: "StartFailed",
+            Error: started.Error?.Code.ToString(),
+            LevelEvents: 0,
+            Peak: 0,
+            AverageRootMeanSquare: 0);
+    }
+
+    await Task.Delay(duration);
+    var result = await capture.StopAsync();
+    lock (levelGate)
+    {
+        return new CaptureMetrics(
+            result.SampleRate,
+            result.Channels,
+            result.Samples.Length,
+            result.Samples.Length * 1000L / result.SampleRate,
+            result.Outcome.ToString(),
+            result.Error?.Code.ToString(),
+            levelEvents,
+            observedPeak,
+            levelEvents == 0 ? 0 : rmsSum / levelEvents);
+    }
+}
+
+static bool CapturePassed(CaptureMetrics result, long minimumDurationMilliseconds) =>
+    result.Outcome == AudioCaptureOutcome.Completed.ToString() &&
+    result.SampleRate == AudioSampleConverter.TargetSampleRate &&
+    result.Channels == 1 &&
+    result.DurationMilliseconds >= minimumDurationMilliseconds &&
+    result.LevelEvents > 0;
+
+internal sealed record CaptureMetrics(
+    int SampleRate,
+    int Channels,
+    int SampleCount,
+    long DurationMilliseconds,
+    string Outcome,
+    string? Error,
+    int LevelEvents,
+    float Peak,
+    double AverageRootMeanSquare);


### PR DESCRIPTION
## Summary

Implements the Phase 3 production WASAPI capture foundation: modern NAudio.Wasapi 3.0.1 integration, typed device enumeration/change contracts, automatic default-device routing, selected-device capture, 16 kHz mono conversion, peak/RMS metering, overlap rejection, cancellation, interruption recovery, and a content-free native UAT harness.

The native NAudio boundary now has a deterministic test seam. Unexpected stops preserve buffered samples with a typed retryable interruption, and endpoint notification classification remains correct after a device disappears.

This PR is intentionally a draft and is stacked on PR #7 (base: codex/phase2-core-storage). Phase 3 remains open until the physical route-change/device-loss paths and documented microphone matrix are observed.

Relates to #8

## Evidence

- Source: product/architecture/pipeline contracts and Phase 3 of docs/plans/windows-master-plan.md.
- Current package/API evidence: NAudio.Wasapi 3.0.1 with WasapiRecorder, MMDeviceEnumerator, and event-based notification client APIs.
- Hardware inventory: one active capture endpoint on this rig, Logitech BRIO USB; no active built-in or Bluetooth capture endpoint.

## Validation

- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate.ps1`
- [x] Deterministic recorder interruption and notification-transition tests
- [x] Real default-route and explicitly selected USB capture
- [ ] Complete native Windows Phase 3 device matrix

Observed results:

- Proof builds and production builds passed with zero warnings/errors.
- Portable proof tests: 34 passed.
- Production tests: 35 passed.
- Default-route USB capture: 31,809 samples, 1,988 ms, 16 kHz mono, 398 level events, completed without error.
- Explicit selected-device USB capture: 15,649 samples, 978 ms, 16 kHz mono, 196 level events, completed without error.
- Concurrent second start was rejected with `CaptureAlreadyActive`; cancel completed and left capture inactive.
- Tests prove normal stop, unexpected-stop preservation, interruption during startup, stop timeout cleanup, malformed callback isolation, typed unavailable-device failure, and capture-versus-render notification tracking.

## Safety check

- [x] No secret, model weight, user content, private path, transcript, or audio sample was committed
- [x] Captured samples remain memory-only and are returned after an unexpected stop
- [x] Harness output contains aggregate format/count/duration/level metadata only
- [x] Founder-tested WPF proof remains unchanged

## UAT and remaining risk

Observed:

- Real default and explicitly selected capture through the connected USB microphone.
- Real peak/RMS callbacks, stop, overlap rejection, and cancellation.
- Deterministic interruption, timeout, malformed-data, and notification transition behavior.

Not yet physically observed:

- Built-in microphone path: no active endpoint exists on this rig.
- Bluetooth microphone path: no active endpoint exists on this rig.
- Physical default-device switch and device removal: only one capture endpoint is connected.

Do not mark Phase 3 complete or merge this draft until those remaining exits are resolved or explicitly re-scoped by the founder.