### PR TITLE
Phase 4: add push-to-talk and session state machine

### DIFF
--- a/EnviousWispr.Windows.slnx
+++ b/EnviousWispr.Windows.slnx
@@ -18,5 +18,6 @@
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/audio-uat/EnviousWispr.Audio.Uat.csproj" />
+    <Project Path="tools/hotkey-uat/EnviousWispr.Hotkey.Uat.csproj" />
   </Folder>
 </Solution>

--- a/notes/phase-four-hotkey.md
+++ b/notes/phase-four-hotkey.md
@@ -1,0 +1,61 @@
+# Phase 4 hotkey and session evidence
+
+Measured on the founder's Windows rig on 2026-08-25. This phase remains in progress until the physical-key
+and real focus-change exit in `docs/plans/windows-master-plan.md` is satisfied.
+
+## Implemented so far
+
+- Core parses configurable push-to-talk gestures into canonical modifier/key values and returns typed,
+  content-free errors for invalid gestures.
+- Services probes `RegisterHotKey` for conflicts, then installs a narrow `WH_KEYBOARD_LL` hook because
+  push-to-talk requires both press and release edges. The callback recognizes only the configured gesture
+  plus Escape while held, queues signals away from the hook thread, debounces repeat keydown, and passes
+  unrelated typing to the next hook.
+- The hook consumes the configured trigger only while its full modifier set matches. Once a valid press is
+  active, release remains recognized even if a modifier is released first. Escape cancels once and the
+  later trigger release cannot finalize the cancelled session.
+- Pipeline freezes an opaque foreground window handle before capture starts, rejects overlapping and stale
+  transitions, applies a 100 ms minimum-hold debounce, preserves recoverable interrupted audio, and models
+  recording, finalizing, delivery, completion, cancellation, failure, and reset explicitly.
+- The production WinUI shell installs the configured hook, drives real WASAPI capture, shows visible state,
+  writes content-free lifecycle categories, and unhooks before disposing capture on shutdown. Final ASR and
+  delivery are still intentionally absent from this production path.
+- `tools/hotkey-uat` is a content-free native harness built by the canonical validator. Its generated input
+  is explicitly labeled synthetic and is not counted as physical-key evidence.
+
+## Automated evidence
+
+- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate.ps1` passed with zero build
+  warnings/errors, 34 portable proof tests, and 59 production tests.
+- Gesture tests cover canonical function keys, letter/number/space forms, modifiers in different orders,
+  duplicates, reserved Escape, malformed separators, and unsupported keys.
+- Settings validation rejects gestures that the production hook cannot install.
+- Edge tests cover press/release, repeat debounce, exact modifier matching, unrelated-key passthrough,
+  Escape cancellation, suppressed release after cancellation, and modifier-first release.
+- Session tests cover frozen target identity, overlap rejection, cancellation with no stop/delivery, missing
+  target, buffered interruption fallback, empty interruption failure, stale completion, reset, and disposal
+  of an active session.
+
+## Native Windows acceptance observed
+
+- The synthetic native harness reported hook install, conflict detection, press/release, Escape
+  cancellation, valid foreground-target capture, and teardown success.
+- The Release x64 production WinUI app launched with `Hold F8` and `Idle` visible. A Computer Use-generated
+  F8 edge changed the app to recording and then `Capture complete`; the content-free diagnostic sequence
+  was `HotkeyReady`, `DictationRecordingStarted`, `DictationCaptureFinalized`, and `ShellClosed`, all with
+  failure category `None`.
+- The first zero-duration synthetic tap found a recorder-start race. The 100 ms minimum-hold debounce fixed
+  it; the repeated native app path finalized in about 129 ms without an audio failure.
+- While the production hook remained installed, 31 ordinary characters entered an isolated unsaved
+  Notepad tab unchanged. No ordinary key values or text entered diagnostics.
+- Closing the production window removed its only visible window and ran the content-free `ShellClosed`
+  path. The independent native harness also reported `teardownReleasedHook: true`.
+
+## Required evidence still missing
+
+- A person has not yet physically held and released the configured key against this production build.
+- Physical Escape-during-hold, focus change while held, repeated long sessions, and confirmation that the
+  configured key never remains blocked after a forced shutdown are unobserved.
+- Conflict probing detects combinations reserved through `RegisterHotKey`; Windows does not expose a
+  reliable way to enumerate competing low-level keyboard hooks, so that narrower conflict class remains a
+  documented platform limitation.

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -73,6 +73,9 @@ try {
     Write-Host "Building native audio UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/audio-uat/EnviousWispr.Audio.Uat.csproj", "-c", "Release", "--nologo")
 
+    Write-Host "Building native hotkey UAT harness (Release)..."
+    Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/hotkey-uat/EnviousWispr.Hotkey.Uat.csproj", "-c", "Release", "--nologo")
+
     if ($IncludeLocalRuntime) {
         Write-Host "Running contract and local model runtime tests..."
         Invoke-DotNet -Executable $dotnet8Exe -Arguments @("test", "src/EnviousWispr.Tests/EnviousWispr.Tests.csproj", "-c", "Release", "--nologo")

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -1,6 +1,11 @@
+using EnviousWispr.Audio;
 using EnviousWispr.Core.Diagnostics;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
 using EnviousWispr.Core.Settings;
+using EnviousWispr.Pipeline;
 using EnviousWispr.Services.Diagnostics;
+using EnviousWispr.Services.Input;
 using EnviousWispr.Services.Lifecycle;
 using EnviousWispr.Services.Settings;
 using Microsoft.UI.Xaml;
@@ -8,14 +13,17 @@ using System.Security;
 
 namespace EnviousWispr.App;
 
-public partial class App : Application
+public partial class App : Application, IAsyncDisposable
 {
     private const string SingleInstanceKey = "EnviousLabs.EnviousWispr.Production";
 
     private readonly JsonLineFileLogger _logger;
     private readonly JsonSettingsStore _settingsStore;
     private SingleInstanceLock? _singleInstanceLock;
+    private WindowsPushToTalkHook? _pushToTalkHook;
+    private PushToTalkSessionController? _sessionController;
     private MainWindow? _window;
+    private bool _disposed;
 
     public App()
     {
@@ -100,16 +108,161 @@ public partial class App : Application
         _window = new MainWindow(settings, loadResult.Status);
         _window.Closed += OnWindowClosed;
         _window.Activate();
+        ConfigurePushToTalk(settings.Preferences.Dictation.PushToTalkGesture);
         _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.ShellShown));
     }
 
-    private void OnWindowClosed(object sender, WindowEventArgs args)
+    private async void OnWindowClosed(object sender, WindowEventArgs args)
     {
         _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.ShellClosed));
-        _singleInstanceLock?.Dispose();
-        _singleInstanceLock = null;
+        await DisposeAsync().ConfigureAwait(true);
         _window = null;
     }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (_pushToTalkHook is not null)
+        {
+            _pushToTalkHook.Signalled -= OnPushToTalkSignalled;
+            await _pushToTalkHook.DisposeAsync().ConfigureAwait(true);
+            _pushToTalkHook = null;
+        }
+
+        if (_sessionController is not null)
+        {
+            await _sessionController.DisposeAsync().ConfigureAwait(true);
+            _sessionController = null;
+        }
+
+        _singleInstanceLock?.Dispose();
+        _singleInstanceLock = null;
+        GC.SuppressFinalize(this);
+    }
+
+    private void ConfigurePushToTalk(string configuredGesture)
+    {
+        if (!WindowsPushToTalkHook.TryCreate(
+                configuredGesture,
+                out _pushToTalkHook,
+                out var error) ||
+            _pushToTalkHook is null)
+        {
+            _window?.SetHotkeyUnavailable(HotkeyFailureStatus(error));
+            _logger.Write(new AppLogEntry(
+                DateTimeOffset.UtcNow,
+                AppEventCode.HotkeyFailed,
+                FailureFor(error)));
+            return;
+        }
+
+        _sessionController = new PushToTalkSessionController(
+            new WasapiAudioCapture(),
+            new WindowsForegroundTargetProvider());
+        _pushToTalkHook.Signalled += OnPushToTalkSignalled;
+        _window?.SetHotkeyReady(_pushToTalkHook.Gesture.ToString());
+        _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.HotkeyReady));
+    }
+
+    private void OnPushToTalkSignalled(object? sender, PushToTalkSignalEvent args) =>
+        _ = HandlePushToTalkAsync(args.Signal);
+
+    private async Task HandlePushToTalkAsync(PushToTalkSignal signal)
+    {
+        var controller = _sessionController;
+        if (controller is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var result = signal switch
+            {
+                PushToTalkSignal.Pressed => await controller.PressAsync().ConfigureAwait(false),
+                PushToTalkSignal.Released => await controller.ReleaseAsync().ConfigureAwait(false),
+                PushToTalkSignal.Cancelled => await controller.CancelAsync().ConfigureAwait(false),
+                _ => throw new InvalidOperationException("Unsupported push-to-talk signal."),
+            };
+
+            if (result.Kind == SessionTransitionKind.FinalizeReady && result.Session is not null)
+            {
+                await controller.CompleteAsync(result.Session.Id).ConfigureAwait(false);
+                await controller.ResetAsync().ConfigureAwait(false);
+            }
+            else if (result.Kind is SessionTransitionKind.Cancelled or SessionTransitionKind.Failed)
+            {
+                await controller.ResetAsync().ConfigureAwait(false);
+            }
+
+            WriteSessionEvent(result);
+            _window?.DispatcherQueue.TryEnqueue(() =>
+                _window?.SetSessionStatus(SessionStatus(result)));
+        }
+        catch (Exception exception) when (exception is not (StackOverflowException or OutOfMemoryException))
+        {
+            _logger.Write(new AppLogEntry(
+                DateTimeOffset.UtcNow,
+                AppEventCode.DictationSessionFailed,
+                AppFailureCategory.Unknown));
+            _window?.DispatcherQueue.TryEnqueue(() =>
+                _window?.SetSessionStatus("Session failed safely"));
+        }
+    }
+
+    private void WriteSessionEvent(SessionTransitionResult result)
+    {
+        var eventCode = result.Kind switch
+        {
+            SessionTransitionKind.Started => AppEventCode.DictationRecordingStarted,
+            SessionTransitionKind.FinalizeReady => AppEventCode.DictationCaptureFinalized,
+            SessionTransitionKind.Cancelled => AppEventCode.DictationCancelled,
+            SessionTransitionKind.Failed => AppEventCode.DictationSessionFailed,
+            _ => (AppEventCode?)null,
+        };
+        if (eventCode is not null)
+        {
+            _logger.Write(new AppLogEntry(
+                DateTimeOffset.UtcNow,
+                eventCode.Value,
+                FailureFor(result.Error)));
+        }
+    }
+
+    private static string SessionStatus(SessionTransitionResult result) => result.Kind switch
+    {
+        SessionTransitionKind.Started => "Recording — release to finish, Escape to cancel",
+        SessionTransitionKind.FinalizeReady when result.Error is not null =>
+            "Capture preserved after a microphone interruption",
+        SessionTransitionKind.FinalizeReady => "Capture complete — final ASR is the next production phase",
+        SessionTransitionKind.Cancelled => "Cancelled — nothing will be delivered",
+        SessionTransitionKind.Failed => "Session failed safely",
+        _ => "Idle",
+    };
+
+    private static string HotkeyFailureStatus(AppError? error) => error?.Code switch
+    {
+        AppErrorCode.HotkeyConflict => "Configured shortcut is already in use",
+        AppErrorCode.HotkeyInvalid => "Configured shortcut is invalid",
+        _ => "Global shortcut is unavailable",
+    };
+
+    private static AppFailureCategory FailureFor(AppError? error) => error?.Code switch
+    {
+        AppErrorCode.HotkeyConflict => AppFailureCategory.HotkeyConflict,
+        AppErrorCode.HotkeyInvalid or AppErrorCode.HotkeyUnavailable =>
+            AppFailureCategory.HotkeyUnavailable,
+        AppErrorCode.TargetUnavailable => AppFailureCategory.TargetUnavailable,
+        AppErrorCode.AudioDeviceUnavailable or AppErrorCode.AudioDeviceLost =>
+            AppFailureCategory.AudioUnavailable,
+        null => AppFailureCategory.None,
+        _ => AppFailureCategory.Unknown,
+    };
 
     private static AppEventCode EventFor(SettingsLoadStatus status) => status switch
     {

--- a/src/Production/EnviousWispr.App/MainWindow.xaml
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml
@@ -27,11 +27,12 @@
                 </StackPanel>
 
                 <InfoBar
+                    x:Name="FoundationInfoBar"
                     IsClosable="False"
                     IsOpen="True"
-                    Message="Phase 2 adds migration-safe settings, portable reusable data, typed errors, and content-free session state. Dictation remains in the verified WPF proof until its production replacements pass native Windows validation."
+                    Message="The production shell now owns settings, WASAPI capture, configurable push-to-talk, frozen target identity, and safe session cancellation. Final ASR and text delivery are still being moved from the verified proof."
                     Severity="Informational"
-                    Title="Storage foundation active" />
+                    Title="Native dictation foundation active" />
 
                 <Grid ColumnSpacing="16">
                     <Grid.ColumnDefinitions>
@@ -67,6 +68,23 @@
                         <StackPanel Grid.Column="1" Spacing="4">
                             <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Production-shell launches" />
                             <TextBlock x:Name="LaunchCountText" FontWeight="SemiBold" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <Border Padding="20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="12">
+                    <Grid ColumnSpacing="20">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Spacing="4">
+                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Push-to-talk" />
+                            <TextBlock x:Name="HotkeyStatusText" FontWeight="SemiBold" Text="Starting…" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" Spacing="4">
+                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Session" />
+                            <TextBlock x:Name="SessionStatusText" FontWeight="SemiBold" Text="Idle" />
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/src/Production/EnviousWispr.App/MainWindow.xaml.cs
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml.cs
@@ -26,4 +26,18 @@ public sealed partial class MainWindow : Window
         };
         LaunchCountText.Text = settings.LaunchCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
     }
+
+    public void SetHotkeyReady(string gesture)
+    {
+        HotkeyStatusText.Text = $"Hold {gesture}";
+        SessionStatusText.Text = "Idle";
+    }
+
+    public void SetHotkeyUnavailable(string status)
+    {
+        HotkeyStatusText.Text = status;
+        SessionStatusText.Text = "Unavailable";
+    }
+
+    public void SetSessionStatus(string status) => SessionStatusText.Text = status;
 }

--- a/src/Production/EnviousWispr.Architecture.Tests/EnviousWispr.Architecture.Tests.csproj
+++ b/src/Production/EnviousWispr.Architecture.Tests/EnviousWispr.Architecture.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Using Include="Xunit" />
     <ProjectReference Include="..\EnviousWispr.Audio\EnviousWispr.Audio.csproj" />
+    <ProjectReference Include="..\EnviousWispr.Pipeline\EnviousWispr.Pipeline.csproj" />
     <ProjectReference Include="..\EnviousWispr.Services\EnviousWispr.Services.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Production/EnviousWispr.Architecture.Tests/HotkeyEdgeTrackerTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/HotkeyEdgeTrackerTests.cs
@@ -1,0 +1,92 @@
+using EnviousWispr.Core.Input;
+using EnviousWispr.Services.Input;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class HotkeyEdgeTrackerTests
+{
+    private const uint F8 = 0x77;
+
+    [Fact]
+    public void PressRepeatAndReleaseProduceOneEdgeEach()
+    {
+        var tracker = new HotkeyEdgeTracker(F8, HotkeyModifiers.None);
+
+        var pressed = tracker.Process(F8, isKeyDown: true, HotkeyModifiers.None);
+        var repeated = tracker.Process(F8, isKeyDown: true, HotkeyModifiers.None);
+        var released = tracker.Process(F8, isKeyDown: false, HotkeyModifiers.None);
+
+        Assert.Equal(PushToTalkSignal.Pressed, pressed.Signal);
+        Assert.True(pressed.Consume);
+        Assert.Null(repeated.Signal);
+        Assert.True(repeated.Consume);
+        Assert.Equal(PushToTalkSignal.Released, released.Signal);
+        Assert.True(released.Consume);
+    }
+
+    [Fact]
+    public void TriggerWithoutConfiguredModifiersPassesThrough()
+    {
+        var tracker = new HotkeyEdgeTracker(F8, HotkeyModifiers.Control);
+
+        var down = tracker.Process(F8, isKeyDown: true, HotkeyModifiers.None);
+        var up = tracker.Process(F8, isKeyDown: false, HotkeyModifiers.None);
+
+        Assert.False(down.Consume);
+        Assert.False(up.Consume);
+    }
+
+    [Fact]
+    public void UnrelatedTypingAlwaysPassesThrough()
+    {
+        var tracker = new HotkeyEdgeTracker(F8, HotkeyModifiers.None);
+
+        var down = tracker.Process(virtualKey: 'A', isKeyDown: true, HotkeyModifiers.None);
+        var up = tracker.Process(virtualKey: 'A', isKeyDown: false, HotkeyModifiers.None);
+
+        Assert.False(down.Consume);
+        Assert.False(up.Consume);
+        Assert.Null(down.Signal);
+        Assert.Null(up.Signal);
+    }
+
+    [Fact]
+    public void EscapeCancelsOnceAndTriggerReleaseDoesNotFinalize()
+    {
+        var tracker = new HotkeyEdgeTracker(F8, HotkeyModifiers.None);
+        tracker.Process(F8, isKeyDown: true, HotkeyModifiers.None);
+
+        var cancelled = tracker.Process(
+            HotkeyEdgeTracker.EscapeVirtualKey,
+            isKeyDown: true,
+            HotkeyModifiers.None);
+        var repeatedEscape = tracker.Process(
+            HotkeyEdgeTracker.EscapeVirtualKey,
+            isKeyDown: true,
+            HotkeyModifiers.None);
+        var escapeUp = tracker.Process(
+            HotkeyEdgeTracker.EscapeVirtualKey,
+            isKeyDown: false,
+            HotkeyModifiers.None);
+        var triggerUp = tracker.Process(F8, isKeyDown: false, HotkeyModifiers.None);
+
+        Assert.Equal(PushToTalkSignal.Cancelled, cancelled.Signal);
+        Assert.True(cancelled.Consume);
+        Assert.Null(repeatedEscape.Signal);
+        Assert.True(escapeUp.Consume);
+        Assert.Null(triggerUp.Signal);
+        Assert.True(triggerUp.Consume);
+    }
+
+    [Fact]
+    public void ReleaseCompletesEvenWhenModifierWasReleasedFirst()
+    {
+        var tracker = new HotkeyEdgeTracker(F8, HotkeyModifiers.Control);
+        tracker.Process(F8, isKeyDown: true, HotkeyModifiers.Control);
+
+        var released = tracker.Process(F8, isKeyDown: false, HotkeyModifiers.None);
+
+        Assert.Equal(PushToTalkSignal.Released, released.Signal);
+        Assert.True(released.Consume);
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/HotkeyGestureParserTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/HotkeyGestureParserTests.cs
@@ -1,0 +1,63 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
+using EnviousWispr.Core.Settings;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class HotkeyGestureParserTests
+{
+    [Theory]
+    [InlineData("F8", HotkeyModifiers.None, "F8")]
+    [InlineData("ctrl+shift+f12", HotkeyModifiers.Control | HotkeyModifiers.Shift, "F12")]
+    [InlineData("F9 + Windows + Alt", HotkeyModifiers.Windows | HotkeyModifiers.Alt, "F9")]
+    [InlineData("control + space", HotkeyModifiers.Control, "Space")]
+    public void ValidGesturesAreCanonicalized(
+        string value,
+        HotkeyModifiers expectedModifiers,
+        string expectedKey)
+    {
+        var result = HotkeyGestureParser.Parse(value);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(expectedModifiers, result.Gesture?.Modifiers);
+        Assert.Equal(expectedKey, result.Gesture?.Key);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Ctrl")]
+    [InlineData("Ctrl+Ctrl+F8")]
+    [InlineData("F8+F9")]
+    [InlineData("Escape")]
+    [InlineData("F25")]
+    [InlineData("Ctrl++F8")]
+    public void InvalidGesturesReturnContentFreeTypedFailure(string? value)
+    {
+        var result = HotkeyGestureParser.Parse(value);
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Gesture);
+        Assert.Equal(AppErrorCode.HotkeyInvalid, result.Error?.Code);
+        Assert.Equal(AppErrorStage.HotkeyConfiguration, result.Error?.Stage);
+    }
+
+    [Fact]
+    public void SettingsValidationRejectsUninstallableGesture()
+    {
+        var settings = AppSettings.Default with
+        {
+            Preferences = UserPreferences.Default with
+            {
+                Dictation = DictationPreferences.Default with
+                {
+                    PushToTalkGesture = "Escape",
+                },
+            },
+        };
+
+        var error = AppSettingsValidator.Validate(settings, AppErrorStage.SettingsSave);
+
+        Assert.Equal(AppErrorCode.InvalidData, error?.Code);
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/ProjectDependencyTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/ProjectDependencyTests.cs
@@ -26,7 +26,12 @@ public sealed class ProjectDependencyTests
                 "EnviousWispr.PostProcessing",
                 "EnviousWispr.Services",
             ],
-            ["EnviousWispr.Architecture.Tests"] = ["EnviousWispr.Audio", "EnviousWispr.Services"],
+            ["EnviousWispr.Architecture.Tests"] =
+            [
+                "EnviousWispr.Audio",
+                "EnviousWispr.Pipeline",
+                "EnviousWispr.Services",
+            ],
         };
 
     [Fact]

--- a/src/Production/EnviousWispr.Architecture.Tests/PushToTalkSessionControllerTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/PushToTalkSessionControllerTests.cs
@@ -1,0 +1,212 @@
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
+using EnviousWispr.Core.Sessions;
+using EnviousWispr.Pipeline;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class PushToTalkSessionControllerTests
+{
+    private static readonly float[] OneSample = [0.2f];
+
+    [Fact]
+    public async Task PressFreezesTargetAndRejectsOverlap()
+    {
+        var audio = new FakeAudioCapture();
+        var targets = new FakeTargetProvider(101);
+        await using var controller = new PushToTalkSessionController(audio, targets);
+
+        var started = await controller.PressAsync();
+        targets.Window = new TargetWindowId(202);
+        var overlap = await controller.PressAsync();
+        var released = await controller.ReleaseAsync();
+
+        Assert.Equal(SessionTransitionKind.Started, started.Kind);
+        Assert.Equal(new TargetWindowId(101), started.Session?.Target);
+        Assert.Equal(SessionTransitionKind.Ignored, overlap.Kind);
+        Assert.Equal(1, audio.StartCount);
+        Assert.Equal(new TargetWindowId(101), released.Session?.Target);
+    }
+
+    [Fact]
+    public async Task EscapeCancellationDeliversNothingAndAllowsReset()
+    {
+        var audio = new FakeAudioCapture();
+        await using var controller = new PushToTalkSessionController(
+            audio,
+            new FakeTargetProvider(101));
+
+        await controller.PressAsync();
+        var cancelled = await controller.CancelAsync();
+        var staleRelease = await controller.ReleaseAsync();
+        var reset = await controller.ResetAsync();
+
+        Assert.Equal(SessionTransitionKind.Cancelled, cancelled.Kind);
+        Assert.Equal(DictationSessionState.Cancelled, cancelled.Session?.State);
+        Assert.NotNull(cancelled.Session?.FinishedAt);
+        Assert.Equal(1, audio.CancelCount);
+        Assert.Equal(0, audio.StopCount);
+        Assert.Equal(SessionTransitionKind.Ignored, staleRelease.Kind);
+        Assert.Equal(SessionTransitionKind.Reset, reset.Kind);
+        Assert.Null(controller.CurrentSession);
+    }
+
+    [Fact]
+    public async Task FocuslessPressFailsBeforeAudioStarts()
+    {
+        var audio = new FakeAudioCapture();
+        await using var controller = new PushToTalkSessionController(
+            audio,
+            new FakeTargetProvider(window: 0));
+
+        var result = await controller.PressAsync();
+
+        Assert.Equal(SessionTransitionKind.Failed, result.Kind);
+        Assert.Equal(AppErrorCode.TargetUnavailable, result.Error?.Code);
+        Assert.Equal(0, audio.StartCount);
+    }
+
+    [Fact]
+    public async Task BufferedInterruptionCanContinueToDeliveryForFrozenTarget()
+    {
+        var audio = new FakeAudioCapture
+        {
+            StopResultFactory = sessionId => new CapturedAudio(
+                sessionId,
+                OneSample,
+                SampleRate: 16_000,
+                Channels: 1,
+                AudioCaptureOutcome.Interrupted,
+                new AppError(
+                    AppErrorCode.AudioDeviceLost,
+                    AppErrorStage.AudioCapture,
+                    CanRetry: true)),
+        };
+        await using var controller = new PushToTalkSessionController(
+            audio,
+            new FakeTargetProvider(303));
+
+        var started = await controller.PressAsync();
+        var released = await controller.ReleaseAsync();
+        var delivering = await controller.BeginDeliveryAsync(started.Session!.Id);
+        var completed = await controller.CompleteAsync(started.Session.Id);
+
+        Assert.Equal(SessionTransitionKind.FinalizeReady, released.Kind);
+        Assert.Equal(AppErrorCode.AudioDeviceLost, released.Error?.Code);
+        Assert.Equal(SessionTransitionKind.Delivering, delivering.Kind);
+        Assert.Equal(new TargetWindowId(303), delivering.Session?.Target);
+        Assert.Equal(SessionTransitionKind.Completed, completed.Kind);
+        Assert.Equal(DictationSessionState.Completed, completed.Session?.State);
+    }
+
+    [Fact]
+    public async Task EmptyInterruptedCaptureFailsQuietlyAndRejectsStaleCompletion()
+    {
+        var audio = new FakeAudioCapture
+        {
+            StopResultFactory = sessionId => new CapturedAudio(
+                sessionId,
+                ReadOnlyMemory<float>.Empty,
+                SampleRate: 16_000,
+                Channels: 1,
+                AudioCaptureOutcome.Interrupted,
+                new AppError(
+                    AppErrorCode.AudioDeviceLost,
+                    AppErrorStage.AudioCapture,
+                    CanRetry: false)),
+        };
+        await using var controller = new PushToTalkSessionController(
+            audio,
+            new FakeTargetProvider(404));
+
+        await controller.PressAsync();
+        var released = await controller.ReleaseAsync();
+        var stale = await controller.CompleteAsync(DictationSessionId.Create());
+
+        Assert.Equal(SessionTransitionKind.Failed, released.Kind);
+        Assert.Equal(DictationSessionState.Failed, released.Session?.State);
+        Assert.Equal(SessionTransitionKind.Ignored, stale.Kind);
+    }
+
+    [Fact]
+    public async Task DisposalCancelsAnActiveSessionAndDisposesAudio()
+    {
+        var audio = new FakeAudioCapture();
+        var controller = new PushToTalkSessionController(audio, new FakeTargetProvider(505));
+        await controller.PressAsync();
+
+        await controller.DisposeAsync();
+
+        Assert.Equal(1, audio.CancelCount);
+        Assert.True(audio.Disposed);
+    }
+
+    private sealed class FakeTargetProvider(nint window) : IForegroundTargetProvider
+    {
+        public TargetWindowId Window { get; set; } = new(window);
+
+        public TargetWindowId? CaptureForegroundTarget() => Window.IsValid ? Window : null;
+    }
+
+    private sealed class FakeAudioCapture : IAudioCapture
+    {
+        private DictationSessionId _sessionId;
+
+        public event EventHandler<AudioLevel>? LevelChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public bool IsCapturing { get; private set; }
+
+        public int StartCount { get; private set; }
+
+        public int StopCount { get; private set; }
+
+        public int CancelCount { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public Func<DictationSessionId, CapturedAudio>? StopResultFactory { get; init; }
+
+        public Task<AudioOperationResult> StartAsync(
+            AudioCaptureRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StartCount++;
+            _sessionId = request.SessionId;
+            IsCapturing = true;
+            return Task.FromResult(new AudioOperationResult(Succeeded: true));
+        }
+
+        public Task<CapturedAudio> StopAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StopCount++;
+            IsCapturing = false;
+            return Task.FromResult(StopResultFactory?.Invoke(_sessionId) ?? new CapturedAudio(
+                _sessionId,
+                OneSample,
+                SampleRate: 16_000,
+                Channels: 1));
+        }
+
+        public Task<AudioOperationResult> CancelAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CancelCount++;
+            IsCapturing = false;
+            return Task.FromResult(new AudioOperationResult(Succeeded: true));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Production/EnviousWispr.Core/Diagnostics/AppEventCode.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/AppEventCode.cs
@@ -12,5 +12,11 @@ public enum AppEventCode
     SettingsNewerVersionPreserved,
     ShellShown,
     ShellClosed,
+    HotkeyReady,
+    HotkeyFailed,
+    DictationRecordingStarted,
+    DictationCaptureFinalized,
+    DictationCancelled,
+    DictationSessionFailed,
     UnhandledFailure,
 }

--- a/src/Production/EnviousWispr.Core/Diagnostics/AppFailureCategory.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/AppFailureCategory.cs
@@ -6,5 +6,9 @@ public enum AppFailureCategory
     AccessDenied,
     InvalidData,
     StorageUnavailable,
+    AudioUnavailable,
+    HotkeyConflict,
+    HotkeyUnavailable,
+    TargetUnavailable,
     Unknown,
 }

--- a/src/Production/EnviousWispr.Core/Errors/AppError.cs
+++ b/src/Production/EnviousWispr.Core/Errors/AppError.cs
@@ -12,6 +12,10 @@ public enum AppErrorCode
     AudioDeviceLost,
     AudioFormatUnsupported,
     CaptureAlreadyActive,
+    HotkeyInvalid,
+    HotkeyConflict,
+    HotkeyUnavailable,
+    TargetUnavailable,
 }
 
 public enum AppErrorStage
@@ -24,6 +28,9 @@ public enum AppErrorStage
     ProfileExport,
     AudioDeviceEnumeration,
     AudioCapture,
+    HotkeyConfiguration,
+    HotkeyHook,
+    TargetCapture,
 }
 
 public sealed record AppError(AppErrorCode Code, AppErrorStage Stage, bool CanRetry);

--- a/src/Production/EnviousWispr.Core/Input/HotkeyContracts.cs
+++ b/src/Production/EnviousWispr.Core/Input/HotkeyContracts.cs
@@ -1,0 +1,173 @@
+using EnviousWispr.Core.Errors;
+
+namespace EnviousWispr.Core.Input;
+
+[Flags]
+public enum HotkeyModifiers
+{
+    None = 0,
+    Control = 1,
+    Alt = 2,
+    Shift = 4,
+    Windows = 8,
+}
+
+public readonly record struct HotkeyGesture(HotkeyModifiers Modifiers, string Key)
+{
+    public override string ToString()
+    {
+        var parts = new List<string>(5);
+        if (Modifiers.HasFlag(HotkeyModifiers.Control))
+        {
+            parts.Add("Ctrl");
+        }
+
+        if (Modifiers.HasFlag(HotkeyModifiers.Alt))
+        {
+            parts.Add("Alt");
+        }
+
+        if (Modifiers.HasFlag(HotkeyModifiers.Shift))
+        {
+            parts.Add("Shift");
+        }
+
+        if (Modifiers.HasFlag(HotkeyModifiers.Windows))
+        {
+            parts.Add("Win");
+        }
+
+        parts.Add(Key);
+        return string.Join('+', parts);
+    }
+}
+
+public sealed record HotkeyGestureParseResult(
+    bool Succeeded,
+    HotkeyGesture? Gesture = null,
+    AppError? Error = null);
+
+public static class HotkeyGestureParser
+{
+    public static HotkeyGestureParseResult Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > 64)
+        {
+            return Failure();
+        }
+
+        var tokens = value.Split('+', StringSplitOptions.TrimEntries);
+        if (tokens.Length == 0 || tokens.Any(string.IsNullOrWhiteSpace))
+        {
+            return Failure();
+        }
+
+        var modifiers = HotkeyModifiers.None;
+        string? key = null;
+        foreach (var token in tokens)
+        {
+            if (TryParseModifier(token, out var modifier))
+            {
+                if ((modifiers & modifier) != 0)
+                {
+                    return Failure();
+                }
+
+                modifiers |= modifier;
+                continue;
+            }
+
+            if (key is not null || !TryNormalizeKey(token, out key))
+            {
+                return Failure();
+            }
+        }
+
+        return key is null
+            ? Failure()
+            : new HotkeyGestureParseResult(true, new HotkeyGesture(modifiers, key));
+    }
+
+    private static bool TryParseModifier(string token, out HotkeyModifiers modifier)
+    {
+        modifier = token.ToUpperInvariant() switch
+        {
+            "CTRL" or "CONTROL" => HotkeyModifiers.Control,
+            "ALT" => HotkeyModifiers.Alt,
+            "SHIFT" => HotkeyModifiers.Shift,
+            "WIN" or "WINDOWS" => HotkeyModifiers.Windows,
+            _ => HotkeyModifiers.None,
+        };
+        return modifier != HotkeyModifiers.None;
+    }
+
+    private static bool TryNormalizeKey(string token, out string key)
+    {
+        var candidate = token.ToUpperInvariant();
+        if (candidate.Length == 1 &&
+            (candidate[0] is >= 'A' and <= 'Z' or >= '0' and <= '9'))
+        {
+            key = candidate;
+            return true;
+        }
+
+        if (candidate.Length is 2 or 3 &&
+            candidate[0] == 'F' &&
+            int.TryParse(candidate.AsSpan(1), out var functionKey) &&
+            functionKey is >= 1 and <= 24)
+        {
+            key = $"F{functionKey}";
+            return true;
+        }
+
+        key = candidate switch
+        {
+            "SPACE" => "Space",
+            "INSERT" => "Insert",
+            "DELETE" => "Delete",
+            "HOME" => "Home",
+            "END" => "End",
+            "PAGEUP" => "PageUp",
+            "PAGEDOWN" => "PageDown",
+            "PAUSE" => "Pause",
+            "SCROLLLOCK" => "ScrollLock",
+            _ => string.Empty,
+        };
+        return key.Length > 0;
+    }
+
+    private static HotkeyGestureParseResult Failure() => new(
+        Succeeded: false,
+        Error: new AppError(
+            AppErrorCode.HotkeyInvalid,
+            AppErrorStage.HotkeyConfiguration,
+            CanRetry: false));
+}
+
+public readonly record struct TargetWindowId(nint Value)
+{
+    public bool IsValid => Value != 0;
+}
+
+public interface IForegroundTargetProvider
+{
+    TargetWindowId? CaptureForegroundTarget();
+}
+
+public enum PushToTalkSignal
+{
+    Pressed,
+    Released,
+    Cancelled,
+}
+
+public sealed record PushToTalkSignalEvent(PushToTalkSignal Signal);
+
+public interface IGlobalPushToTalk : IAsyncDisposable
+{
+    event EventHandler<PushToTalkSignalEvent>? Signalled;
+
+    HotkeyGesture Gesture { get; }
+
+    bool IsInstalled { get; }
+}

--- a/src/Production/EnviousWispr.Core/Sessions/DictationSessionSnapshot.cs
+++ b/src/Production/EnviousWispr.Core/Sessions/DictationSessionSnapshot.cs
@@ -1,5 +1,6 @@
 using EnviousWispr.Core.Dictation;
 using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
 
 namespace EnviousWispr.Core.Sessions;
 
@@ -17,11 +18,22 @@ public sealed record DictationSessionSnapshot(
     DictationSessionId Id,
     DictationSessionState State,
     DateTimeOffset StartedAt,
+    TargetWindowId Target,
     DateTimeOffset? FinishedAt = null,
     AppError? Error = null)
 {
     public static DictationSessionSnapshot Start(DateTimeOffset startedAt) => new(
         DictationSessionId.Create(),
         DictationSessionState.Recording,
-        startedAt);
+        startedAt,
+        default);
+
+    public static DictationSessionSnapshot Start(
+        DictationSessionId id,
+        DateTimeOffset startedAt,
+        TargetWindowId target) => new(
+        id,
+        DictationSessionState.Recording,
+        startedAt,
+        target);
 }

--- a/src/Production/EnviousWispr.Core/Settings/AppSettingsValidator.cs
+++ b/src/Production/EnviousWispr.Core/Settings/AppSettingsValidator.cs
@@ -1,4 +1,5 @@
 using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
 
 namespace EnviousWispr.Core.Settings;
 
@@ -40,8 +41,7 @@ public static class AppSettingsValidator
         preferences.Polish is not null &&
         preferences.History is not null &&
         Enum.IsDefined(preferences.Dictation.FinalEngine) &&
-        !string.IsNullOrWhiteSpace(preferences.Dictation.PushToTalkGesture) &&
-        preferences.Dictation.PushToTalkGesture.Length <= 64 &&
+        HotkeyGestureParser.Parse(preferences.Dictation.PushToTalkGesture).Succeeded &&
         Enum.IsDefined(preferences.Polish.Provider) &&
         (preferences.Polish.ModelId is null ||
             (!string.IsNullOrWhiteSpace(preferences.Polish.ModelId) && preferences.Polish.ModelId.Length <= 256)) &&

--- a/src/Production/EnviousWispr.Pipeline/PushToTalkSessionController.cs
+++ b/src/Production/EnviousWispr.Pipeline/PushToTalkSessionController.cs
@@ -1,0 +1,290 @@
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
+using EnviousWispr.Core.Sessions;
+
+namespace EnviousWispr.Pipeline;
+
+public enum SessionTransitionKind
+{
+    Started,
+    FinalizeReady,
+    Delivering,
+    Cancelled,
+    Completed,
+    Reset,
+    Ignored,
+    Failed,
+}
+
+public sealed record SessionTransitionResult(
+    SessionTransitionKind Kind,
+    DictationSessionSnapshot? Session = null,
+    CapturedAudio? Audio = null,
+    AppError? Error = null);
+
+public sealed class PushToTalkSessionController : IAsyncDisposable
+{
+    private readonly IAudioCapture _audioCapture;
+    private readonly IForegroundTargetProvider _targetProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _minimumHoldDuration;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _disposed;
+
+    public PushToTalkSessionController(
+        IAudioCapture audioCapture,
+        IForegroundTargetProvider targetProvider,
+        TimeProvider? timeProvider = null,
+        TimeSpan? minimumHoldDuration = null)
+    {
+        ArgumentNullException.ThrowIfNull(audioCapture);
+        ArgumentNullException.ThrowIfNull(targetProvider);
+        _audioCapture = audioCapture;
+        _targetProvider = targetProvider;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _minimumHoldDuration = minimumHoldDuration ?? TimeSpan.FromMilliseconds(100);
+        ArgumentOutOfRangeException.ThrowIfLessThan(_minimumHoldDuration, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            _minimumHoldDuration,
+            TimeSpan.FromSeconds(1));
+    }
+
+    public event EventHandler<DictationSessionSnapshot>? SessionChanged;
+
+    public DictationSessionSnapshot? CurrentSession { get; private set; }
+
+    public async Task<SessionTransitionResult> PressAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (CurrentSession is not null)
+            {
+                return Ignored();
+            }
+
+            var target = _targetProvider.CaptureForegroundTarget();
+            if (target is null || !target.Value.IsValid)
+            {
+                return Failure(new AppError(
+                    AppErrorCode.TargetUnavailable,
+                    AppErrorStage.TargetCapture,
+                    CanRetry: true));
+            }
+
+            var sessionId = DictationSessionId.Create();
+            var started = await _audioCapture
+                .StartAsync(new AudioCaptureRequest(sessionId), cancellationToken)
+                .ConfigureAwait(false);
+            if (!started.Succeeded)
+            {
+                return Failure(started.Error ?? new AppError(
+                    AppErrorCode.AudioDeviceUnavailable,
+                    AppErrorStage.AudioCapture,
+                    CanRetry: true));
+            }
+
+            CurrentSession = DictationSessionSnapshot.Start(
+                sessionId,
+                _timeProvider.GetUtcNow(),
+                target.Value);
+            RaiseChanged();
+            return new SessionTransitionResult(SessionTransitionKind.Started, CurrentSession);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<SessionTransitionResult> ReleaseAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (CurrentSession?.State != DictationSessionState.Recording)
+            {
+                return Ignored();
+            }
+
+            var heldFor = _timeProvider.GetUtcNow() - CurrentSession.StartedAt;
+            var remainingDebounce = _minimumHoldDuration - heldFor;
+            if (remainingDebounce > TimeSpan.Zero)
+            {
+                await Task.Delay(
+                    remainingDebounce,
+                    _timeProvider,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            CurrentSession = CurrentSession with { State = DictationSessionState.Finalizing };
+            RaiseChanged();
+            var audio = await _audioCapture.StopAsync(cancellationToken).ConfigureAwait(false);
+            if (audio.Error is not null && audio.Samples.IsEmpty)
+            {
+                CurrentSession = CurrentSession with
+                {
+                    State = DictationSessionState.Failed,
+                    FinishedAt = _timeProvider.GetUtcNow(),
+                    Error = audio.Error,
+                };
+                RaiseChanged();
+                return new SessionTransitionResult(
+                    SessionTransitionKind.Failed,
+                    CurrentSession,
+                    audio,
+                    audio.Error);
+            }
+
+            return new SessionTransitionResult(
+                SessionTransitionKind.FinalizeReady,
+                CurrentSession,
+                audio,
+                audio.Error);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<SessionTransitionResult> CancelAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (CurrentSession?.State != DictationSessionState.Recording)
+            {
+                return Ignored();
+            }
+
+            var cancelled = await _audioCapture.CancelAsync(cancellationToken).ConfigureAwait(false);
+            var failed = !cancelled.Succeeded;
+            CurrentSession = CurrentSession with
+            {
+                State = failed ? DictationSessionState.Failed : DictationSessionState.Cancelled,
+                FinishedAt = _timeProvider.GetUtcNow(),
+                Error = cancelled.Error,
+            };
+            RaiseChanged();
+            return new SessionTransitionResult(
+                failed ? SessionTransitionKind.Failed : SessionTransitionKind.Cancelled,
+                CurrentSession,
+                Error: cancelled.Error);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<SessionTransitionResult> BeginDeliveryAsync(
+        DictationSessionId sessionId,
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (CurrentSession?.Id != sessionId ||
+                CurrentSession.State != DictationSessionState.Finalizing)
+            {
+                return Ignored();
+            }
+
+            CurrentSession = CurrentSession with { State = DictationSessionState.Delivering };
+            RaiseChanged();
+            return new SessionTransitionResult(SessionTransitionKind.Delivering, CurrentSession);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<SessionTransitionResult> CompleteAsync(
+        DictationSessionId sessionId,
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (CurrentSession?.Id != sessionId ||
+                CurrentSession.State is not (DictationSessionState.Finalizing or
+                    DictationSessionState.Delivering))
+            {
+                return Ignored();
+            }
+
+            CurrentSession = CurrentSession with
+            {
+                State = DictationSessionState.Completed,
+                FinishedAt = _timeProvider.GetUtcNow(),
+            };
+            RaiseChanged();
+            return new SessionTransitionResult(SessionTransitionKind.Completed, CurrentSession);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<SessionTransitionResult> ResetAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (CurrentSession?.State is not (DictationSessionState.Completed or
+                DictationSessionState.Cancelled or DictationSessionState.Failed))
+            {
+                return Ignored();
+            }
+
+            CurrentSession = null;
+            return new SessionTransitionResult(SessionTransitionKind.Reset);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (CurrentSession?.State == DictationSessionState.Recording)
+        {
+            await CancelAsync().ConfigureAwait(false);
+        }
+
+        _disposed = true;
+        await _audioCapture.DisposeAsync().ConfigureAwait(false);
+        _gate.Dispose();
+    }
+
+    private void RaiseChanged() => SessionChanged?.Invoke(this, CurrentSession!);
+
+    private SessionTransitionResult Ignored() => new(
+        SessionTransitionKind.Ignored,
+        CurrentSession);
+
+    private static SessionTransitionResult Failure(AppError error) => new(
+        SessionTransitionKind.Failed,
+        Error: error);
+}

--- a/src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj
+++ b/src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="EnviousWispr.Architecture.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\EnviousWispr.Core\EnviousWispr.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Production/EnviousWispr.Services/Input/HotkeyEdgeTracker.cs
+++ b/src/Production/EnviousWispr.Services/Input/HotkeyEdgeTracker.cs
@@ -1,0 +1,81 @@
+using EnviousWispr.Core.Input;
+
+namespace EnviousWispr.Services.Input;
+
+internal readonly record struct HotkeyEdgeDecision(
+    bool Consume,
+    PushToTalkSignal? Signal = null);
+
+internal sealed class HotkeyEdgeTracker(uint triggerVirtualKey, HotkeyModifiers requiredModifiers)
+{
+    internal const uint EscapeVirtualKey = 0x1B;
+
+    private bool _triggerHeld;
+    private bool _cancelHeld;
+    private bool _cancelledUntilTriggerRelease;
+
+    public HotkeyEdgeDecision Process(
+        uint virtualKey,
+        bool isKeyDown,
+        HotkeyModifiers activeModifiers)
+    {
+        if (virtualKey == triggerVirtualKey)
+        {
+            if (isKeyDown)
+            {
+                if (_triggerHeld)
+                {
+                    return new HotkeyEdgeDecision(Consume: true);
+                }
+
+                if (activeModifiers != requiredModifiers)
+                {
+                    return new HotkeyEdgeDecision(Consume: false);
+                }
+
+                _triggerHeld = true;
+                _cancelledUntilTriggerRelease = false;
+                return new HotkeyEdgeDecision(Consume: true, PushToTalkSignal.Pressed);
+            }
+
+            if (!_triggerHeld)
+            {
+                return new HotkeyEdgeDecision(Consume: false);
+            }
+
+            _triggerHeld = false;
+            if (_cancelledUntilTriggerRelease)
+            {
+                _cancelledUntilTriggerRelease = false;
+                return new HotkeyEdgeDecision(Consume: true);
+            }
+
+            return new HotkeyEdgeDecision(Consume: true, PushToTalkSignal.Released);
+        }
+
+        if (virtualKey != EscapeVirtualKey || !_triggerHeld)
+        {
+            return new HotkeyEdgeDecision(Consume: false);
+        }
+
+        if (isKeyDown)
+        {
+            if (_cancelHeld)
+            {
+                return new HotkeyEdgeDecision(Consume: true);
+            }
+
+            _cancelHeld = true;
+            _cancelledUntilTriggerRelease = true;
+            return new HotkeyEdgeDecision(Consume: true, PushToTalkSignal.Cancelled);
+        }
+
+        if (!_cancelHeld)
+        {
+            return new HotkeyEdgeDecision(Consume: false);
+        }
+
+        _cancelHeld = false;
+        return new HotkeyEdgeDecision(Consume: true);
+    }
+}

--- a/src/Production/EnviousWispr.Services/Input/WindowsForegroundTargetProvider.cs
+++ b/src/Production/EnviousWispr.Services/Input/WindowsForegroundTargetProvider.cs
@@ -1,0 +1,16 @@
+using EnviousWispr.Core.Input;
+using System.Runtime.InteropServices;
+
+namespace EnviousWispr.Services.Input;
+
+public sealed class WindowsForegroundTargetProvider : IForegroundTargetProvider
+{
+    public TargetWindowId? CaptureForegroundTarget()
+    {
+        var handle = GetForegroundWindow();
+        return handle == 0 ? null : new TargetWindowId(handle);
+    }
+
+    [DllImport("user32.dll")]
+    private static extern nint GetForegroundWindow();
+}

--- a/src/Production/EnviousWispr.Services/Input/WindowsPushToTalkHook.cs
+++ b/src/Production/EnviousWispr.Services/Input/WindowsPushToTalkHook.cs
@@ -1,0 +1,306 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Threading.Channels;
+
+namespace EnviousWispr.Services.Input;
+
+public sealed class WindowsPushToTalkHook : IGlobalPushToTalk
+{
+    private const int WhKeyboardLowLevel = 13;
+    private const int WmKeyDown = 0x0100;
+    private const int WmKeyUp = 0x0101;
+    private const int WmSystemKeyDown = 0x0104;
+    private const int WmSystemKeyUp = 0x0105;
+    private const int ErrorHotkeyAlreadyRegistered = 1409;
+    private const uint ModifierNoRepeat = 0x4000;
+    private const uint VirtualKeyShift = 0x10;
+    private const uint VirtualKeyControl = 0x11;
+    private const uint VirtualKeyAlt = 0x12;
+    private const uint VirtualKeyLeftWindows = 0x5B;
+    private const uint VirtualKeyRightWindows = 0x5C;
+
+    private static int _probeId = 0x5100;
+
+    private readonly LowLevelKeyboardProcedure _procedure;
+    private readonly HotkeyEdgeTracker _edgeTracker;
+    private readonly Channel<PushToTalkSignal> _signals = Channel.CreateUnbounded<PushToTalkSignal>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+    private readonly Task _dispatchTask;
+    private nint _hook;
+
+    private WindowsPushToTalkHook(HotkeyGesture gesture, uint virtualKey)
+    {
+        Gesture = gesture;
+        _edgeTracker = new HotkeyEdgeTracker(virtualKey, gesture.Modifiers);
+        _procedure = HookCallback;
+        _dispatchTask = Task.Run(DispatchAsync);
+        _hook = SetWindowsHookEx(
+            WhKeyboardLowLevel,
+            _procedure,
+            GetModuleHandle(moduleName: null),
+            threadId: 0);
+
+        if (_hook == 0)
+        {
+            _signals.Writer.TryComplete();
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Global keyboard hook unavailable.");
+        }
+    }
+
+    public event EventHandler<PushToTalkSignalEvent>? Signalled;
+
+    public HotkeyGesture Gesture { get; }
+
+    public bool IsInstalled => _hook != 0;
+
+    public static bool TryCreate(
+        string configuredGesture,
+        out WindowsPushToTalkHook? hook,
+        out AppError? error)
+    {
+        hook = null;
+        var parsed = HotkeyGestureParser.Parse(configuredGesture);
+        if (!parsed.Succeeded || parsed.Gesture is null)
+        {
+            error = parsed.Error;
+            return false;
+        }
+
+        var gesture = parsed.Gesture.Value;
+        if (!WindowsVirtualKeyMap.TryMap(gesture.Key, out var virtualKey))
+        {
+            error = new AppError(
+                AppErrorCode.HotkeyInvalid,
+                AppErrorStage.HotkeyConfiguration,
+                CanRetry: false);
+            return false;
+        }
+
+        var conflict = ProbeConflict(gesture, virtualKey);
+        if (conflict is not null)
+        {
+            error = conflict;
+            return false;
+        }
+
+        try
+        {
+            hook = new WindowsPushToTalkHook(gesture, virtualKey);
+            error = null;
+            return true;
+        }
+        catch (Win32Exception)
+        {
+            error = new AppError(
+                AppErrorCode.HotkeyUnavailable,
+                AppErrorStage.HotkeyHook,
+                CanRetry: true);
+            return false;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var hook = Interlocked.Exchange(ref _hook, 0);
+        if (hook == 0)
+        {
+            return;
+        }
+
+        UnhookWindowsHookEx(hook);
+        _signals.Writer.TryComplete();
+        await _dispatchTask.ConfigureAwait(false);
+    }
+
+    private nint HookCallback(int code, nint message, nint data)
+    {
+        if (code >= 0 && IsKeyboardEdge(message))
+        {
+            var keyboard = Marshal.PtrToStructure<LowLevelKeyboardData>(data);
+            var decision = _edgeTracker.Process(
+                keyboard.VirtualKey,
+                IsKeyDown(message),
+                ReadActiveModifiers());
+            if (decision.Signal is not null)
+            {
+                _signals.Writer.TryWrite(decision.Signal.Value);
+            }
+
+            if (decision.Consume)
+            {
+                return 1;
+            }
+        }
+
+        return CallNextHookEx(_hook, code, message, data);
+    }
+
+    private async Task DispatchAsync()
+    {
+        await foreach (var signal in _signals.Reader.ReadAllAsync().ConfigureAwait(false))
+        {
+            try
+            {
+                Signalled?.Invoke(this, new PushToTalkSignalEvent(signal));
+            }
+            catch
+            {
+                // Subscribers cannot be allowed to tear down the native hook dispatch loop.
+            }
+        }
+    }
+
+    private static AppError? ProbeConflict(HotkeyGesture gesture, uint virtualKey)
+    {
+        var id = Interlocked.Increment(ref _probeId);
+        if (RegisterHotKey(0, id, ToWindowsModifiers(gesture.Modifiers) | ModifierNoRepeat, virtualKey))
+        {
+            UnregisterHotKey(0, id);
+            return null;
+        }
+
+        return new AppError(
+            Marshal.GetLastWin32Error() == ErrorHotkeyAlreadyRegistered
+                ? AppErrorCode.HotkeyConflict
+                : AppErrorCode.HotkeyUnavailable,
+            AppErrorStage.HotkeyConfiguration,
+            CanRetry: true);
+    }
+
+    private static HotkeyModifiers ReadActiveModifiers()
+    {
+        var modifiers = HotkeyModifiers.None;
+        if (IsPressed(VirtualKeyControl))
+        {
+            modifiers |= HotkeyModifiers.Control;
+        }
+
+        if (IsPressed(VirtualKeyAlt))
+        {
+            modifiers |= HotkeyModifiers.Alt;
+        }
+
+        if (IsPressed(VirtualKeyShift))
+        {
+            modifiers |= HotkeyModifiers.Shift;
+        }
+
+        if (IsPressed(VirtualKeyLeftWindows) || IsPressed(VirtualKeyRightWindows))
+        {
+            modifiers |= HotkeyModifiers.Windows;
+        }
+
+        return modifiers;
+    }
+
+    private static bool IsPressed(uint virtualKey) => (GetAsyncKeyState((int)virtualKey) & 0x8000) != 0;
+
+    private static bool IsKeyboardEdge(nint message) =>
+        message is WmKeyDown or WmKeyUp or WmSystemKeyDown or WmSystemKeyUp;
+
+    private static bool IsKeyDown(nint message) => message is WmKeyDown or WmSystemKeyDown;
+
+    private static uint ToWindowsModifiers(HotkeyModifiers modifiers)
+    {
+        uint result = 0;
+        if (modifiers.HasFlag(HotkeyModifiers.Alt))
+        {
+            result |= 0x0001;
+        }
+
+        if (modifiers.HasFlag(HotkeyModifiers.Control))
+        {
+            result |= 0x0002;
+        }
+
+        if (modifiers.HasFlag(HotkeyModifiers.Shift))
+        {
+            result |= 0x0004;
+        }
+
+        if (modifiers.HasFlag(HotkeyModifiers.Windows))
+        {
+            result |= 0x0008;
+        }
+
+        return result;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly struct LowLevelKeyboardData
+    {
+        public readonly uint VirtualKey;
+        public readonly uint ScanCode;
+        public readonly uint Flags;
+        public readonly uint Time;
+        public readonly nint ExtraInfo;
+    }
+
+    private delegate nint LowLevelKeyboardProcedure(int code, nint message, nint data);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern nint SetWindowsHookEx(
+        int hookId,
+        LowLevelKeyboardProcedure procedure,
+        nint module,
+        uint threadId);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UnhookWindowsHookEx(nint hook);
+
+    [DllImport("user32.dll")]
+    private static extern nint CallNextHookEx(nint hook, int code, nint message, nint data);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern nint GetModuleHandle(string? moduleName);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool RegisterHotKey(nint window, int id, uint modifiers, uint virtualKey);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UnregisterHotKey(nint window, int id);
+
+    [DllImport("user32.dll")]
+    private static extern short GetAsyncKeyState(int virtualKey);
+}
+
+internal static class WindowsVirtualKeyMap
+{
+    public static bool TryMap(string key, out uint virtualKey)
+    {
+        if (key.Length == 1 && key[0] is >= 'A' and <= 'Z' or >= '0' and <= '9')
+        {
+            virtualKey = key[0];
+            return true;
+        }
+
+        if (key.Length is 2 or 3 &&
+            key[0] == 'F' &&
+            int.TryParse(key.AsSpan(1), out var functionKey) &&
+            functionKey is >= 1 and <= 24)
+        {
+            virtualKey = checked((uint)(0x70 + functionKey - 1));
+            return true;
+        }
+
+        virtualKey = key switch
+        {
+            "Space" => 0x20,
+            "Pause" => 0x13,
+            "PageUp" => 0x21,
+            "PageDown" => 0x22,
+            "End" => 0x23,
+            "Home" => 0x24,
+            "Insert" => 0x2D,
+            "Delete" => 0x2E,
+            "ScrollLock" => 0x91,
+            _ => 0,
+        };
+        return virtualKey != 0;
+    }
+}

--- a/tools/hotkey-uat/EnviousWispr.Hotkey.Uat.csproj
+++ b/tools/hotkey-uat/EnviousWispr.Hotkey.Uat.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Core\EnviousWispr.Core.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Services\EnviousWispr.Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/hotkey-uat/Program.cs
+++ b/tools/hotkey-uat/Program.cs
@@ -1,0 +1,165 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Input;
+using EnviousWispr.Services.Input;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading.Channels;
+
+const byte F24 = 0x87;
+const byte Escape = 0x1B;
+const int ConflictRegistrationId = 0x6204;
+const uint ControlAltShift = 0x0001 | 0x0002 | 0x0004;
+
+var target = new WindowsForegroundTargetProvider().CaptureForegroundTarget();
+var conflictRegistered = NativeMethods.RegisterHotKey(
+    0,
+    ConflictRegistrationId,
+    ControlAltShift,
+    0x86);
+var conflictDetected = false;
+if (conflictRegistered)
+{
+    conflictDetected = !WindowsPushToTalkHook.TryCreate(
+        "Ctrl+Alt+Shift+F23",
+        out var conflictingHook,
+        out var conflictError) &&
+        conflictingHook is null &&
+        conflictError?.Code == AppErrorCode.HotkeyConflict;
+    NativeMethods.UnregisterHotKey(0, ConflictRegistrationId);
+}
+
+if (!WindowsPushToTalkHook.TryCreate("F24", out var hook, out var installationError) || hook is null)
+{
+    Console.WriteLine(JsonSerializer.Serialize(new
+    {
+        inputKind = "SyntheticSendInput",
+        installed = false,
+        installationError = installationError?.Code.ToString(),
+        targetFrozen = target?.IsValid == true,
+        conflictDetected,
+    }));
+    return 2;
+}
+
+var signals = Channel.CreateUnbounded<PushToTalkSignal>();
+hook.Signalled += (_, args) => signals.Writer.TryWrite(args.Signal);
+
+SendKey(F24, keyDown: true);
+SendKey(F24, keyDown: true);
+SendKey(F24, keyDown: false);
+var holdReleaseSignals = await ReadSignalsAsync(signals.Reader, count: 2);
+
+SendKey(F24, keyDown: true);
+SendKey(Escape, keyDown: true);
+SendKey(Escape, keyDown: false);
+SendKey(F24, keyDown: false);
+var cancellationSignals = await ReadSignalsAsync(signals.Reader, count: 2);
+
+await hook.DisposeAsync();
+var summary = new
+{
+    inputKind = "SyntheticSendInput",
+    installed = true,
+    targetFrozen = target?.IsValid == true,
+    conflictDetected,
+    pressRelease = holdReleaseSignals is
+        [PushToTalkSignal.Pressed, PushToTalkSignal.Released],
+    cancellation = cancellationSignals is
+        [PushToTalkSignal.Pressed, PushToTalkSignal.Cancelled],
+    teardownReleasedHook = !hook.IsInstalled,
+};
+Console.WriteLine(JsonSerializer.Serialize(summary));
+
+return summary.targetFrozen &&
+    summary.conflictDetected &&
+    summary.pressRelease &&
+    summary.cancellation &&
+    summary.teardownReleasedHook
+    ? 0
+    : 4;
+
+static async Task<IReadOnlyList<PushToTalkSignal>> ReadSignalsAsync(
+    ChannelReader<PushToTalkSignal> reader,
+    int count)
+{
+    var result = new List<PushToTalkSignal>(count);
+    using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+    while (result.Count < count)
+    {
+        result.Add(await reader.ReadAsync(timeout.Token));
+    }
+
+    return result;
+}
+
+static void SendKey(byte virtualKey, bool keyDown)
+{
+    var input = new Input
+    {
+        Type = 1,
+        Data = new InputUnion
+        {
+            Keyboard = new KeyboardInput
+            {
+                VirtualKey = virtualKey,
+                Flags = keyDown ? 0u : 0x0002u,
+            },
+        },
+    };
+    if (NativeMethods.SendInput(1, [input], Marshal.SizeOf<Input>()) != 1)
+    {
+        throw new InvalidOperationException("Synthetic keyboard input was rejected.");
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct Input
+{
+    public uint Type;
+    public InputUnion Data;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct InputUnion
+{
+    [FieldOffset(0)]
+    public KeyboardInput Keyboard;
+
+    [FieldOffset(0)]
+    public MouseInput Mouse;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct KeyboardInput
+{
+    public ushort VirtualKey;
+    public ushort ScanCode;
+    public uint Flags;
+    public uint Time;
+    public nuint ExtraInfo;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct MouseInput
+{
+    public int DeltaX;
+    public int DeltaY;
+    public uint MouseData;
+    public uint Flags;
+    public uint Time;
+    public nuint ExtraInfo;
+}
+
+internal static class NativeMethods
+{
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern uint SendInput(uint inputCount, Input[] inputs, int inputSize);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool RegisterHotKey(nint window, int id, uint modifiers, uint virtualKey);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool UnregisterHotKey(nint window, int id);
+}


### PR DESCRIPTION
## Summary

Implements the Phase 4 production push-to-talk and dictation-session foundation: configurable gesture parsing, conflict probing, deterministic press/release edges, repeat debounce, Escape cancellation, frozen foreground target identity, no-overlap/stale-transition rules, content-free diagnostics, and idempotent native hook teardown.

The Release x64 WinUI shell now installs the configured F8 hook and drives the production WASAPI capture path. Final ASR and text delivery remain intentionally disconnected until their documented phases.

This PR is intentionally a draft and is stacked on PR #9 (base: `codex/phase3-wasapi-audio`). Phase 4 remains open until physical-key, physical Escape, focus-change, and forced-shutdown paths are observed.

Relates to #10

## Validation

- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate.ps1`
- [x] Gesture, edge, session-state, cancellation, and target-freeze tests
- [x] Native synthetic hook harness
- [x] Native WinUI launch and synthetic F8 capture path
- [x] Unrelated typing passthrough in Notepad
- [ ] Complete physical-key Windows UAT

