### PR TITLE
Phase 8: add isolated multilingual live preview

### DIFF
--- a/notes/phase-eight-preview.md
+++ b/notes/phase-eight-preview.md
@@ -1,0 +1,66 @@
+# Phase 8 live-preview evidence
+
+Measured on the founder's Windows rig on 2026-08-26. This phase remains in progress because the current
+measurements cover one high-end desktop, not the target laptop matrix, and controlled spoken
+multilingual UI evidence is still missing.
+
+## Implemented so far
+
+- Live preview has its own `ILivePreviewEngine` and `LivePreviewUpdate` contract. Preview text is a
+  display-only type; it never becomes a final `Transcript` in the app, pipeline, history, diagnostics, or
+  delivery path.
+- WASAPI capture exposes a read-only, duration-bounded snapshot without consuming or mutating the final
+  capture buffer. The preview loop uses at most the latest 20 seconds and ignores snapshots shorter than
+  500 ms.
+- The preview model is multilingual `ggml-small-q5_1.bin` from `ggerganov/whisper.cpp`, revision
+  `5359861c739e955e79d9a303bcbc70fb988958b1`. The observed 190,085,487-byte file matched SHA-256
+  `ae85e4a935d7a567bd102fe55afc16bb595bdb618e11b2fc7591bc08120411bb` before use. The model remains in
+  the ignored local model directory and is not committed.
+- Preview starts only when the dedicated model is present. Its isolated worker runs at Windows
+  `BelowNormal` priority and owns a typed CPU or accelerator lease. Missing model, busy resource, startup
+  failure, or update failure disables preview without changing capture or final transcription.
+- Release and cancellation stop the preview loop, remove its exact worker, release its lease, clear the
+  display, and only then allow final ASR to begin.
+- Diagnostics contain event names, failure categories, and elapsed milliseconds only. They do not contain
+  preview text, final text, audio, model paths, or hardware identifiers.
+
+## Runtime evidence
+
+The same isolated worker and public fixtures used for Phase 7 measured the preview model after one warm-up:
+
+| Provider | 3.754 s French | 5.851 s German | 10 s English | 20 s English | 91.467 s English |
+|---|---:|---:|---:|---:|---:|
+| CPU, 8 threads | 2,139 ms | 2,129 ms | 2,278 ms | 2,487 ms | 6,921 ms |
+| NVIDIA CUDA 13 | 65 ms | 82 ms | 165 ms | 355 ms | 1,002 ms |
+
+- French and German language detection and fixture WER passed on CPU and CUDA. The existing Spanish
+  MInDS-14 fixture remained at 52.38% WER; preview is not being used to weaken the final-ASR accuracy gate.
+- Cancellation removed the exact preview worker in 585-591 ms.
+- A Release x64 WinUI run used a synthetic held F8 input with the real WASAPI microphone path. Preview
+  started 350-363 ms after recording began and produced updates at a 2.5-second cadence. CUDA update
+  inference took 57-221 ms across the observed runs.
+- During recording, the app owned two isolated workers: the final Whisper worker at `Normal` priority and
+  the preview worker at `BelowNormal` priority. On release, only the preview worker disappeared. Content-free
+  diagnostics recorded `LivePreviewStopped` 63-70 ms after capture finalization and before
+  `DictationTranscriptionStarted`; final CUDA transcription then completed in 76-254 ms.
+- Closing the WinUI shell removed both exact workers. No EnviousWispr worker remained.
+
+## Automated evidence
+
+- Tests cover bounded non-destructive audio snapshots, typed display-only updates, disabled preview,
+  resource contention, resource release before final ASR, failed startup, and cancelled startup.
+- The small-model mode is durable in `tools/whisper-uat` through `--preview-small` and emits only counts,
+  booleans, timings, language matches, and WER.
+
+## Required evidence still missing
+
+- CPU cadence is approximately 2.1-2.5 seconds on this 24-core desktop. The master-plan laptop
+  responsiveness exit is unobserved and may require a smaller model, fewer threads, a longer cadence, or
+  disabling preview on low-power hardware after measurement.
+- The native WinUI test used synthetic F8 input and ambient microphone audio. A physical key with
+  controlled spoken English and multilingual phrases, plus a visible non-empty preview assertion, remains
+  unobserved.
+- Preview enable/disable and cadence controls are not yet exposed in settings. The current safe behavior is
+  automatic enablement only when the dedicated model pack is installed.
+- AMD, Intel integrated graphics, CPU-only laptops, suspend/resume, device removal, and prolonged thermal
+  behavior remain unobserved.

