### PR TITLE
Phase 5: add hardware-aware isolated runtime foundation

### DIFF
--- a/EnviousWispr.Windows.slnx
+++ b/EnviousWispr.Windows.slnx
@@ -14,10 +14,12 @@
     <Project Path="src/Production/EnviousWispr.ModelDelivery/EnviousWispr.ModelDelivery.csproj" />
     <Project Path="src/Production/EnviousWispr.Pipeline/EnviousWispr.Pipeline.csproj" />
     <Project Path="src/Production/EnviousWispr.PostProcessing/EnviousWispr.PostProcessing.csproj" />
+    <Project Path="src/Production/EnviousWispr.RuntimeWorker/EnviousWispr.RuntimeWorker.csproj" />
     <Project Path="src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj" />
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/audio-uat/EnviousWispr.Audio.Uat.csproj" />
     <Project Path="tools/hotkey-uat/EnviousWispr.Hotkey.Uat.csproj" />
+    <Project Path="tools/runtime-uat/EnviousWispr.Runtime.Uat.csproj" />
   </Folder>
 </Solution>

--- a/notes/phase-five-runtime.md
+++ b/notes/phase-five-runtime.md
@@ -1,0 +1,58 @@
+# Phase 5 hardware discovery and runtime isolation evidence
+
+Measured on the founder's Windows rig on 2026-08-26. This phase remains in progress until the supported
+hardware-class matrix and provider-failure fallback exit in `docs/plans/windows-master-plan.md` are
+satisfied.
+
+## Implemented so far
+
+- Services discovers processor architecture and vendor, physical and logical core counts, physical memory,
+  active graphics-vendor capabilities, DirectML runtime availability, and NVIDIA CUDA driver/device state.
+  The returned contract deliberately excludes adapter names, device identifiers, paths, and user content.
+- Model delivery checks the exact shared, int8, and full-precision Parakeet file sets and requires every
+  selected file to be non-empty.
+- ASR selects an explained safe default. NVIDIA with an initialized CUDA device and a complete QDQ-free
+  full-precision pack selects CUDA. Every other supported x64 case falls back to the int8 CPU pack with
+  measured thread tuning bounded to two through eight intra-op threads and one inter-op thread.
+- Manual CPU and CUDA choices pass through the same probes. DirectML is explicitly rejected for this
+  Parakeet decoder because the measured per-frame decoder path is incompatible with the phase-one latency
+  bar; it is not silently selected merely because the DLL or a candidate adapter exists.
+- A content-free, versioned JSON-line worker runs outside the app process, watches its parent, supports
+  health and graceful shutdown commands, and is supervised with startup/health timeouts, process-tree
+  teardown, bounded crash recovery, and typed retryable failure.
+- CPU and accelerator resources have separate single-owner leases. Preview, final ASR, and local polish can
+  report a typed busy result instead of oversubscribing a device.
+- `tools/runtime-uat` exercises the native probes and process/resource lifecycle without emitting hardware
+  names, identifiers, filesystem paths, model content, transcript text, or audio.
+
+## Automated evidence
+
+- The production test project passed 77 tests. Coverage includes vendor classification, partial-probe
+  behavior, complete and incomplete model packs, automatic NVIDIA CUDA selection, CPU fallback and thread
+  bounds, manual-provider rejection, DirectML incompatibility, worker start/health/stop, worker crash
+  recovery, bounded restart failure, startup timeout, and CPU/accelerator resource isolation.
+- The repository validator builds the preserved proof, production WinUI module graph, audio/hotkey/runtime
+  native harnesses, portable contract tests, and the production test suite with warnings treated as errors.
+
+## Native Windows acceptance observed
+
+- The hardware probe completed on x64 Intel with 24 physical cores, 32 logical processors, 63.7 GiB of
+  physical memory, one active NVIDIA-class adapter, DirectML available, and one initialized CUDA device.
+- Both local Parakeet packs were complete. Automatic selection chose CUDA, the QDQ-free full-precision pack,
+  one intra-op thread, and one inter-op thread with reason `NvidiaCudaWithQdqFreeModel`.
+- The isolated worker started and answered health, was forcibly terminated, restarted under the bounded
+  recovery policy with a new process identifier, and stopped without leaving its replacement alive.
+- A deliberately delayed worker missed its 100 ms startup deadline, returned a typed fault, and was torn
+  down. No worker process remained attached to that failed start.
+- A live-preview accelerator lease blocked final ASR during a bounded wait. Releasing preview immediately
+  allowed final ASR to acquire the same resource.
+
+## Required evidence still missing
+
+- Native discovery and explained defaults remain unobserved on AMD DirectML, Intel DirectML, integrated-only,
+  CPU-only, ARM64, and NPU-equipped machines. The current product policy supports x64; ARM64 is detected and
+  rejected explicitly rather than assumed compatible.
+- A real ONNX Runtime provider initialization or inference failure is not yet wired to preserve audio and
+  retry final ASR on the CPU fallback. Phase 6 owns the concrete Parakeet engine needed to close that path.
+- Resource arbitration is proven at the contract/process level, but production ASR and local-polish workers
+  do not consume these leases yet.

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -76,6 +76,9 @@ try {
     Write-Host "Building native hotkey UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/hotkey-uat/EnviousWispr.Hotkey.Uat.csproj", "-c", "Release", "--nologo")
 