Observed results:

- All proof and production builds passed with zero warnings/errors.
- Portable proof tests: 34 passed.
- Production tests: 59 passed.
- Native hook harness: install, conflict detection, press/release, Escape cancellation, foreground target, and teardown all passed; output identifies input as `SyntheticSendInput`.
- Production WinUI: `Hold F8` and `Idle` appeared; generated F8 moved through recording to capture complete.
- The first zero-duration generated tap exposed a recorder startup race; a 100 ms minimum-hold debounce fixed it. The repeated path finalized in about 129 ms with failure category `None`.
- With the production hook installed, 31 ordinary characters entered an isolated Notepad tab unchanged.
- Clean window shutdown logged `ShellClosed` and removed the production window.

## Safety check

- [x] Hook callback recognizes only the configured gesture and Escape while held
- [x] Ordinary key values, window titles, target handles, text, audio, and clipboard content do not enter diagnostics
- [x] Subscriber work is queued off the native hook callback
- [x] Hook teardown occurs before audio/session disposal
- [x] Founder-tested WPF proof remains unchanged

## Remaining native evidence

- A person has not physically held and released F8 against this production build.
- Physical Escape-during-hold and focus change while held are unobserved.
- Forced shutdown/stuck-hook recovery and repeated long physical sessions are unobserved.
- `RegisterHotKey` conflicts are detected; competing low-level hooks cannot be reliably enumerated by Windows.

Do not mark Phase 4 complete or merge this draft until the remaining exits are resolved or explicitly re-scoped by the founder.