--- a/src/Production/EnviousWispr.ASR/WhisperTranscriptionEngine.cs
+++ b/src/Production/EnviousWispr.ASR/WhisperTranscriptionEngine.cs
@@ -9,7 +9,8 @@ namespace EnviousWispr.ASR;
 
 public sealed class WhisperTranscriptionEngine : ITranscriptionEngine, IAsyncDisposable, IDisposable
 {
-    public const string ModelId = "whisper-large-v3-turbo";
+    public const string ModelId = WhisperModelIds.Final;
+    public const string PreviewModelId = WhisperModelIds.Preview;
     public const string NativeRuntimeVersion = "whisper.net-1.9.1-whisper.cpp-23ee035";
     public const int RequiredSampleRate = 16_000;
 
@@ -24,7 +25,7 @@ public sealed class WhisperTranscriptionEngine : ITranscriptionEngine, IAsyncDis
         Validate(options);
         Provider = options.Provider;
         ModelPack = options.ModelPack;
-        EngineId = $"{ModelId}:{Provider.ToString().ToLowerInvariant()}";
+        EngineId = $"{WhisperModelIds.For(options.ModelPack)}:{Provider.ToString().ToLowerInvariant()}";
 
         WhisperFactory? factory = null;
         try

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -24,10 +24,17 @@ public partial class App : Application, IAsyncDisposable
 
     private readonly JsonLineFileLogger _logger;
     private readonly JsonSettingsStore _settingsStore;
+    private readonly RuntimeResourceArbiter _resourceArbiter = new();
+    private readonly SemaphoreSlim _previewGate = new(1, 1);
     private SingleInstanceLock? _singleInstanceLock;
     private WindowsPushToTalkHook? _pushToTalkHook;
     private PushToTalkSessionController? _sessionController;
+    private WasapiAudioCapture? _audioCapture;
     private RuntimeWorkerTranscriptionEngine? _transcriptionEngine;
+    private RuntimeWorkerLivePreviewEngine? _previewEngine;
+    private CancellationTokenSource? _previewCancellation;
+    private Task? _previewLoop;
+    private long _previewSequence;
     private MainWindow? _window;
     private bool _disposed;
 
@@ -142,10 +149,19 @@ public partial class App : Application, IAsyncDisposable
             _pushToTalkHook = null;
         }
 
+        await StopLivePreviewAsync().ConfigureAwait(true);
+
         if (_sessionController is not null)
         {
             await _sessionController.DisposeAsync().ConfigureAwait(true);
             _sessionController = null;
+            _audioCapture = null;
+        }
+
+        if (_previewEngine is not null)
+        {
+            await _previewEngine.DisposeAsync().ConfigureAwait(true);
+            _previewEngine = null;
         }
 
         if (_transcriptionEngine is not null)
@@ -156,6 +172,8 @@ public partial class App : Application, IAsyncDisposable
 
         _singleInstanceLock?.Dispose();
         _singleInstanceLock = null;
+        _resourceArbiter.Dispose();
+        _previewGate.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -175,8 +193,9 @@ public partial class App : Application, IAsyncDisposable
             return;
         }
 
+        _audioCapture = new WasapiAudioCapture();
         _sessionController = new PushToTalkSessionController(
-            new WasapiAudioCapture(),
+            _audioCapture,
             new WindowsForegroundTargetProvider());
         _pushToTalkHook.Signalled += OnPushToTalkSignalled;
         _window?.SetHotkeyReady(_pushToTalkHook.Gesture.ToString());
@@ -235,7 +254,47 @@ public partial class App : Application, IAsyncDisposable
             return;
         }
 
+        ConfigureLivePreview(workerExecutable, hardware);
         _window?.SetSessionStatus("Local transcription ready");
+    }
+
+    private void ConfigureLivePreview(string workerExecutable, HardwareSnapshot hardware)
+    {
+        var modelDirectory = ResolveModelDirectory(
+            WhisperTranscriptionEngine.PreviewModelId,
+            "ENVIOUSWISPR_PREVIEW_MODEL_DIRECTORY");
+        if (modelDirectory is null ||
+            !new LocalWhisperModelProbe().Probe(modelDirectory).PreviewSmallComplete)
+        {
+            return;
+        }
+
+        var useCuda = hardware.Architecture == ProcessorArchitectureKind.X64 &&
+            hardware.Cuda.IsDriverAvailable &&
+            hardware.Cuda.DeviceCount > 0;
+        var provider = useCuda ? RuntimeProviderKind.Cuda : RuntimeProviderKind.Cpu;
+        var threads = Math.Clamp(
+            hardware.PhysicalCoreCount > 0
+                ? hardware.PhysicalCoreCount
+                : Math.Max(1, hardware.LogicalProcessorCount / 2),
+            2,
+            8);
+        _previewEngine = new RuntimeWorkerLivePreviewEngine(
+            new RuntimeWorkerTranscriptionOptions(
+                workerExecutable,
+                modelDirectory,
+                provider,
+                ParakeetModelPack.Quantized,
+                threads,
+                CpuFallbackThreads: threads,
+                StartupTimeout: TimeSpan.FromSeconds(15),
+                TranscriptionTimeout: TimeSpan.FromSeconds(15),
+                Engine: FinalAsrEngine.Whisper,
+                WhisperPack: WhisperModelPack.PreviewSmall,
+                Language: "auto",
+                CudaRuntimeDirectory: Environment.GetEnvironmentVariable(
+                    "ENVIOUSWISPR_CUDA_RUNTIME_DIR")),
+            _resourceArbiter);
     }
 
     private static RuntimeWorkerTranscriptionEngine? CreateParakeetEngine(
@@ -303,9 +362,11 @@ public partial class App : Application, IAsyncDisposable
                 "ENVIOUSWISPR_CUDA_RUNTIME_DIR")));
     }
 
-    private static string? ResolveModelDirectory(string modelId)
+    private static string? ResolveModelDirectory(
+        string modelId,
+        string environmentVariable = "ENVIOUSWISPR_MODEL_DIRECTORY")
     {
-        var configured = Environment.GetEnvironmentVariable("ENVIOUSWISPR_MODEL_DIRECTORY");
+        var configured = Environment.GetEnvironmentVariable(environmentVariable);
         if (!string.IsNullOrWhiteSpace(configured) && Directory.Exists(configured))
         {
             return Path.GetFullPath(configured);
@@ -358,16 +419,22 @@ public partial class App : Application, IAsyncDisposable
             };
 
             WriteSessionEvent(result);
-            if (result.Kind == SessionTransitionKind.FinalizeReady &&
+            if (result.Kind == SessionTransitionKind.Started && result.Session is not null)
+            {
+                await StartLivePreviewAsync().ConfigureAwait(false);
+            }
+            else if (result.Kind == SessionTransitionKind.FinalizeReady &&
                 result.Session is not null &&
                 result.Audio is not null)
             {
+                await StopLivePreviewAsync().ConfigureAwait(false);
                 await TranscribeFinalAsync(controller, result.Session.Id, result.Audio)
                     .ConfigureAwait(false);
                 return;
             }
             else if (result.Kind is SessionTransitionKind.Cancelled or SessionTransitionKind.Failed)
             {
+                await StopLivePreviewAsync().ConfigureAwait(false);
                 await controller.ResetAsync().ConfigureAwait(false);
             }
 
@@ -382,6 +449,142 @@ public partial class App : Application, IAsyncDisposable
                 AppFailureCategory.Unknown));
             _window?.DispatcherQueue.TryEnqueue(() =>
                 _window?.SetSessionStatus("Session failed safely"));