+    Write-Host "Building native runtime UAT harness (Release)..."
+    Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/runtime-uat/EnviousWispr.Runtime.Uat.csproj", "-c", "Release", "--nologo")
+
     if ($IncludeLocalRuntime) {
         Write-Host "Running contract and local model runtime tests..."
         Invoke-DotNet -Executable $dotnet8Exe -Arguments @("test", "src/EnviousWispr.Tests/EnviousWispr.Tests.csproj", "-c", "Release", "--nologo")

--- a/src/Production/EnviousWispr.ASR/ParakeetRuntimeSelector.cs
+++ b/src/Production/EnviousWispr.ASR/ParakeetRuntimeSelector.cs
@@ -1,0 +1,138 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.ASR;
+
+public static class ParakeetRuntimeSelector
+{
+    public static RuntimeSelection Select(
+        HardwareSnapshot hardware,
+        ParakeetModelInventory models,
+        RuntimeProviderPreference preference = RuntimeProviderPreference.Automatic)
+    {
+        ArgumentNullException.ThrowIfNull(hardware);
+        ArgumentNullException.ThrowIfNull(models);
+
+        if (hardware.Architecture != ProcessorArchitectureKind.X64)
+        {
+            return Failure(
+                RuntimeSelectionReason.UnsupportedProcessorArchitecture,
+                AppErrorCode.RuntimeProviderUnavailable);
+        }
+
+        return preference switch
+        {
+            RuntimeProviderPreference.Automatic => SelectAutomatic(hardware, models),
+            RuntimeProviderPreference.Cpu => SelectCpu(hardware, models, manual: true),
+            RuntimeProviderPreference.Cuda => SelectCuda(hardware, models, manual: true),
+            RuntimeProviderPreference.DirectMl => Failure(
+                RuntimeSelectionReason.DirectMlIncompatibleWithParakeetDecoder,
+                AppErrorCode.RuntimeProviderIncompatible),
+            _ => Failure(
+                RuntimeSelectionReason.RequestedProviderUnavailable,
+                AppErrorCode.RuntimeProviderUnavailable),
+        };
+    }
+
+    public static int ChooseCpuIntraOpThreads(HardwareSnapshot hardware)
+    {
+        ArgumentNullException.ThrowIfNull(hardware);
+        var physicalCores = hardware.PhysicalCoreCount > 0
+            ? hardware.PhysicalCoreCount
+            : Math.Max(1, hardware.LogicalProcessorCount / 2);
+        return Math.Clamp(physicalCores / 2, 2, 8);
+    }
+
+    private static RuntimeSelection SelectAutomatic(
+        HardwareSnapshot hardware,
+        ParakeetModelInventory models)
+    {
+        if (hardware.Cuda.IsDriverAvailable &&
+            hardware.Cuda.DeviceCount > 0 &&
+            hardware.HasActiveAdapter(GraphicsVendor.Nvidia) &&
+            models.Fp32Complete)
+        {
+            return Success(
+                RuntimeProviderKind.Cuda,
+                ParakeetModelPack.FullPrecision,
+                intraOpThreads: 1,
+                RuntimeSelectionReason.NvidiaCudaWithQdqFreeModel);
+        }
+
+        return SelectCpu(hardware, models, manual: false);
+    }
+
+    private static RuntimeSelection SelectCpu(
+        HardwareSnapshot hardware,
+        ParakeetModelInventory models,
+        bool manual)
+    {
+        if (!models.Int8Complete)
+        {
+            return Failure(
+                RuntimeSelectionReason.RequiredModelPackMissing,
+                AppErrorCode.ModelPackUnavailable);
+        }
+
+        return Success(
+            RuntimeProviderKind.Cpu,
+            ParakeetModelPack.Quantized,
+            ChooseCpuIntraOpThreads(hardware),
+            manual
+                ? RuntimeSelectionReason.ManualProviderAccepted
+                : RuntimeSelectionReason.TunedCpuUniversalFallback);
+    }
+
+    private static RuntimeSelection SelectCuda(
+        HardwareSnapshot hardware,
+        ParakeetModelInventory models,
+        bool manual)
+    {
+        if (!hardware.Cuda.IsDriverAvailable ||
+            hardware.Cuda.DeviceCount == 0 ||
+            !hardware.HasActiveAdapter(GraphicsVendor.Nvidia))
+        {
+            return Failure(
+                RuntimeSelectionReason.RequestedProviderUnavailable,
+                AppErrorCode.RuntimeProviderUnavailable);
+        }
+
+        if (!models.Fp32Complete)
+        {
+            return Failure(
+                RuntimeSelectionReason.RequiredModelPackMissing,
+                AppErrorCode.ModelPackUnavailable);
+        }
+
+        return Success(
+            RuntimeProviderKind.Cuda,
+            ParakeetModelPack.FullPrecision,
+            intraOpThreads: 1,
+            manual
+                ? RuntimeSelectionReason.ManualProviderAccepted
+                : RuntimeSelectionReason.NvidiaCudaWithQdqFreeModel);
+    }
+
+    private static RuntimeSelection Success(
+        RuntimeProviderKind provider,
+        ParakeetModelPack modelPack,
+        int intraOpThreads,
+        RuntimeSelectionReason reason) => new(
+        Succeeded: true,
+        provider,
+        modelPack,
+        intraOpThreads,
+        InterOpThreads: 1,
+        reason);
+
+    private static RuntimeSelection Failure(
+        RuntimeSelectionReason reason,
+        AppErrorCode errorCode) => new(
+        Succeeded: false,
+        Provider: null,
+        ModelPack: null,
+        IntraOpThreads: 0,
+        InterOpThreads: 0,
+        reason,
+        new AppError(errorCode, AppErrorStage.RuntimeSelection, CanRetry: true));
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/EnviousWispr.Architecture.Tests.csproj
+++ b/src/Production/EnviousWispr.Architecture.Tests/EnviousWispr.Architecture.Tests.csproj
@@ -15,8 +15,18 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <ProjectReference Include="..\EnviousWispr.ASR\EnviousWispr.ASR.csproj" />
     <ProjectReference Include="..\EnviousWispr.Audio\EnviousWispr.Audio.csproj" />
+    <ProjectReference Include="..\EnviousWispr.ModelDelivery\EnviousWispr.ModelDelivery.csproj" />
     <ProjectReference Include="..\EnviousWispr.Pipeline\EnviousWispr.Pipeline.csproj" />
+    <ProjectReference Include="..\EnviousWispr.RuntimeWorker\EnviousWispr.RuntimeWorker.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\EnviousWispr.Services\EnviousWispr.Services.csproj" />
   </ItemGroup>
+
+  <Target Name="CopyRuntimeWorkerForTests" AfterTargets="Build">
+    <ItemGroup>
+      <RuntimeWorkerFiles Include="..\EnviousWispr.RuntimeWorker\bin\$(Configuration)\net10.0-windows10.0.26100.0\EnviousWispr.RuntimeWorker*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RuntimeWorkerFiles)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/src/Production/EnviousWispr.Architecture.Tests/HardwareDiscoveryTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/HardwareDiscoveryTests.cs
@@ -1,0 +1,45 @@
+using EnviousWispr.Core.Runtime;
+using EnviousWispr.Services.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class HardwareDiscoveryTests
+{
+    [Fact]
+    public async Task RealProbeReturnsContentFreeConsistentCapabilities()
+    {
+        var discovery = new WindowsHardwareDiscovery();
+
+        var result = await discovery.ProbeAsync();
+
+        Assert.NotEqual(ProcessorArchitectureKind.Unknown, result.Architecture);
+        Assert.True(result.PhysicalCoreCount > 0);
+        Assert.True(result.LogicalProcessorCount >= result.PhysicalCoreCount);
+        Assert.True(result.TotalPhysicalMemoryBytes > 0);
+        Assert.All(result.GraphicsAdapters, adapter =>
+        {
+            Assert.True(Enum.IsDefined(adapter.Vendor));
+            Assert.Equal(
+                adapter.IsActive && adapter.Vendor != GraphicsVendor.Unknown,
+                adapter.IsDirectMlCandidate);
+        });
+        Assert.True(result.Cuda.DeviceCount >= 0);
+        Assert.Equal(result.Cuda.DeviceCount > 0, result.Cuda.IsDriverAvailable);
+    }
+
+    [Fact]
+    public void HardwareContractsCannotHoldDeviceNamesIdentifiersOrPaths()
+    {
+        var propertyNames = typeof(HardwareSnapshot).GetProperties()
+            .Concat(typeof(GraphicsAdapterCapability).GetProperties())
+            .Select(property => property.Name)
+            .ToArray();
+
+        Assert.DoesNotContain(propertyNames, name =>
+            name.Contains("name", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("identifier", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("deviceId", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("path", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("serial", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/LocalParakeetModelProbeTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/LocalParakeetModelProbeTests.cs
@@ -1,0 +1,41 @@
+using EnviousWispr.ModelDelivery;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class LocalParakeetModelProbeTests
+{
+    [Fact]
+    public async Task ProbeRequiresEveryNonEmptyFileForEachPack()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"enviouswispr-model-probe-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            await WriteFilesAsync(directory,
+                "nemo128.onnx",
+                "vocab.txt",
+                "encoder-model.int8.onnx",
+                "decoder_joint-model.int8.onnx",
+                "encoder-model.onnx",
+                "encoder-model.onnx.data");
+            await File.WriteAllBytesAsync(Path.Combine(directory, "decoder_joint-model.onnx"), []);
+
+            var result = new LocalParakeetModelProbe().Probe(directory);
+
+            Assert.True(result.Int8Complete);
+            Assert.False(result.Fp32Complete);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static async Task WriteFilesAsync(string directory, params string[] fileNames)
+    {
+        foreach (var fileName in fileNames)
+        {
+            await File.WriteAllBytesAsync(Path.Combine(directory, fileName), [1]);
+        }
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/ParakeetRuntimeSelectorTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/ParakeetRuntimeSelectorTests.cs
@@ -1,0 +1,111 @@
+using EnviousWispr.ASR;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class ParakeetRuntimeSelectorTests
+{
+    [Fact]
+    public void AutomaticSelectsCudaOnlyWithNvidiaDriverAndQdqFreePack()
+    {
+        var result = ParakeetRuntimeSelector.Select(
+            Snapshot(cuda: true, GraphicsVendor.Nvidia),
+            new ParakeetModelInventory(Int8Complete: true, Fp32Complete: true));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(RuntimeProviderKind.Cuda, result.Provider);
+        Assert.Equal(ParakeetModelPack.FullPrecision, result.ModelPack);
+        Assert.Equal(RuntimeSelectionReason.NvidiaCudaWithQdqFreeModel, result.Reason);
+        Assert.Equal(1, result.IntraOpThreads);
+    }
+
+    [Fact]
+    public void AutomaticFallsBackToTunedCpuWhenQdqFreePackIsMissing()
+    {
+        var result = ParakeetRuntimeSelector.Select(
+            Snapshot(cuda: true, GraphicsVendor.Nvidia),
+            new ParakeetModelInventory(Int8Complete: true, Fp32Complete: false));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(RuntimeProviderKind.Cpu, result.Provider);
+        Assert.Equal(ParakeetModelPack.Quantized, result.ModelPack);
+        Assert.Equal(RuntimeSelectionReason.TunedCpuUniversalFallback, result.Reason);
+        Assert.Equal(8, result.IntraOpThreads);
+        Assert.Equal(1, result.InterOpThreads);
+    }
+
+    [Fact]
+    public void ManualCudaRejectsMissingQdqFreeModelInsteadOfUsingSlowQdqGraph()
+    {
+        var result = ParakeetRuntimeSelector.Select(
+            Snapshot(cuda: true, GraphicsVendor.Nvidia),
+            new ParakeetModelInventory(Int8Complete: true, Fp32Complete: false),
+            RuntimeProviderPreference.Cuda);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(RuntimeSelectionReason.RequiredModelPackMissing, result.Reason);
+        Assert.Equal(AppErrorCode.ModelPackUnavailable, result.Error?.Code);
+    }
+
+    [Theory]
+    [InlineData(GraphicsVendor.Amd)]
+    [InlineData(GraphicsVendor.Intel)]
+    [InlineData(GraphicsVendor.Nvidia)]
+    public void DirectMlIsDiscoveredButRejectedForParakeetDecoder(GraphicsVendor vendor)
+    {
+        var result = ParakeetRuntimeSelector.Select(
+            Snapshot(cuda: false, vendor),
+            new ParakeetModelInventory(Int8Complete: true, Fp32Complete: true),
+            RuntimeProviderPreference.DirectMl);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(
+            RuntimeSelectionReason.DirectMlIncompatibleWithParakeetDecoder,
+            result.Reason);
+        Assert.Equal(AppErrorCode.RuntimeProviderIncompatible, result.Error?.Code);
+    }
+
+    [Theory]
+    [InlineData(4, 2)]
+    [InlineData(8, 4)]
+    [InlineData(16, 8)]
+    [InlineData(24, 8)]
+    public void CpuThreadPolicyIsBoundedByMeasuredHybridSafeRange(int physicalCores, int expected)
+    {
+        var hardware = Snapshot(cuda: false, GraphicsVendor.Intel) with
+        {
+            PhysicalCoreCount = physicalCores,
+            LogicalProcessorCount = physicalCores * 2,
+        };
+
+        Assert.Equal(expected, ParakeetRuntimeSelector.ChooseCpuIntraOpThreads(hardware));
+    }
+
+    [Fact]
+    public void UnsupportedArchitectureFailsBeforeProviderSelection()
+    {
+        var hardware = Snapshot(cuda: true, GraphicsVendor.Nvidia) with
+        {
+            Architecture = ProcessorArchitectureKind.Arm64,
+        };
+
+        var result = ParakeetRuntimeSelector.Select(
+            hardware,
+            new ParakeetModelInventory(Int8Complete: true, Fp32Complete: true));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(RuntimeSelectionReason.UnsupportedProcessorArchitecture, result.Reason);
+    }
+
+    private static HardwareSnapshot Snapshot(bool cuda, GraphicsVendor vendor) => new(
+        HardwareProbeStatus.Complete,
+        ProcessorArchitectureKind.X64,
+        ProcessorVendor.Intel,
+        PhysicalCoreCount: 24,
+        LogicalProcessorCount: 32,
+        TotalPhysicalMemoryBytes: 64UL * 1024 * 1024 * 1024,
+        GraphicsAdapters: [new GraphicsAdapterCapability(vendor, true, true)],
+        IsDirectMlRuntimeAvailable: true,
+        new CudaDriverCapability(cuda, cuda ? 1 : 0, cuda ? 13_000 : null));
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/ProjectDependencyTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/ProjectDependencyTests.cs
@@ -13,6 +13,7 @@ public sealed class ProjectDependencyTests
             ["EnviousWispr.PostProcessing"] = ["EnviousWispr.Core"],
             ["EnviousWispr.LLM"] = ["EnviousWispr.Core"],
             ["EnviousWispr.Pipeline"] = ["EnviousWispr.Core"],
+            ["EnviousWispr.RuntimeWorker"] = [],
             ["EnviousWispr.Services"] = ["EnviousWispr.Core"],
             ["EnviousWispr.ModelDelivery"] = ["EnviousWispr.Core"],
             ["EnviousWispr.App"] =
@@ -28,8 +29,11 @@ public sealed class ProjectDependencyTests
             ],
             ["EnviousWispr.Architecture.Tests"] =
             [
+                "EnviousWispr.ASR",
                 "EnviousWispr.Audio",
+                "EnviousWispr.ModelDelivery",
                 "EnviousWispr.Pipeline",
+                "EnviousWispr.RuntimeWorker",
                 "EnviousWispr.Services",
             ],
         };

--- a/src/Production/EnviousWispr.Architecture.Tests/RuntimeResourceArbiterTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/RuntimeResourceArbiterTests.cs
@@ -1,0 +1,59 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+using EnviousWispr.Services.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class RuntimeResourceArbiterTests
+{
+    [Fact]
+    public async Task FinalAsrWaitsUntilPreviewReleasesAccelerator()
+    {
+        using var arbiter = new RuntimeResourceArbiter();
+        var preview = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Accelerator,
+            RuntimeWorkloadKind.LivePreview,
+            TimeSpan.Zero);
+
+        var blockedFinal = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Accelerator,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.FromMilliseconds(20));
+        await preview.Lease!.DisposeAsync();
+        var final = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Accelerator,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.Zero);
+
+        Assert.True(preview.Succeeded);
+        Assert.False(blockedFinal.Succeeded);
+        Assert.Equal(AppErrorCode.RuntimeResourceBusy, blockedFinal.Error?.Code);
+        Assert.True(final.Succeeded);
+        Assert.Equal(
+            RuntimeWorkloadKind.FinalAsr,
+            arbiter.ActiveOwners[RuntimeResourceKind.Accelerator]);
+        await final.Lease!.DisposeAsync();
+        Assert.Empty(arbiter.ActiveOwners);
+    }
+
+    [Fact]
+    public async Task CpuAndAcceleratorHaveIndependentLeases()
+    {
+        using var arbiter = new RuntimeResourceArbiter();
+
+        var cpu = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Cpu,
+            RuntimeWorkloadKind.LocalPolish,
+            TimeSpan.Zero);
+        var accelerator = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Accelerator,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.Zero);
+
+        Assert.True(cpu.Succeeded);
+        Assert.True(accelerator.Succeeded);
+        Assert.Equal(2, arbiter.ActiveOwners.Count);
+        await cpu.Lease!.DisposeAsync();
+        await accelerator.Lease!.DisposeAsync();
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/RuntimeWorkerSupervisorTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/RuntimeWorkerSupervisorTests.cs
@@ -1,0 +1,66 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+using EnviousWispr.Services.Runtime;
+using System.Diagnostics;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class RuntimeWorkerSupervisorTests
+{
+    [Fact]
+    public async Task WorkerHandshakeCrashRecoveryAndTeardownAreIsolated()
+    {
+        var workerPath = WorkerPath();
+        var supervisor = new RuntimeWorkerSupervisor(workerPath, maximumRestarts: 1);
+
+        var started = await supervisor.StartAsync(TimeSpan.FromSeconds(2));
+        var firstProcessId = supervisor.WorkerProcessId;
+        var health = await supervisor.CheckHealthAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(firstProcessId);
+        using (var worker = Process.GetProcessById(firstProcessId.Value))
+        {
+            worker.Kill(entireProcessTree: true);
+            await worker.WaitForExitAsync();
+        }
+
+        var recovered = await supervisor.EnsureHealthyAsync(TimeSpan.FromSeconds(2));
+        var secondProcessId = supervisor.WorkerProcessId;
+        await supervisor.DisposeAsync();
+
+        Assert.True(started.Succeeded);
+        Assert.True(health.Succeeded);
+        Assert.True(recovered.Succeeded);
+        Assert.NotNull(secondProcessId);
+        Assert.NotEqual(firstProcessId, secondProcessId);
+        Assert.Equal(RuntimeWorkerState.Disposed, supervisor.State);
+        Assert.Null(supervisor.WorkerProcessId);
+        AssertProcessIsGone(secondProcessId.Value);
+    }
+
+    [Fact]
+    public async Task StartupTimeoutKillsWedgedWorkerAndReturnsTypedFailure()
+    {
+        var supervisor = new RuntimeWorkerSupervisor(
+            WorkerPath(),
+            ["--health-delay-ms", "1000"],
+            maximumRestarts: 0);
+
+        var result = await supervisor.StartAsync(TimeSpan.FromMilliseconds(50));
+        await supervisor.DisposeAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(RuntimeWorkerState.Faulted, result.State);
+        Assert.Equal(AppErrorCode.RuntimeWorkerFailed, result.Error?.Code);
+        Assert.Null(supervisor.WorkerProcessId);
+    }
+
+    private static string WorkerPath()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "EnviousWispr.RuntimeWorker.exe");
+        Assert.True(File.Exists(path), $"Worker apphost missing: {path}");
+        return path;
+    }
+
+    private static void AssertProcessIsGone(int processId) =>
+        Assert.Throws<ArgumentException>(() => Process.GetProcessById(processId));
+}

--- a/src/Production/EnviousWispr.Core/Errors/AppError.cs
+++ b/src/Production/EnviousWispr.Core/Errors/AppError.cs
@@ -16,6 +16,12 @@ public enum AppErrorCode
     HotkeyConflict,
     HotkeyUnavailable,
     TargetUnavailable,
+    HardwareProbeFailed,
+    RuntimeProviderUnavailable,
+    RuntimeProviderIncompatible,
+    ModelPackUnavailable,
+    RuntimeWorkerFailed,
+    RuntimeResourceBusy,
 }
 
 public enum AppErrorStage
@@ -31,6 +37,10 @@ public enum AppErrorStage
     HotkeyConfiguration,
     HotkeyHook,
     TargetCapture,
+    HardwareDiscovery,
+    RuntimeSelection,
+    RuntimeWorker,
+    RuntimeResource,
 }
 
 public sealed record AppError(AppErrorCode Code, AppErrorStage Stage, bool CanRetry);

--- a/src/Production/EnviousWispr.Core/Runtime/HardwareContracts.cs
+++ b/src/Production/EnviousWispr.Core/Runtime/HardwareContracts.cs
@@ -1,0 +1,116 @@
+using EnviousWispr.Core.Errors;
+
+namespace EnviousWispr.Core.Runtime;
+
+public enum ProcessorArchitectureKind
+{
+    Unknown,
+    X64,
+    Arm64,
+}
+
+public enum ProcessorVendor
+{
+    Unknown,
+    Intel,
+    Amd,
+    Qualcomm,
+}
+
+public enum GraphicsVendor
+{
+    Unknown,
+    Nvidia,
+    Amd,
+    Intel,
+}
+
+public enum HardwareProbeStatus
+{
+    Complete,
+    Partial,
+}
+
+public sealed record GraphicsAdapterCapability(
+    GraphicsVendor Vendor,
+    bool IsActive,
+    bool IsDirectMlCandidate);
+
+public sealed record CudaDriverCapability(
+    bool IsDriverAvailable,
+    int DeviceCount,
+    int? DriverVersion);
+
+public sealed record HardwareSnapshot(
+    HardwareProbeStatus Status,
+    ProcessorArchitectureKind Architecture,
+    ProcessorVendor ProcessorVendor,
+    int PhysicalCoreCount,
+    int LogicalProcessorCount,
+    ulong TotalPhysicalMemoryBytes,
+    IReadOnlyList<GraphicsAdapterCapability> GraphicsAdapters,
+    bool IsDirectMlRuntimeAvailable,
+    CudaDriverCapability Cuda,
+    AppError? Error = null)
+{
+    public bool HasActiveAdapter(GraphicsVendor vendor) =>
+        GraphicsAdapters.Any(adapter => adapter.IsActive && adapter.Vendor == vendor);
+
+    public bool HasDirectMlCandidate(GraphicsVendor vendor) =>
+        IsDirectMlRuntimeAvailable &&
+        GraphicsAdapters.Any(adapter =>
+            adapter.IsActive && adapter.IsDirectMlCandidate && adapter.Vendor == vendor);
+}
+
+public interface IHardwareDiscovery
+{
+    Task<HardwareSnapshot> ProbeAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record ParakeetModelInventory(bool Int8Complete, bool Fp32Complete);
+
+public interface IParakeetModelProbe
+{
+    ParakeetModelInventory Probe(string modelDirectory);
+}
+
+public enum RuntimeProviderPreference
+{
+    Automatic,
+    Cpu,
+    Cuda,
+    DirectMl,
+}
+
+public enum RuntimeProviderKind
+{
+    Cpu,
+    Cuda,
+    DirectMl,
+}
+
+public enum ParakeetModelPack
+{
+    Quantized,
+    FullPrecision,
+}
+
+public enum RuntimeSelectionReason
+{
+    NvidiaCudaWithQdqFreeModel,
+    TunedCpuUniversalFallback,
+    ManualProviderAccepted,
+    RequestedProviderUnavailable,
+    RequiredModelPackMissing,
+    DirectMlIncompatibleWithParakeetDecoder,
+    UnsupportedProcessorArchitecture,
+}
+
+public sealed record RuntimeSelection(
+    bool Succeeded,
+    RuntimeProviderKind? Provider,
+    ParakeetModelPack? ModelPack,
+    int IntraOpThreads,
+    int InterOpThreads,
+    RuntimeSelectionReason Reason,
+    AppError? Error = null);

--- a/src/Production/EnviousWispr.Core/Runtime/RuntimeWorkerContracts.cs
+++ b/src/Production/EnviousWispr.Core/Runtime/RuntimeWorkerContracts.cs
@@ -1,0 +1,56 @@
+using EnviousWispr.Core.Errors;
+
+namespace EnviousWispr.Core.Runtime;
+
+public enum RuntimeWorkerState
+{
+    Stopped,
+    Starting,
+    Ready,
+    Faulted,
+    Disposed,
+}
+
+public sealed record RuntimeWorkerResult(
+    bool Succeeded,
+    RuntimeWorkerState State,
+    AppError? Error = null);
+
+public interface IRuntimeWorkerSupervisor : IAsyncDisposable
+{
+    RuntimeWorkerState State { get; }
+
+    int? WorkerProcessId { get; }
+
+    Task<RuntimeWorkerResult> StartAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+
+    Task<RuntimeWorkerResult> CheckHealthAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+
+    Task<RuntimeWorkerResult> EnsureHealthyAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+
+    Task<RuntimeWorkerResult> StopAsync(CancellationToken cancellationToken = default);
+}
+
+public enum RuntimeResourceKind
+{
+    Cpu,
+    Accelerator,
+}
+
+public enum RuntimeWorkloadKind
+{
+    LivePreview,
+    FinalAsr,
+    LocalPolish,
+}
+
+public sealed record RuntimeResourceAcquireResult(
+    bool Succeeded,
+    IAsyncDisposable? Lease = null,
+    AppError? Error = null);

--- a/src/Production/EnviousWispr.ModelDelivery/LocalParakeetModelProbe.cs
+++ b/src/Production/EnviousWispr.ModelDelivery/LocalParakeetModelProbe.cs
@@ -1,0 +1,29 @@
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.ModelDelivery;
+
+public sealed class LocalParakeetModelProbe : IParakeetModelProbe
+{
+    private static readonly string[] SharedFiles = ["nemo128.onnx", "vocab.txt"];
+    private static readonly string[] Int8Files =
+        ["encoder-model.int8.onnx", "decoder_joint-model.int8.onnx"];
+    private static readonly string[] Fp32Files =
+        ["encoder-model.onnx", "encoder-model.onnx.data", "decoder_joint-model.onnx"];
+
+    public ParakeetModelInventory Probe(string modelDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(modelDirectory);
+        var directory = Path.GetFullPath(modelDirectory);
+        var sharedComplete = AllNonEmpty(directory, SharedFiles);
+        return new ParakeetModelInventory(
+            Int8Complete: sharedComplete && AllNonEmpty(directory, Int8Files),
+            Fp32Complete: sharedComplete && AllNonEmpty(directory, Fp32Files));
+    }
+
+    private static bool AllNonEmpty(string directory, IEnumerable<string> fileNames) =>
+        fileNames.All(fileName =>
+        {
+            var path = Path.Combine(directory, fileName);
+            return File.Exists(path) && new FileInfo(path).Length > 0;
+        });
+}

--- a/src/Production/EnviousWispr.RuntimeWorker/EnviousWispr.RuntimeWorker.csproj
+++ b/src/Production/EnviousWispr.RuntimeWorker/EnviousWispr.RuntimeWorker.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>EnviousWispr.RuntimeWorker</AssemblyName>
+    <RootNamespace>EnviousWispr.RuntimeWorker</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/src/Production/EnviousWispr.RuntimeWorker/Program.cs
+++ b/src/Production/EnviousWispr.RuntimeWorker/Program.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+
+const int ProtocolVersion = 1;
+
+var parentProcessId = ReadIntegerArgument(args, "--parent-pid");
+var healthDelayMilliseconds = ReadIntegerArgument(args, "--health-delay-ms", defaultValue: 0);
+if (parentProcessId <= 0 || healthDelayMilliseconds < 0)
+{
+    return 2;
+}
+
+Process parent;
+try
+{
+    parent = Process.GetProcessById(parentProcessId);
+}
+catch (ArgumentException)
+{
+    return 3;
+}
+
+using (parent)
+{
+    parent.EnableRaisingEvents = true;
+    parent.Exited += (_, _) => Environment.Exit(24);
+
+    while (await Console.In.ReadLineAsync() is { } line)
+    {
+        RuntimeWorkerRequest? request;
+        try
+        {
+            request = JsonSerializer.Deserialize<RuntimeWorkerRequest>(line);
+        }
+        catch (JsonException)
+        {
+            await WriteResponseAsync(new RuntimeWorkerResponse(
+                ProtocolVersion,
+                RequestId: Guid.Empty,
+                Status: "invalid"));
+            continue;
+        }
+
+        if (request is null ||
+            request.ProtocolVersion != ProtocolVersion ||
+            request.RequestId == Guid.Empty)
+        {
+            await WriteResponseAsync(new RuntimeWorkerResponse(
+                ProtocolVersion,
+                request?.RequestId ?? Guid.Empty,
+                Status: "invalid"));
+            continue;
+        }
+
+        if (string.Equals(request.Command, "health", StringComparison.Ordinal))
+        {
+            if (healthDelayMilliseconds > 0)
+            {
+                await Task.Delay(healthDelayMilliseconds);
+            }
+
+            await WriteResponseAsync(new RuntimeWorkerResponse(
+                ProtocolVersion,
+                request.RequestId,
+                Status: "ready"));
+            continue;
+        }
+
+        if (string.Equals(request.Command, "shutdown", StringComparison.Ordinal))
+        {
+            await WriteResponseAsync(new RuntimeWorkerResponse(
+                ProtocolVersion,
+                request.RequestId,
+                Status: "stopping"));
+            return 0;
+        }
+
+        await WriteResponseAsync(new RuntimeWorkerResponse(
+            ProtocolVersion,
+            request.RequestId,
+            Status: "unsupported"));
+    }
+}
+
+return 0;
+
+static int ReadIntegerArgument(string[] arguments, string name, int defaultValue = -1)
+{
+    var index = Array.IndexOf(arguments, name);
+    return index >= 0 && index + 1 < arguments.Length &&
+        int.TryParse(
+            arguments[index + 1],
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out var value)
+        ? value
+        : defaultValue;
+}
+
+static async Task WriteResponseAsync(RuntimeWorkerResponse response)
+{
+    await Console.Out.WriteLineAsync(JsonSerializer.Serialize(response));
+    await Console.Out.FlushAsync();
+}
+
+internal sealed record RuntimeWorkerRequest(int ProtocolVersion, Guid RequestId, string Command);
+
+internal sealed record RuntimeWorkerResponse(int ProtocolVersion, Guid RequestId, string Status);

--- a/src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj
+++ b/src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj
@@ -6,4 +6,8 @@
   <ItemGroup>
     <ProjectReference Include="..\EnviousWispr.Core\EnviousWispr.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Management" Version="10.0.11" />
+  </ItemGroup>
 </Project>

--- a/src/Production/EnviousWispr.Services/Runtime/RuntimeResourceArbiter.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/RuntimeResourceArbiter.cs
@@ -1,0 +1,101 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Services.Runtime;
+
+public sealed class RuntimeResourceArbiter : IDisposable
+{
+    private readonly SemaphoreSlim _cpu = new(1, 1);
+    private readonly SemaphoreSlim _accelerator = new(1, 1);
+    private readonly object _gate = new();
+    private readonly Dictionary<RuntimeResourceKind, RuntimeWorkloadKind> _owners = [];
+    private bool _disposed;
+
+    public IReadOnlyDictionary<RuntimeResourceKind, RuntimeWorkloadKind> ActiveOwners
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return new Dictionary<RuntimeResourceKind, RuntimeWorkloadKind>(_owners);
+            }
+        }
+    }
+
+    public async Task<RuntimeResourceAcquireResult> AcquireAsync(
+        RuntimeResourceKind resource,
+        RuntimeWorkloadKind workload,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentOutOfRangeException.ThrowIfLessThan(timeout, TimeSpan.Zero);
+        var semaphore = SemaphoreFor(resource);
+        if (!await semaphore.WaitAsync(timeout, cancellationToken).ConfigureAwait(false))
+        {
+            return new RuntimeResourceAcquireResult(
+                Succeeded: false,
+                Error: new AppError(
+                    AppErrorCode.RuntimeResourceBusy,
+                    AppErrorStage.RuntimeResource,
+                    CanRetry: true));
+        }
+
+        lock (_gate)
+        {
+            _owners[resource] = workload;
+        }
+
+        return new RuntimeResourceAcquireResult(
+            Succeeded: true,
+            new ResourceLease(this, semaphore, resource));
+    }
+
+    private SemaphoreSlim SemaphoreFor(RuntimeResourceKind resource) => resource switch
+    {
+        RuntimeResourceKind.Cpu => _cpu,
+        RuntimeResourceKind.Accelerator => _accelerator,
+        _ => throw new ArgumentOutOfRangeException(nameof(resource)),
+    };
+
+    private void Release(SemaphoreSlim semaphore, RuntimeResourceKind resource)
+    {
+        lock (_gate)
+        {
+            _owners.Remove(resource);
+        }
+
+        semaphore.Release();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _cpu.Dispose();
+        _accelerator.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class ResourceLease(
+        RuntimeResourceArbiter owner,
+        SemaphoreSlim semaphore,
+        RuntimeResourceKind resource) : IAsyncDisposable
+    {
+        private int _released;
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                owner.Release(semaphore, resource);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerSupervisor.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerSupervisor.cs
@@ -1,0 +1,373 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace EnviousWispr.Services.Runtime;
+
+public sealed class RuntimeWorkerSupervisor : IRuntimeWorkerSupervisor
+{
+    private const int ProtocolVersion = 1;
+
+    private readonly string _workerExecutable;
+    private readonly string[] _workerArguments;
+    private readonly int _maximumRestarts;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private Process? _process;
+    private Task<string>? _stderrDrain;
+    private int _restartCount;
+    private bool _disposed;
+
+    public RuntimeWorkerSupervisor(
+        string workerExecutable,
+        IEnumerable<string>? workerArguments = null,
+        int maximumRestarts = 1)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workerExecutable);
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumRestarts);
+        _workerExecutable = Path.GetFullPath(workerExecutable);
+        _workerArguments = workerArguments?.ToArray() ?? [];
+        _maximumRestarts = maximumRestarts;
+    }
+
+    public RuntimeWorkerState State { get; private set; } = RuntimeWorkerState.Stopped;
+
+    public int? WorkerProcessId => _process is { HasExited: false } process ? process.Id : null;
+
+    public async Task<RuntimeWorkerResult> StartAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateTimeout(timeout);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_process is { HasExited: false } && State == RuntimeWorkerState.Ready)
+            {
+                return Success(RuntimeWorkerState.Ready);
+            }
+
+            _restartCount = 0;
+            return await StartCoreAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<RuntimeWorkerResult> CheckHealthAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateTimeout(timeout);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return await CheckHealthCoreAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<RuntimeWorkerResult> EnsureHealthyAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateTimeout(timeout);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            var health = await CheckHealthCoreAsync(timeout, cancellationToken).ConfigureAwait(false);
+            if (health.Succeeded)
+            {
+                return health;
+            }
+
+            if (_restartCount >= _maximumRestarts)
+            {
+                return Failure();
+            }
+
+            _restartCount++;
+            return await StartCoreAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<RuntimeWorkerResult> StopAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_disposed)
+            {
+                return Success(RuntimeWorkerState.Disposed);
+            }
+
+            await StopCoreAsync().ConfigureAwait(false);
+            State = RuntimeWorkerState.Stopped;
+            return Success(State);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            await StopCoreAsync().ConfigureAwait(false);
+            _disposed = true;
+            State = RuntimeWorkerState.Disposed;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        _gate.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<RuntimeWorkerResult> StartCoreAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        await StopCoreAsync().ConfigureAwait(false);
+        State = RuntimeWorkerState.Starting;
+        if (!File.Exists(_workerExecutable))
+        {
+            State = RuntimeWorkerState.Faulted;
+            return Failure();
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = _workerExecutable,
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("--parent-pid");
+        startInfo.ArgumentList.Add(Environment.ProcessId.ToString(
+            System.Globalization.CultureInfo.InvariantCulture));
+        foreach (var argument in _workerArguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        var process = new Process { StartInfo = startInfo };
+        try
+        {
+            if (!process.Start())
+            {
+                process.Dispose();
+                State = RuntimeWorkerState.Faulted;
+                return Failure();
+            }
+
+            _process = process;
+            _stderrDrain = process.StandardError.ReadToEndAsync(CancellationToken.None);
+            var health = await SendRequestAsync("health", timeout, cancellationToken)
+                .ConfigureAwait(false);
+            if (!health.Succeeded)
+            {
+                await StopCoreAsync().ConfigureAwait(false);
+                State = RuntimeWorkerState.Faulted;
+                return Failure();
+            }
+
+            State = RuntimeWorkerState.Ready;
+            return Success(State);
+        }
+        catch (Exception exception) when (
+            exception is Win32Exception or IOException or InvalidOperationException)
+        {
+            await StopCoreAsync().ConfigureAwait(false);
+            State = RuntimeWorkerState.Faulted;
+            return Failure();
+        }
+    }
+
+    private async Task<RuntimeWorkerResult> CheckHealthCoreAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        if (_process is null || _process.HasExited || State is not RuntimeWorkerState.Ready)
+        {
+            State = RuntimeWorkerState.Faulted;
+            return Failure();
+        }
+
+        var result = await SendRequestAsync("health", timeout, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded)
+        {
+            await StopCoreAsync().ConfigureAwait(false);
+            State = RuntimeWorkerState.Faulted;
+            return Failure();
+        }
+
+        State = RuntimeWorkerState.Ready;
+        return Success(State);
+    }
+
+    private async Task<RuntimeWorkerResult> SendRequestAsync(
+        string command,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var process = _process;
+        if (process is null || process.HasExited)
+        {
+            return Failure();
+        }
+
+        var requestId = Guid.NewGuid();
+        var request = new RuntimeWorkerRequest(ProtocolVersion, requestId, command);
+        try
+        {
+            await process.StandardInput.WriteLineAsync(JsonSerializer.Serialize(request))
+                .ConfigureAwait(false);
+            await process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
+            var line = await process.StandardOutput.ReadLineAsync(cancellationToken)
+                .AsTask()
+                .WaitAsync(timeout, cancellationToken)
+                .ConfigureAwait(false);
+            if (line is null)
+            {
+                return Failure();
+            }
+
+            var response = JsonSerializer.Deserialize<RuntimeWorkerResponse>(line);
+            var expectedStatus = command == "shutdown" ? "stopping" : "ready";
+            return response is not null &&
+                response.ProtocolVersion == ProtocolVersion &&
+                response.RequestId == requestId &&
+                string.Equals(response.Status, expectedStatus, StringComparison.Ordinal)
+                ? Success(State)
+                : Failure();
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return Failure();
+        }
+        catch (Exception exception) when (
+            exception is IOException or InvalidOperationException or JsonException or TimeoutException)
+        {
+            return Failure();
+        }
+    }
+
+    private async Task StopCoreAsync()
+    {
+        var process = Interlocked.Exchange(ref _process, null);
+        if (process is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!process.HasExited)
+            {
+                await TryRequestShutdownAsync(process).ConfigureAwait(false);
+            }
+
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            await process.WaitForExitAsync(CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(2), CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or Win32Exception or TimeoutException)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        finally
+        {
+            process.Dispose();
+            if (_stderrDrain is not null)
+            {
+                try
+                {
+                    await _stderrDrain.WaitAsync(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (
+                    exception is IOException or OperationCanceledException or TimeoutException)
+                {
+                    // Stderr is intentionally discarded and cannot block teardown.
+                }
+
+                _stderrDrain = null;
+            }
+        }
+    }
+
+    private static async Task TryRequestShutdownAsync(Process process)
+    {
+        var request = new RuntimeWorkerRequest(ProtocolVersion, Guid.NewGuid(), "shutdown");
+        try
+        {
+            await process.StandardInput.WriteLineAsync(JsonSerializer.Serialize(request))
+                .ConfigureAwait(false);
+            await process.StandardInput.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+            await process.WaitForExitAsync(CancellationToken.None)
+                .WaitAsync(TimeSpan.FromMilliseconds(500), CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (
+            exception is IOException or InvalidOperationException or TimeoutException)
+        {
+            // The worker is already gone or wedged; process-tree kill is the fallback.
+        }
+    }
+
+    private static void ValidateTimeout(TimeSpan timeout) =>
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
+    private static RuntimeWorkerResult Success(RuntimeWorkerState state) => new(true, state);
+
+    private static RuntimeWorkerResult Failure() => new(
+        Succeeded: false,
+        RuntimeWorkerState.Faulted,
+        new AppError(
+            AppErrorCode.RuntimeWorkerFailed,
+            AppErrorStage.RuntimeWorker,
+            CanRetry: true));
+
+    private sealed record RuntimeWorkerRequest(int ProtocolVersion, Guid RequestId, string Command);
+
+    private sealed record RuntimeWorkerResponse(int ProtocolVersion, Guid RequestId, string Status);
+}

--- a/src/Production/EnviousWispr.Services/Runtime/WindowsHardwareDiscovery.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/WindowsHardwareDiscovery.cs
@@ -1,0 +1,249 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+using System.Management;
+using System.Runtime.InteropServices;
+
+namespace EnviousWispr.Services.Runtime;
+
+public sealed class WindowsHardwareDiscovery : IHardwareDiscovery
+{
+    public Task<HardwareSnapshot> ProbeAsync(CancellationToken cancellationToken = default) =>
+        Task.Run(() => Probe(cancellationToken), cancellationToken);
+
+    private static HardwareSnapshot Probe(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var status = HardwareProbeStatus.Complete;
+        var processorVendor = ProcessorVendor.Unknown;
+        var physicalCores = 0;
+        var logicalProcessors = Environment.ProcessorCount;
+        IReadOnlyList<GraphicsAdapterCapability> graphicsAdapters = [];
+
+        try
+        {
+            (processorVendor, physicalCores, logicalProcessors) = ProbeProcessors(cancellationToken);
+        }
+        catch (Exception exception) when (IsRecoverableProbeFailure(exception))
+        {
+            status = HardwareProbeStatus.Partial;
+            physicalCores = Math.Max(1, logicalProcessors / 2);
+        }
+
+        try
+        {
+            graphicsAdapters = ProbeGraphicsAdapters(cancellationToken);
+        }
+        catch (Exception exception) when (IsRecoverableProbeFailure(exception))
+        {
+            status = HardwareProbeStatus.Partial;
+        }
+
+        var memoryBytes = ProbePhysicalMemory();
+        if (memoryBytes == 0)
+        {
+            status = HardwareProbeStatus.Partial;
+        }
+
+        var directMlAvailable = ProbeNativeLibrary("DirectML.dll");
+        var cuda = ProbeCudaDriver();
+        return new HardwareSnapshot(
+            status,
+            CurrentArchitecture(),
+            processorVendor,
+            physicalCores,
+            logicalProcessors,
+            memoryBytes,
+            graphicsAdapters,
+            directMlAvailable,
+            cuda,
+            status == HardwareProbeStatus.Complete
+                ? null
+                : new AppError(
+                    AppErrorCode.HardwareProbeFailed,
+                    AppErrorStage.HardwareDiscovery,
+                    CanRetry: true));
+    }
+
+    private static (ProcessorVendor Vendor, int PhysicalCores, int LogicalProcessors) ProbeProcessors(
+        CancellationToken cancellationToken)
+    {
+        var vendor = ProcessorVendor.Unknown;
+        var physicalCores = 0;
+        var logicalProcessors = 0;
+        using var searcher = new ManagementObjectSearcher(
+            "SELECT Manufacturer, NumberOfCores, NumberOfLogicalProcessors FROM Win32_Processor");
+        using var processors = searcher.Get();
+        foreach (ManagementBaseObject processor in processors)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            vendor = MergeVendor(vendor, ClassifyProcessorVendor(processor["Manufacturer"] as string));
+            physicalCores += Convert.ToInt32(processor["NumberOfCores"],
+                System.Globalization.CultureInfo.InvariantCulture);
+            logicalProcessors += Convert.ToInt32(processor["NumberOfLogicalProcessors"],
+                System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        return (
+            vendor,
+            Math.Max(1, physicalCores),
+            Math.Max(1, logicalProcessors));
+    }
+
+    private static GraphicsAdapterCapability[] ProbeGraphicsAdapters(
+        CancellationToken cancellationToken)
+    {
+        var result = new List<GraphicsAdapterCapability>();
+        using var searcher = new ManagementObjectSearcher(
+            "SELECT AdapterCompatibility, PNPDeviceID, Status FROM Win32_VideoController");
+        using var adapters = searcher.Get();
+        foreach (ManagementBaseObject adapter in adapters)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var vendor = ClassifyGraphicsVendor(
+                adapter["AdapterCompatibility"] as string,
+                adapter["PNPDeviceID"] as string);
+            var active = string.Equals(adapter["Status"] as string, "OK", StringComparison.OrdinalIgnoreCase);
+            result.Add(new GraphicsAdapterCapability(
+                vendor,
+                active,
+                IsDirectMlCandidate: active && vendor != GraphicsVendor.Unknown));
+        }
+
+        return result.ToArray();
+    }
+
+    private static CudaDriverCapability ProbeCudaDriver()
+    {
+        if (!NativeLibrary.TryLoad("nvcuda.dll", out var library))
+        {
+            return new CudaDriverCapability(false, DeviceCount: 0, DriverVersion: null);
+        }
+
+        try
+        {
+            var initialize = Marshal.GetDelegateForFunctionPointer<CudaInitialize>(
+                NativeLibrary.GetExport(library, "cuInit"));
+            var getDeviceCount = Marshal.GetDelegateForFunctionPointer<CudaGetDeviceCount>(
+                NativeLibrary.GetExport(library, "cuDeviceGetCount"));
+            var getDriverVersion = Marshal.GetDelegateForFunctionPointer<CudaGetDriverVersion>(
+                NativeLibrary.GetExport(library, "cuDriverGetVersion"));
+
+            if (initialize(0) != 0 || getDeviceCount(out var deviceCount) != 0)
+            {
+                return new CudaDriverCapability(false, DeviceCount: 0, DriverVersion: null);
+            }
+
+            int? driverVersion = getDriverVersion(out var version) == 0 ? version : null;
+            return new CudaDriverCapability(
+                IsDriverAvailable: deviceCount > 0,
+                deviceCount,
+                driverVersion);
+        }
+        catch (Exception exception) when (exception is EntryPointNotFoundException or ArgumentException)
+        {
+            return new CudaDriverCapability(false, DeviceCount: 0, DriverVersion: null);
+        }
+        finally
+        {
+            NativeLibrary.Free(library);
+        }
+    }
+
+    private static ulong ProbePhysicalMemory()
+    {
+        var status = new MemoryStatus { Length = checked((uint)Marshal.SizeOf<MemoryStatus>()) };
+        return GlobalMemoryStatusEx(ref status) ? status.TotalPhysical : 0;
+    }
+
+    private static bool ProbeNativeLibrary(string libraryName)
+    {
+        if (!NativeLibrary.TryLoad(libraryName, out var library))
+        {
+            return false;
+        }
+
+        NativeLibrary.Free(library);
+        return true;
+    }
+
+    private static ProcessorArchitectureKind CurrentArchitecture() =>
+        RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64 => ProcessorArchitectureKind.X64,
+            Architecture.Arm64 => ProcessorArchitectureKind.Arm64,
+            _ => ProcessorArchitectureKind.Unknown,
+        };
+
+    private static ProcessorVendor ClassifyProcessorVendor(string? manufacturer)
+    {
+        if (manufacturer?.Contains("Intel", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return ProcessorVendor.Intel;
+        }
+
+        if (manufacturer?.Contains("AMD", StringComparison.OrdinalIgnoreCase) == true ||
+            manufacturer?.Contains("AuthenticAMD", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return ProcessorVendor.Amd;
+        }
+
+        return manufacturer?.Contains("Qualcomm", StringComparison.OrdinalIgnoreCase) == true
+            ? ProcessorVendor.Qualcomm
+            : ProcessorVendor.Unknown;
+    }
+
+    private static GraphicsVendor ClassifyGraphicsVendor(string? compatibility, string? pnpDeviceId)
+    {
+        var evidence = $"{compatibility} {pnpDeviceId}";
+        if (evidence.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase) ||
+            evidence.Contains("VEN_10DE", StringComparison.OrdinalIgnoreCase))
+        {
+            return GraphicsVendor.Nvidia;
+        }
+
+        if (evidence.Contains("AMD", StringComparison.OrdinalIgnoreCase) ||
+            evidence.Contains("ATI", StringComparison.OrdinalIgnoreCase) ||
+            evidence.Contains("VEN_1002", StringComparison.OrdinalIgnoreCase))
+        {
+            return GraphicsVendor.Amd;
+        }
+
+        return evidence.Contains("Intel", StringComparison.OrdinalIgnoreCase) ||
+            evidence.Contains("VEN_8086", StringComparison.OrdinalIgnoreCase)
+            ? GraphicsVendor.Intel
+            : GraphicsVendor.Unknown;
+    }
+
+    private static ProcessorVendor MergeVendor(ProcessorVendor current, ProcessorVendor next) =>
+        current == ProcessorVendor.Unknown ? next : current;
+
+    private static bool IsRecoverableProbeFailure(Exception exception) =>
+        exception is ManagementException or COMException or UnauthorizedAccessException;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MemoryStatus
+    {
+        public uint Length;
+        public uint MemoryLoad;
+        public ulong TotalPhysical;
+        public ulong AvailablePhysical;
+        public ulong TotalPageFile;
+        public ulong AvailablePageFile;
+        public ulong TotalVirtual;
+        public ulong AvailableVirtual;
+        public ulong AvailableExtendedVirtual;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate int CudaInitialize(uint flags);
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate int CudaGetDeviceCount(out int count);
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate int CudaGetDriverVersion(out int version);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GlobalMemoryStatusEx(ref MemoryStatus buffer);
+}

--- a/tools/runtime-uat/EnviousWispr.Runtime.Uat.csproj
+++ b/tools/runtime-uat/EnviousWispr.Runtime.Uat.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.ASR\EnviousWispr.ASR.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Core\EnviousWispr.Core.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.ModelDelivery\EnviousWispr.ModelDelivery.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.RuntimeWorker\EnviousWispr.RuntimeWorker.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Services\EnviousWispr.Services.csproj" />
+  </ItemGroup>
+
+  <Target Name="CopyRuntimeWorkerForUat" AfterTargets="Build">
+    <ItemGroup>
+      <RuntimeWorkerFiles Include="..\..\src\Production\EnviousWispr.RuntimeWorker\bin\$(Configuration)\net10.0-windows10.0.26100.0\EnviousWispr.RuntimeWorker*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RuntimeWorkerFiles)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/tools/runtime-uat/Program.cs
+++ b/tools/runtime-uat/Program.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using System.Text.Json;
+using EnviousWispr.ASR;
+using EnviousWispr.Core.Runtime;
+using EnviousWispr.ModelDelivery;
+using EnviousWispr.Services.Runtime;
+
+var repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+var modelDirectory = Path.Combine(repositoryRoot, "models", "parakeet-tdt-0.6b-v3");
+var workerExecutable = Path.Combine(AppContext.BaseDirectory, "EnviousWispr.RuntimeWorker.exe");
+
+var hardware = await new WindowsHardwareDiscovery().ProbeAsync();
+var models = new LocalParakeetModelProbe().Probe(modelDirectory);
+var selection = ParakeetRuntimeSelector.Select(hardware, models);
+
+var workerStarted = false;
+var workerRecovered = false;
+var workerStopped = false;
+await using (var supervisor = new RuntimeWorkerSupervisor(workerExecutable, maximumRestarts: 1))
+{
+    var start = await supervisor.StartAsync(TimeSpan.FromSeconds(2));
+    workerStarted = start.Succeeded && supervisor.WorkerProcessId is not null;
+    var originalProcessId = supervisor.WorkerProcessId;
+    if (originalProcessId is not null)
+    {
+        using var worker = Process.GetProcessById(originalProcessId.Value);
+        worker.Kill(entireProcessTree: true);
+        await worker.WaitForExitAsync();
+        var recovery = await supervisor.EnsureHealthyAsync(TimeSpan.FromSeconds(2));
+        workerRecovered = recovery.Succeeded &&
+            supervisor.WorkerProcessId is { } recoveredProcessId &&
+            recoveredProcessId != originalProcessId.Value;
+    }
+
+    var activeProcessId = supervisor.WorkerProcessId;
+    var stop = await supervisor.StopAsync();
+    workerStopped = stop.Succeeded &&
+        activeProcessId is not null &&
+        !IsProcessRunning(activeProcessId.Value);
+}
+
+var timeoutRejected = false;
+await using (var delayedSupervisor = new RuntimeWorkerSupervisor(
+    workerExecutable,
+    ["--health-delay-ms", "1000"],
+    maximumRestarts: 0))
+{
+    var delayedStart = await delayedSupervisor.StartAsync(TimeSpan.FromMilliseconds(100));
+    timeoutRejected = !delayedStart.Succeeded &&
+        delayedStart.State == RuntimeWorkerState.Faulted &&
+        delayedSupervisor.WorkerProcessId is null;
+}
+
+var previewBlocksFinal = false;
+var finalRunsAfterRelease = false;
+using (var arbiter = new RuntimeResourceArbiter())
+{
+    var preview = await arbiter.AcquireAsync(
+        RuntimeResourceKind.Accelerator,
+        RuntimeWorkloadKind.LivePreview,
+        TimeSpan.FromSeconds(1));
+    if (preview.Lease is not null)
+    {
+        var blockedFinal = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Accelerator,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.FromMilliseconds(50));
+        previewBlocksFinal = !blockedFinal.Succeeded;
+        await preview.Lease.DisposeAsync();
+        var allowedFinal = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Accelerator,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.FromSeconds(1));
+        finalRunsAfterRelease = allowedFinal.Succeeded;
+        if (allowedFinal.Lease is not null)
+        {
+            await allowedFinal.Lease.DisposeAsync();
+        }
+    }
+}
+
+var summary = new
+{
+    hardware = new
+    {
+        status = hardware.Status.ToString(),
+        architecture = hardware.Architecture.ToString(),
+        processorVendor = hardware.ProcessorVendor.ToString(),
+        physicalCores = hardware.PhysicalCoreCount,
+        logicalProcessors = hardware.LogicalProcessorCount,
+        physicalMemoryGiB = Math.Round(hardware.TotalPhysicalMemoryBytes / 1024d / 1024d / 1024d, 1),
+        graphicsVendors = hardware.GraphicsAdapters.Select(adapter => adapter.Vendor.ToString()).ToArray(),
+        directMlRuntime = hardware.IsDirectMlRuntimeAvailable,
+        cudaAvailable = hardware.Cuda.IsDriverAvailable,
+        cudaDevices = hardware.Cuda.DeviceCount,
+        cudaDriverVersion = hardware.Cuda.DriverVersion,
+    },
+    models = new
+    {
+        int8Complete = models.Int8Complete,
+        fp32Complete = models.Fp32Complete,
+    },
+    selection = new
+    {
+        succeeded = selection.Succeeded,
+        provider = selection.Provider?.ToString(),
+        modelPack = selection.ModelPack?.ToString(),
+        reason = selection.Reason.ToString(),
+        intraOpThreads = selection.IntraOpThreads,
+        interOpThreads = selection.InterOpThreads,
+    },
+    worker = new
+    {
+        started = workerStarted,
+        recoveredAfterCrash = workerRecovered,
+        stoppedCleanly = workerStopped,
+        startupTimeoutRejected = timeoutRejected,
+    },
+    resources = new
+    {
+        previewBlocksFinal,
+        finalRunsAfterRelease,
+    },
+};
+
+Console.WriteLine(JsonSerializer.Serialize(summary));
+return hardware.Status == HardwareProbeStatus.Complete &&
+    selection.Succeeded &&
+    workerStarted &&
+    workerRecovered &&
+    workerStopped &&
+    timeoutRejected &&
+    previewBlocksFinal &&
+    finalRunsAfterRelease
+    ? 0
+    : 5;
+
+static string FindRepositoryRoot(string startDirectory)
+{
+    var directory = new DirectoryInfo(startDirectory);
+    while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "CLAUDE.md")))
+    {
+        directory = directory.Parent;
+    }
+
+    return directory?.FullName ?? throw new DirectoryNotFoundException(
+        "The repository root could not be located.");
+}
+
+static bool IsProcessRunning(int processId)
+{
+    try
+    {
+        using var process = Process.GetProcessById(processId);
+        return !process.HasExited;
+    }
+    catch (ArgumentException)
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- discover CPU, memory, graphics-vendor, DirectML, CUDA, and local Parakeet model capabilities without retaining device identifiers
- select explained CPU/CUDA defaults and reject incompatible DirectML use for the measured Parakeet decoder
- isolate runtime work behind a supervised process with timeouts, bounded crash recovery, and clean process-tree teardown
- arbitrate CPU and accelerator ownership across preview, final ASR, and local polish
- add a content-free native Windows acceptance harness and Phase 5 evidence note

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/validate.ps1` (34 portable tests, 77 production tests, zero build warnings/errors)
- `dotnet run --project tools/runtime-uat/EnviousWispr.Runtime.Uat.csproj -c Release` (live discovery/selection, forced worker crash recovery, startup timeout, and resource arbitration passed)

## Phase status
Draft/in progress. Native NVIDIA CUDA hardware is observed. AMD/Intel/integrated-only/CPU-only/ARM64/NPU hardware classes and real ONNX provider-failure fallback remain unobserved; the concrete fallback path depends on the Phase 6 Parakeet engine.

Closes #12