+        }
+    }
+
+    private async Task StartLivePreviewAsync()
+    {
+        var engine = _previewEngine;
+        var audioCapture = _audioCapture;
+        if (engine is null || audioCapture is null)
+        {
+            return;
+        }
+
+        await _previewGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_previewLoop is not null)
+            {
+                return;
+            }
+
+            var started = await engine.StartAsync().ConfigureAwait(false);
+            if (!started.Succeeded)
+            {
+                _logger.Write(new AppLogEntry(
+                    DateTimeOffset.UtcNow,
+                    AppEventCode.LivePreviewFailed,
+                    FailureFor(started.Error)));
+                return;
+            }
+
+            _previewSequence = 0;
+            _previewCancellation = new CancellationTokenSource();
+            _previewLoop = RunLivePreviewAsync(
+                engine,
+                audioCapture,
+                _previewCancellation.Token);
+            _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.LivePreviewStarted));
+        }
+        finally
+        {
+            _previewGate.Release();
+        }
+    }
+
+    private async Task RunLivePreviewAsync(
+        RuntimeWorkerLivePreviewEngine engine,
+        WasapiAudioCapture audioCapture,
+        CancellationToken cancellationToken)
+    {
+        var cadence = TimeSpan.FromMilliseconds(2_500);
+        var maximumWindow = TimeSpan.FromSeconds(20);
+        try
+        {
+            while (true)
+            {
+                await Task.Delay(cadence, cancellationToken).ConfigureAwait(false);
+                var snapshot = audioCapture.GetSnapshot(maximumWindow);
+                if (snapshot is null || snapshot.Samples.Length < 8_000)
+                {
+                    continue;
+                }
+
+                var timer = System.Diagnostics.Stopwatch.StartNew();
+                var update = await engine.PreviewAsync(
+                    snapshot,
+                    Interlocked.Increment(ref _previewSequence),
+                    cancellationToken).ConfigureAwait(false);
+                timer.Stop();
+                if (!update.Succeeded)
+                {
+                    _logger.Write(new AppLogEntry(
+                        DateTimeOffset.UtcNow,
+                        AppEventCode.LivePreviewFailed,
+                        FailureFor(update.Error),
+                        timer.ElapsedMilliseconds));
+                    return;
+                }
+
+                _logger.Write(new AppLogEntry(
+                    DateTimeOffset.UtcNow,
+                    AppEventCode.LivePreviewUpdated,
+                    ElapsedMilliseconds: timer.ElapsedMilliseconds));
+                _window?.DispatcherQueue.TryEnqueue(() =>
+                    _window?.SetLivePreview(update.Text));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Release or cancellation intentionally stops preview without affecting final ASR.
+        }
+        catch (Exception exception) when (exception is not (StackOverflowException or OutOfMemoryException))
+        {
+            _logger.Write(new AppLogEntry(
+                DateTimeOffset.UtcNow,
+                AppEventCode.LivePreviewFailed,
+                AppFailureCategory.RuntimeWorker));
+        }
+    }
+
+    private async Task StopLivePreviewAsync()
+    {
+        await _previewGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var cancellation = _previewCancellation;
+            var loop = _previewLoop;
+            _previewCancellation = null;
+            _previewLoop = null;
+            cancellation?.Cancel();
+            if (loop is not null)
+            {
+                try
+                {
+                    await loop.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // The preview task observes cancellation as its normal stop path.
+                }
+            }
+
+            cancellation?.Dispose();
+            if (_previewEngine is not null)
+            {
+                await _previewEngine.StopAsync().ConfigureAwait(false);
+            }
+
+            _window?.DispatcherQueue.TryEnqueue(() => _window?.SetLivePreview(text: null));
+            if (loop is not null)
+            {
+                _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.LivePreviewStopped));
+            }
+        }
+        finally
+        {
+            _previewGate.Release();
         }
     }
 

--- a/src/Production/EnviousWispr.App/MainWindow.xaml
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml
@@ -85,6 +85,13 @@
                         <StackPanel Grid.Column="1" Spacing="4">
                             <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Session" />
                             <TextBlock x:Name="SessionStatusText" FontWeight="SemiBold" Text="Idle" />
+                            <TextBlock
+                                x:Name="LivePreviewText"
+                                AutomationProperties.Name="Live transcription preview"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                MaxLines="3"
+                                TextWrapping="Wrap"
+                                Visibility="Collapsed" />
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/src/Production/EnviousWispr.App/MainWindow.xaml.cs
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml.cs
@@ -40,4 +40,12 @@ public sealed partial class MainWindow : Window
     }
 
     public void SetSessionStatus(string status) => SessionStatusText.Text = status;
+
+    public void SetLivePreview(string? text)
+    {
+        LivePreviewText.Text = text ?? string.Empty;
+        LivePreviewText.Visibility = string.IsNullOrWhiteSpace(text)
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
 }

--- a/src/Production/EnviousWispr.Architecture.Tests/LocalWhisperModelProbeTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/LocalWhisperModelProbeTests.cs
@@ -13,11 +13,13 @@ public sealed class LocalWhisperModelProbeTests
         {
             File.WriteAllBytes(Path.Combine(directory.FullName, WhisperModelFileNames.Quantized), [1]);
             File.WriteAllBytes(Path.Combine(directory.FullName, WhisperModelFileNames.FullPrecision), []);
+            File.WriteAllBytes(Path.Combine(directory.FullName, WhisperModelFileNames.PreviewSmall), [2]);
 
             var inventory = new LocalWhisperModelProbe().Probe(directory.FullName);
 
             Assert.True(inventory.QuantizedComplete);
             Assert.False(inventory.FullPrecisionComplete);
+            Assert.True(inventory.PreviewSmallComplete);
         }
         finally
         {

--- a/src/Production/EnviousWispr.Architecture.Tests/RuntimeWorkerLivePreviewEngineTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/RuntimeWorkerLivePreviewEngineTests.cs
@@ -1,0 +1,153 @@
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+using EnviousWispr.Services.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class RuntimeWorkerLivePreviewEngineTests
+{
+    private static readonly float[] SampleAudio = [0.2f];
+
+    [Fact]
+    public async Task StopReleasesPreviewResourceBeforeFinalAsr()
+    {
+        using var arbiter = new RuntimeResourceArbiter();
+        var runtime = new FakePreviewRuntime();
+        await using var preview = new RuntimeWorkerLivePreviewEngine(
+            runtime,
+            arbiter,
+            RuntimeResourceKind.Cpu);
+        var sessionId = DictationSessionId.Create();
+
+        var started = await preview.StartAsync();
+        var update = await preview.PreviewAsync(
+            new AudioSnapshot(sessionId, SampleAudio, 16_000, 1),
+            sequence: 3);
+        var blockedFinal = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Cpu,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.Zero);
+        await preview.StopAsync();
+        var final = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Cpu,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.Zero);
+
+        Assert.True(started.Succeeded);
+        Assert.True(update.Succeeded);
+        Assert.Equal(sessionId.Value, update.SessionId);
+        Assert.Equal(3, update.Sequence);
+        Assert.Equal("preview only", update.Text);
+        Assert.False(blockedFinal.Succeeded);
+        Assert.True(runtime.Stopped);
+        Assert.True(final.Succeeded);
+        await final.Lease!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task FailedPreviewStartDoesNotHoldResource()
+    {
+        using var arbiter = new RuntimeResourceArbiter();
+        var runtime = new FakePreviewRuntime(startSucceeds: false);
+        await using var preview = new RuntimeWorkerLivePreviewEngine(
+            runtime,
+            arbiter,
+            RuntimeResourceKind.Accelerator);
+
+        var started = await preview.StartAsync();
+        var final = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Accelerator,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.Zero);
+
+        Assert.False(started.Succeeded);
+        Assert.True(final.Succeeded);
+        await final.Lease!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task CancelledPreviewStartDoesNotHoldResource()
+    {
+        using var arbiter = new RuntimeResourceArbiter();
+        var runtime = new FakePreviewRuntime(cancelStart: true);
+        await using var preview = new RuntimeWorkerLivePreviewEngine(
+            runtime,
+            arbiter,
+            RuntimeResourceKind.Cpu);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => preview.StartAsync());
+        var final = await arbiter.AcquireAsync(
+            RuntimeResourceKind.Cpu,
+            RuntimeWorkloadKind.FinalAsr,
+            TimeSpan.Zero);
+
+        Assert.True(final.Succeeded);
+        await final.Lease!.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisabledPreviewReturnsTypedFailureWithoutCallingRuntime()
+    {
+        using var arbiter = new RuntimeResourceArbiter();
+        var runtime = new FakePreviewRuntime();
+        await using var preview = new RuntimeWorkerLivePreviewEngine(
+            runtime,
+            arbiter,
+            RuntimeResourceKind.Cpu);
+        var sessionId = DictationSessionId.Create();
+
+        var update = await preview.PreviewAsync(
+            new AudioSnapshot(sessionId, SampleAudio, 16_000, 1),
+            sequence: 0);
+
+        Assert.False(update.Succeeded);
+        Assert.Equal(AppErrorCode.RuntimeResourceBusy, update.Error?.Code);
+        Assert.Equal(0, runtime.TranscriptionCount);
+    }
+
+    private sealed class FakePreviewRuntime(
+        bool startSucceeds = true,
+        bool cancelStart = false) : IWorkerTranscriptionRuntime
+    {
+        public string EngineId => "whisper-small:cpu:isolated";
+
+        public bool Stopped { get; private set; }
+
+        public int TranscriptionCount { get; private set; }
+
+        public Task<RuntimeWorkerResult> StartAsync(CancellationToken cancellationToken = default) =>
+            cancelStart
+                ? Task.FromException<RuntimeWorkerResult>(new OperationCanceledException())
+                : Task.FromResult(startSucceeds
+                ? new RuntimeWorkerResult(true, RuntimeWorkerState.Ready)
+                : new RuntimeWorkerResult(
+                    false,
+                    RuntimeWorkerState.Faulted,
+                    new AppError(
+                        AppErrorCode.RuntimeWorkerFailed,
+                        AppErrorStage.RuntimeWorker,
+                        CanRetry: true)));
+
+        public Task<RuntimeWorkerResult> StopAsync(CancellationToken cancellationToken = default)
+        {
+            Stopped = true;
+            return Task.FromResult(new RuntimeWorkerResult(true, RuntimeWorkerState.Stopped));
+        }
+
+        public Task<Transcript> TranscribeAsync(
+            CapturedAudio audio,
+            CancellationToken cancellationToken = default)
+        {
+            TranscriptionCount++;
+            return Task.FromResult(new Transcript(
+                audio.SessionId,
+                "preview only",
+                EngineId,
+                DetectedLanguage: "en"));
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/WasapiAudioCaptureTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/WasapiAudioCaptureTests.cs
@@ -9,6 +9,8 @@ namespace EnviousWispr.Architecture.Tests;
 public sealed class WasapiAudioCaptureTests
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromMilliseconds(25);
+    private static readonly float[] PreviewTail = [0.3f, 0.4f];
+    private static readonly float[] CompletePreviewFixture = [0.1f, 0.2f, 0.3f, 0.4f];
 
     [Fact]
     public async Task ClientStopReturnsCompletedBufferedAudio()
@@ -28,6 +30,25 @@ public sealed class WasapiAudioCaptureTests
         Assert.Null(result.Error);
         Assert.Equal(new[] { 0.25f, -0.5f }, result.Samples.ToArray());
         Assert.True(recorder.Disposed);
+    }
+
+    [Fact]
+    public async Task PreviewSnapshotIsBoundedAndDoesNotConsumeFinalAudio()
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+        var sessionId = DictationSessionId.Create();
+
+        await capture.StartAsync(new AudioCaptureRequest(sessionId));
+        recorder.Emit(0.1f, 0.2f, 0.3f, 0.4f);
+        var snapshot = capture.GetSnapshot(TimeSpan.FromSeconds(2d / 16_000));
+        var final = await capture.StopAsync();
+
+        Assert.NotNull(snapshot);
+        Assert.Equal(sessionId, snapshot.SessionId);
+        Assert.Equal(PreviewTail, snapshot.Samples.ToArray());
+        Assert.Equal(CompletePreviewFixture, final.Samples.ToArray());
+        Assert.Null(capture.GetSnapshot(TimeSpan.FromSeconds(1)));
     }
 
     [Fact]

--- a/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
+++ b/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace EnviousWispr.Audio;
 
-public sealed class WasapiAudioCapture : IAudioCapture
+public sealed class WasapiAudioCapture : IAudioCapture, IAudioSnapshotSource
 {
     private static readonly AudioBufferFormat CaptureFormat = new(
         AudioSampleConverter.TargetSampleRate,
@@ -43,6 +43,43 @@ public sealed class WasapiAudioCapture : IAudioCapture
     public event EventHandler<AudioLevel>? LevelChanged;
 
     public bool IsCapturing => _isCapturing;
+
+    public AudioSnapshot? GetSnapshot(TimeSpan maximumDuration)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDuration, TimeSpan.Zero);
+        var maximumSamples = Math.Max(
+            1,
+            checked((int)Math.Ceiling(
+                maximumDuration.TotalSeconds * AudioSampleConverter.TargetSampleRate)));
+        var maximumBytes = checked(maximumSamples * sizeof(float));
+        byte[] bytes;
+        DictationSessionId sessionId;
+        lock (_bufferGate)
+        {
+            if (!_isCapturing || _request is null)
+            {
+                return null;
+            }
+
+            sessionId = _request.SessionId;
+            var byteCount = (int)Math.Min(_capturedBytes.Length, maximumBytes);
+            if (!_capturedBytes.TryGetBuffer(out var buffer) || buffer.Array is null)
+            {
+                return null;
+            }
+
+            bytes = buffer.Array.AsSpan(
+                buffer.Offset + checked((int)_capturedBytes.Length) - byteCount,
+                byteCount).ToArray();
+        }
+
+        var samples = AudioSampleConverter.ConvertToMono16Khz(bytes, CaptureFormat).Samples;
+        return new AudioSnapshot(
+            sessionId,
+            samples,
+            AudioSampleConverter.TargetSampleRate,
+            Channels: 1);
+    }
 
     public async Task<AudioOperationResult> StartAsync(
         AudioCaptureRequest request,

--- a/src/Production/EnviousWispr.Core/Audio/AudioContracts.cs
+++ b/src/Production/EnviousWispr.Core/Audio/AudioContracts.cs
@@ -35,6 +35,17 @@ public readonly record struct AudioLevel(float Peak, float RootMeanSquare)
 
 public sealed record AudioOperationResult(bool Succeeded, AppError? Error = null);
 
+public sealed record AudioSnapshot(
+    DictationSessionId SessionId,
+    ReadOnlyMemory<float> Samples,
+    int SampleRate,
+    int Channels);
+
+public interface IAudioSnapshotSource
+{
+    AudioSnapshot? GetSnapshot(TimeSpan maximumDuration);
+}
+
 public interface IAudioCapture : IAsyncDisposable
 {
     event EventHandler<AudioLevel>? LevelChanged;

--- a/src/Production/EnviousWispr.Core/Diagnostics/AppEventCode.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/AppEventCode.cs
@@ -22,5 +22,9 @@ public enum AppEventCode
     DictationTranscriptionFailed,
     DictationCancelled,
     DictationSessionFailed,
+    LivePreviewStarted,
+    LivePreviewUpdated,
+    LivePreviewStopped,
+    LivePreviewFailed,
     UnhandledFailure,
 }

--- a/src/Production/EnviousWispr.Core/Preview/LivePreviewContracts.cs
+++ b/src/Production/EnviousWispr.Core/Preview/LivePreviewContracts.cs
@@ -1,0 +1,27 @@
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Core.Preview;
+
+public sealed record LivePreviewUpdate(
+    Guid SessionId,
+    long Sequence,
+    bool Succeeded,
+    string Text,
+    string? DetectedLanguage = null,
+    AppError? Error = null);
+
+public interface ILivePreviewEngine : IAsyncDisposable
+{
+    string EngineId { get; }
+
+    Task<RuntimeWorkerResult> StartAsync(CancellationToken cancellationToken = default);
+
+    Task<LivePreviewUpdate> PreviewAsync(
+        AudioSnapshot snapshot,
+        long sequence,
+        CancellationToken cancellationToken = default);
+
+    Task<RuntimeWorkerResult> StopAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Production/EnviousWispr.Core/Runtime/HardwareContracts.cs
+++ b/src/Production/EnviousWispr.Core/Runtime/HardwareContracts.cs
@@ -74,7 +74,10 @@ public interface IParakeetModelProbe
     ParakeetModelInventory Probe(string modelDirectory);
 }
 
-public sealed record WhisperModelInventory(bool QuantizedComplete, bool FullPrecisionComplete);
+public sealed record WhisperModelInventory(
+    bool QuantizedComplete,
+    bool FullPrecisionComplete,
+    bool PreviewSmallComplete = false);
 
 public interface IWhisperModelProbe
 {
@@ -106,17 +109,33 @@ public enum WhisperModelPack
 {
     Quantized,
     FullPrecision,
+    PreviewSmall,
 }
 
 public static class WhisperModelFileNames
 {
     public const string Quantized = "ggml-large-v3-turbo-q5_0.bin";
     public const string FullPrecision = "ggml-large-v3-turbo.bin";
+    public const string PreviewSmall = "ggml-small-q5_1.bin";
 
     public static string For(WhisperModelPack modelPack) => modelPack switch
     {
         WhisperModelPack.Quantized => Quantized,
         WhisperModelPack.FullPrecision => FullPrecision,
+        WhisperModelPack.PreviewSmall => PreviewSmall,
+        _ => throw new ArgumentOutOfRangeException(nameof(modelPack)),
+    };
+}
+
+public static class WhisperModelIds
+{
+    public const string Final = "whisper-large-v3-turbo";
+    public const string Preview = "whisper-small";
+
+    public static string For(WhisperModelPack modelPack) => modelPack switch
+    {
+        WhisperModelPack.PreviewSmall => Preview,
+        WhisperModelPack.Quantized or WhisperModelPack.FullPrecision => Final,
         _ => throw new ArgumentOutOfRangeException(nameof(modelPack)),
     };
 }

--- a/src/Production/EnviousWispr.ModelDelivery/LocalWhisperModelProbe.cs
+++ b/src/Production/EnviousWispr.ModelDelivery/LocalWhisperModelProbe.cs
@@ -10,7 +10,8 @@ public sealed class LocalWhisperModelProbe : IWhisperModelProbe
         var directory = Path.GetFullPath(modelDirectory);
         return new WhisperModelInventory(
             QuantizedComplete: IsNonEmpty(Path.Combine(directory, WhisperModelFileNames.Quantized)),
-            FullPrecisionComplete: IsNonEmpty(Path.Combine(directory, WhisperModelFileNames.FullPrecision)));
+            FullPrecisionComplete: IsNonEmpty(Path.Combine(directory, WhisperModelFileNames.FullPrecision)),
+            PreviewSmallComplete: IsNonEmpty(Path.Combine(directory, WhisperModelFileNames.PreviewSmall)));
     }
 
     private static bool IsNonEmpty(string path) =>

--- a/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerLivePreviewEngine.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerLivePreviewEngine.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.Preview;
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Services.Runtime;
+
+public sealed class RuntimeWorkerLivePreviewEngine : ILivePreviewEngine
+{
+    private readonly IWorkerTranscriptionRuntime _engine;
+    private readonly RuntimeResourceArbiter _resourceArbiter;
+    private readonly RuntimeResourceKind _resource;
+    private readonly TimeSpan _resourceTimeout;
+    private IAsyncDisposable? _resourceLease;
+    private bool _disposed;
+
+    public RuntimeWorkerLivePreviewEngine(
+        RuntimeWorkerTranscriptionOptions options,
+        RuntimeResourceArbiter resourceArbiter,
+        TimeSpan? resourceTimeout = null)
+        : this(
+            CreateRuntime(options),
+            resourceArbiter,
+            options.Provider == RuntimeProviderKind.Cpu
+                ? RuntimeResourceKind.Cpu
+                : RuntimeResourceKind.Accelerator,
+            resourceTimeout)
+    {
+    }
+
+    internal RuntimeWorkerLivePreviewEngine(
+        IWorkerTranscriptionRuntime engine,
+        RuntimeResourceArbiter resourceArbiter,
+        RuntimeResourceKind resource,
+        TimeSpan? resourceTimeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(resourceArbiter);
+        _engine = engine;
+        _resourceArbiter = resourceArbiter;
+        _resource = resource;
+        _resourceTimeout = resourceTimeout ?? TimeSpan.Zero;
+    }
+
+    public string EngineId => _engine.EngineId;
+
+    public async Task<RuntimeWorkerResult> StartAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_resourceLease is not null)
+        {
+            return new RuntimeWorkerResult(true, RuntimeWorkerState.Ready);
+        }
+
+        var acquired = await _resourceArbiter.AcquireAsync(
+            _resource,
+            RuntimeWorkloadKind.LivePreview,
+            _resourceTimeout,
+            cancellationToken).ConfigureAwait(false);
+        if (!acquired.Succeeded)
+        {
+            return new RuntimeWorkerResult(
+                false,
+                RuntimeWorkerState.Faulted,
+                acquired.Error);
+        }
+
+        _resourceLease = acquired.Lease;
+        try
+        {
+            var started = await _engine.StartAsync(cancellationToken).ConfigureAwait(false);
+            if (!started.Succeeded)
+            {
+                await ReleaseResourceAsync().ConfigureAwait(false);
+            }
+
+            return started;
+        }
+        catch
+        {
+            await ReleaseResourceAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task<LivePreviewUpdate> PreviewAsync(
+        AudioSnapshot snapshot,
+        long sequence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentOutOfRangeException.ThrowIfNegative(sequence);
+        if (_resourceLease is null)
+        {
+            return Failure(snapshot, sequence, AppErrorCode.RuntimeResourceBusy);
+        }
+
+        try
+        {
+            var transcript = await _engine.TranscribeAsync(new CapturedAudio(
+                snapshot.SessionId,
+                snapshot.Samples,
+                snapshot.SampleRate,
+                snapshot.Channels), cancellationToken).ConfigureAwait(false);
+            return new LivePreviewUpdate(
+                snapshot.SessionId.Value,
+                sequence,
+                Succeeded: true,
+                transcript.Text,
+                transcript.DetectedLanguage);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (TranscriptionEngineException exception)
+        {
+            return new LivePreviewUpdate(
+                snapshot.SessionId.Value,
+                sequence,
+                Succeeded: false,
+                string.Empty,
+                Error: exception.Error);
+        }
+    }
+
+    public async Task<RuntimeWorkerResult> StopAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (_disposed)
+        {
+            return new RuntimeWorkerResult(true, RuntimeWorkerState.Disposed);
+        }
+
+        try
+        {
+            return await _engine.StopAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await ReleaseResourceAsync().ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            await _engine.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await ReleaseResourceAsync().ConfigureAwait(false);
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    private async ValueTask ReleaseResourceAsync()
+    {
+        var lease = Interlocked.Exchange(ref _resourceLease, null);
+        if (lease is not null)
+        {
+            await lease.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static LivePreviewUpdate Failure(
+        AudioSnapshot snapshot,
+        long sequence,
+        AppErrorCode code) => new(
+        snapshot.SessionId.Value,
+        sequence,
+        Succeeded: false,
+        string.Empty,
+        Error: new AppError(code, AppErrorStage.RuntimeResource, CanRetry: true));
+
+    private static RuntimeWorkerTranscriptionEngine CreateRuntime(
+        RuntimeWorkerTranscriptionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.Engine != Core.Settings.FinalAsrEngine.Whisper ||
+            options.WhisperPack != WhisperModelPack.PreviewSmall)
+        {
+            throw new ArgumentException(
+                "Live preview requires the dedicated small Whisper model pack.",
+                nameof(options));
+        }
+
+        return new RuntimeWorkerTranscriptionEngine(options with
+        {
+            WorkerPriority = ProcessPriorityClass.BelowNormal,
+            MaximumWorkerRestarts = 0,
+        });
+    }
+}

--- a/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerSupervisor.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerSupervisor.cs
@@ -13,6 +13,7 @@ public sealed class RuntimeWorkerSupervisor : IRuntimeWorkerSupervisor
     private readonly string _workerExecutable;
     private readonly string[] _workerArguments;
     private readonly int _maximumRestarts;
+    private readonly ProcessPriorityClass? _processPriority;
     private readonly SemaphoreSlim _gate = new(1, 1);
     private Process? _process;
     private Task<string>? _stderrDrain;
@@ -22,13 +23,15 @@ public sealed class RuntimeWorkerSupervisor : IRuntimeWorkerSupervisor
     public RuntimeWorkerSupervisor(
         string workerExecutable,
         IEnumerable<string>? workerArguments = null,
-        int maximumRestarts = 1)
+        int maximumRestarts = 1,
+        ProcessPriorityClass? processPriority = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workerExecutable);
         ArgumentOutOfRangeException.ThrowIfNegative(maximumRestarts);
         _workerExecutable = Path.GetFullPath(workerExecutable);
         _workerArguments = workerArguments?.ToArray() ?? [];
         _maximumRestarts = maximumRestarts;
+        _processPriority = processPriority;
     }
 
     public RuntimeWorkerState State { get; private set; } = RuntimeWorkerState.Stopped;
@@ -237,6 +240,18 @@ public sealed class RuntimeWorkerSupervisor : IRuntimeWorkerSupervisor
             }
 
             _process = process;
+            if (_processPriority is { } priority)
+            {
+                try
+                {
+                    process.PriorityClass = priority;
+                }
+                catch (Exception exception) when (exception is Win32Exception or InvalidOperationException)
+                {
+                    // Priority is a best-effort hint; worker isolation and correctness do not depend on it.
+                }
+            }
+
             _stderrDrain = process.StandardError.ReadToEndAsync(CancellationToken.None);
             var health = await SendRequestAsync("health", timeout, cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerTranscriptionEngine.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/RuntimeWorkerTranscriptionEngine.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.IO.MemoryMappedFiles;
+using System.Diagnostics;
 using EnviousWispr.Core.Dictation;
 using EnviousWispr.Core.Errors;
 using EnviousWispr.Core.Runtime;
@@ -22,9 +23,17 @@ public sealed record RuntimeWorkerTranscriptionOptions(
     int MaximumWorkerRestarts = 1,
     FinalAsrEngine Engine = FinalAsrEngine.Parakeet,
     WhisperModelPack WhisperPack = WhisperModelPack.Quantized,
-    string? Language = null);
+    string? Language = null,
+    ProcessPriorityClass? WorkerPriority = null);
 
-public sealed class RuntimeWorkerTranscriptionEngine : ITranscriptionEngine, IAsyncDisposable
+internal interface IWorkerTranscriptionRuntime : ITranscriptionEngine, IAsyncDisposable
+{
+    Task<RuntimeWorkerResult> StartAsync(CancellationToken cancellationToken = default);
+
+    Task<RuntimeWorkerResult> StopAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class RuntimeWorkerTranscriptionEngine : IWorkerTranscriptionRuntime
 {
     private const int RequiredSampleRate = 16_000;
     private readonly RuntimeWorkerSupervisor _supervisor;
@@ -38,14 +47,15 @@ public sealed class RuntimeWorkerTranscriptionEngine : ITranscriptionEngine, IAs
         ArgumentNullException.ThrowIfNull(options);
         Validate(options);
         EngineId = options.Engine == FinalAsrEngine.Whisper
-            ? $"whisper-large-v3-turbo:{options.Provider.ToString().ToLowerInvariant()}:isolated"
+            ? $"{WhisperModelIds.For(options.WhisperPack)}:{options.Provider.ToString().ToLowerInvariant()}:isolated"
             : $"parakeet-tdt-0.6b-v3:{options.Provider.ToString().ToLowerInvariant()}:isolated";
         _startupTimeout = options.StartupTimeout ?? TimeSpan.FromSeconds(30);
         _transcriptionTimeout = options.TranscriptionTimeout ?? TimeSpan.FromMinutes(2);
         _supervisor = new RuntimeWorkerSupervisor(
             options.WorkerExecutable,
             CreateWorkerArguments(options),
-            options.MaximumWorkerRestarts);
+            options.MaximumWorkerRestarts,
+            options.WorkerPriority);
     }
 
     public string EngineId { get; }
@@ -54,6 +64,9 @@ public sealed class RuntimeWorkerTranscriptionEngine : ITranscriptionEngine, IAs
 
     public async Task<RuntimeWorkerResult> StartAsync(CancellationToken cancellationToken = default) =>
         await _supervisor.StartAsync(_startupTimeout, cancellationToken).ConfigureAwait(false);
+
+    public async Task<RuntimeWorkerResult> StopAsync(CancellationToken cancellationToken = default) =>
+        await _supervisor.StopAsync(cancellationToken).ConfigureAwait(false);
 
     public async Task<Transcript> TranscribeAsync(
         CapturedAudio audio,

--- a/tools/whisper-uat/Program.cs
+++ b/tools/whisper-uat/Program.cs
@@ -30,9 +30,15 @@ var multilingual = new Dictionary<string, MultilingualFixture>(StringComparer.Or
 
 var mode = args.FirstOrDefault()?.ToLowerInvariant();
 var requestedProvider = mode is "cpu" or "cuda" ? mode : null;
-var modelPack = args.Contains("--full-precision", StringComparer.OrdinalIgnoreCase)
-    ? WhisperModelPack.FullPrecision
-    : WhisperModelPack.Quantized;
+var modelPack = args.Contains("--preview-small", StringComparer.OrdinalIgnoreCase)
+    ? WhisperModelPack.PreviewSmall
+    : args.Contains("--full-precision", StringComparer.OrdinalIgnoreCase)
+        ? WhisperModelPack.FullPrecision
+        : WhisperModelPack.Quantized;
+if (modelPack == WhisperModelPack.PreviewSmall)
+{
+    modelDirectory = Path.Combine(repositoryRoot, "models", "whisper-small");
+}
 if (mode is "fixed-cpu" or "fixed-cuda")
 {
     var provider = mode == "fixed-cpu" ? RuntimeProviderKind.Cpu : RuntimeProviderKind.Cuda;


### PR DESCRIPTION
## Outcome

Adds the first production Phase 8 live-preview slice as a separate, display-only small Whisper workload. Preview failure, absence, cancellation, or resource contention cannot change capture or final transcription.

## Included

- bounded, read-only WASAPI snapshots that preserve the final audio buffer
- a dedicated `ILivePreviewEngine` result type kept out of final transcript/pipeline contracts
- pinned multilingual `ggml-small-q5_1.bin` model identity and probing
- isolated preview worker at Windows `BelowNormal` priority
- typed CPU/accelerator lease with guaranteed release on stop, failure, and cancellation
- 2.5-second preview cadence over a maximum 20-second rolling snapshot
- WinUI preview display that is cleared before final ASR
- content-free preview lifecycle diagnostics and small-model UAT mode

## Validation

- `scripts/validate.ps1`: passed
- preserved proof tests: 34/34
- production tests: 98/98
- all Release builds: zero warnings/errors
- CUDA short-preview inference: 57-221 ms in native WinUI runs
- model harness: French 65 ms, German 82 ms, 10 s English 165 ms, 20 s English 355 ms on CUDA
- CPU model harness: 2.1-2.5 s for the short French/German/English fixtures
- during native recording, final worker stayed `Normal`; preview worker was `BelowNormal`
- preview worker disappeared 63-70 ms after release and before final ASR started
- final CUDA transcription remained 76-254 ms
- closing the shell left no EnviousWispr worker process

## Known gaps (why this is draft)

- target laptop responsiveness and thermal behavior are unobserved
- physical-key controlled spoken multilingual UI evidence is unobserved
- preview settings controls are not yet exposed
- AMD/Intel integrated graphics, CPU-only laptops, suspend/resume, and device-removal paths remain unobserved
- the existing Spanish MInDS-14 fixture remains above the final-ASR accuracy guardrail; preview does not weaken that gate

Tracks #20. This PR intentionally does not close the issue.