### PR TITLE
Phase 14: build the Windows product UX

### DIFF
--- a/notes/phase-fourteen-product-ux.md
+++ b/notes/phase-fourteen-product-ux.md
@@ -1,0 +1,82 @@
+# Phase 14: complete product UX
+
+## Contracts
+
+- READ 2026-08-26 — `docs/plans/windows-master-plan.md` Phase 14 requires the production product
+  shell: onboarding, microphone readiness, overlay, tray, settings, engine/model visibility, local
+  history, dictionary, snippets, portable profiles, update/help surfaces, accessibility, theme,
+  localization, and founder-journey validation.
+- READ 2026-08-26 — `.claude/knowledge/product-contract.md`, `architecture.md`, `pipeline.md`,
+  `distribution.md`, `workflow.md`, and `validation.md` require private local defaults, explicit
+  provider consent, Windows-native behavior, content-free diagnostics, atomic storage, current-phase
+  truth, and native runtime evidence rather than compile-only claims.
+- READ 2026-08-26 — the routed macOS onboarding, settings, history, overlay, permissions, tray, and
+  update maps define the reusable product concepts. Windows translates those concepts to WinUI 3,
+  WASAPI, Windows Credential Manager, per-monitor work areas, and Windows microphone privacy without
+  importing Apple-specific permission or lifecycle machinery.
+
+## Implementation
+
+- MEASURED 2026-08-26 — the WinUI shell now provides first-run privacy guidance and live readiness,
+  Home, History, Dictionary, Snippets, Settings, Help and privacy, plus a compact always-on-top
+  non-activating dictation overlay and notification-area lifecycle. Closing the main window hides the
+  process to the tray; explicit tray Exit remains the shutdown path.
+- MEASURED 2026-08-26 — the overlay reports recording, processing, success, warning, and failure,
+  carries a polite accessibility name/live state, never contains transcript diagnostics, and uses
+  signed work-area placement math for primary, negative-coordinate left, right, above, oversized, and
+  invalid monitor arrangements.
+- MEASURED 2026-08-26 — settings schema v5 adds a machine-local preferred microphone, routes it into
+  capture, validates it, migrates older schemas, and deliberately excludes it from portable profile
+  exports. Microphone discovery reports a real readiness snapshot and both onboarding and Settings can
+  open the exact Windows microphone privacy destination.
+- MEASURED 2026-08-26 — local history uses bounded atomic JSON storage, configurable retention,
+  corruption preservation, search, copy, per-entry deletion, and explicit clear-all confirmation.
+  Final processed text is saved only when history is enabled; diagnostics still exclude transcript
+  content.
+- MEASURED 2026-08-26 — dictionary and snippet editing persist through the existing settings store;
+  portable import/export includes reusable settings and user data while excluding keys, microphone,
+  history, audio, lifecycle state, and private machine paths.
+- MEASURED 2026-08-26 — direct-cloud API-key management is write-only in the UI. OpenAI, Anthropic,
+  and Gemini keys are stored under provider-specific Windows Credential Manager targets; settings and
+  exports contain no secret. Presence checks free the native credential without materializing its
+  value, and the UI reports only found, missing, or unavailable.
+- MEASURED 2026-08-26 — light, dark, and high-contrast resources, semantic UI Automation names,
+  polite live status, access keys, a Ctrl+Enter onboarding accelerator, deterministic first focus, and
+  an en-US resource seam are present. Phase 17 still owns the wider language and assistive-technology
+  matrix.
+- MEASURED 2026-08-26 — model downloads and signed app updates remain truthful read-only surfaces.
+  They do not simulate completion before Phase 16 and Phase 19 implement those delivery systems.
+
+## Validation
+
+- MEASURED 2026-08-26 — `scripts/validate.ps1` passed with zero warnings/errors: preserved founder
+  proof 34/34, production architecture 258/258, WinUI x64 Release, and every existing native UAT
+  harness. `git diff --check` also passed.
+- MEASURED 2026-08-26 — isolated native WinUI UAT reported an active microphone, local transcription
+  readiness, and the configured F8 shortcut. A clean first launch exposed meaningful UI Automation
+  names and focused Get started; completing onboarding focused Home and persisted the choice.
+- MEASURED 2026-08-26 — isolated native journeys created and reloaded synthetic dictionary, snippet,
+  and history rows; history search returned the synthetic match. Theme changes rendered immediately,
+  and dark plus light surfaces were readable at the host's actual 150% scale.
+- MEASURED 2026-08-26 — native cloud-key UAT selected OpenAI, changed the key controls from disabled
+  to enabled, reported missing, masked a synthetic non-secret value, stored it under a bounded isolated
+  Credential Manager target, cleared the field, and reported presence without revealing the value.
+  The exact synthetic credential was deleted and its absence verified afterward.
+- MEASURED 2026-08-26 — the microphone privacy action opened Windows Settings. No privacy control was
+  read or changed. Closing the product window hid the main surface while the exact process remained
+  responsive in the tray lifecycle.
+- MEASURED 2026-08-26 — the recording-state UAT seam exposed a second overlay window with the exact
+  accessible listening/cancel guidance while Get started retained focus, proving the overlay did not
+  steal activation.
+- UNOBSERVED 2026-08-26 — this host exposes one active monitor, so a physical multi-monitor move and
+  tray-menu restore were not observed. Monitor placement has deterministic signed-coordinate coverage,
+  but those tests do not replace native multi-monitor proof.
+- UNOBSERVED 2026-08-26 — the host was exercised at its actual 150% scale, not separate live 100% and
+  200% configurations. Narrator was not run. UI Automation names/live regions were inspected, but a
+  real screen-reader journey and a complete keyboard-only journey remain required before the Phase 14
+  exit can be called final.
+- UNOBSERVED 2026-08-26 — native file-picker profile import/export and founder acceptance were not
+  completed in this pass. Atomic profile contracts and exclusions are covered by tests; picker and
+  founder evidence still need native observation.
+- MEASURED 2026-08-26 — the founder-tested WPF proof was not modified. No real credential, user text,
+  model weight, external provider, protected port 8081 runtime, or unrelated model server was touched.

--- a/src/Production/EnviousWispr.App/App.xaml
+++ b/src/Production/EnviousWispr.App/App.xaml
@@ -5,9 +5,46 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <Color x:Key="BrandAccentColor">#7C3AED</Color>
+                    <SolidColorBrush x:Key="BrandAccentBrush" Color="#7C3AED" />
+                    <SolidColorBrush x:Key="BrandAccentSoftBrush" Color="#167C3AED" />
+                    <SolidColorBrush x:Key="ProductCanvasBrush" Color="#FFF8F5FF" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <Color x:Key="BrandAccentColor">#A78BFA</Color>
+                    <SolidColorBrush x:Key="BrandAccentBrush" Color="#A78BFA" />
+                    <SolidColorBrush x:Key="BrandAccentSoftBrush" Color="#29A78BFA" />
+                    <SolidColorBrush x:Key="ProductCanvasBrush" Color="#FF131019" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <Color x:Key="BrandAccentColor">{ThemeResource SystemAccentColor}</Color>
+                    <SolidColorBrush x:Key="BrandAccentBrush" Color="{ThemeResource SystemAccentColor}" />
+                    <SolidColorBrush x:Key="BrandAccentSoftBrush" Color="Transparent" />
+                    <SolidColorBrush x:Key="ProductCanvasBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
             </ResourceDictionary.MergedDictionaries>
+            <Style x:Key="PageTitleStyle" TargetType="TextBlock">
+                <Setter Property="FontSize" Value="30" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="TextWrapping" Value="Wrap" />
+            </Style>
+            <Style x:Key="SectionTitleStyle" TargetType="TextBlock">
+                <Setter Property="FontSize" Value="18" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="TextWrapping" Value="Wrap" />
+            </Style>
+            <Style x:Key="CardStyle" TargetType="Border">
+                <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
+                <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="14" />
+                <Setter Property="Padding" Value="20" />
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -3,6 +3,7 @@ using EnviousWispr.Core.Diagnostics;
 using EnviousWispr.Core.Dictation;
 using EnviousWispr.Core.Errors;
 using EnviousWispr.Core.Input;
+using EnviousWispr.Core.History;
 using EnviousWispr.Core.Runtime;
 using EnviousWispr.Core.Settings;
 using EnviousWispr.ASR;
@@ -12,10 +13,12 @@ using EnviousWispr.Pipeline;
 using EnviousWispr.Services.Diagnostics;
 using EnviousWispr.Services.Credentials;
 using EnviousWispr.Services.Input;
+using EnviousWispr.Services.History;
 using EnviousWispr.Services.Lifecycle;
 using EnviousWispr.Services.Runtime;
 using EnviousWispr.Services.Settings;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Windowing;
 using System.Security;
 
 namespace EnviousWispr.App;
@@ -26,6 +29,9 @@ public partial class App : Application, IAsyncDisposable
 
     private readonly JsonLineFileLogger _logger;
     private readonly JsonSettingsStore _settingsStore;
+    private readonly JsonPortableProfileService _profileService = new();
+    private readonly JsonHistoryStore _historyStore;
+    private readonly WindowsCredentialApiKeyStore _credentialStore;
     private readonly RuntimeResourceArbiter _resourceArbiter = new();
     private readonly SemaphoreSlim _previewGate = new(1, 1);
     private readonly DeterministicTextPipeline _deterministicTextPipeline = new();
@@ -48,21 +54,38 @@ public partial class App : Application, IAsyncDisposable
     private Task? _previewLoop;
     private long _previewSequence;
     private MainWindow? _window;
+    private WindowsTrayIcon? _trayIcon;
     private IReadOnlyList<CustomWordEntry> _customWords = [];
+    private AppSettings _settings = AppSettings.Default;
     private DeterministicTextOptions _deterministicTextOptions =
         DeterministicTextOptions.From(DictationPreferences.Default);
     private bool _disposed;
+    private bool _exitRequested;
+    private bool _backgroundNoticeShown;
 
     public App()
     {
         InitializeComponent();
 
-        var dataDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Envious Labs",
-            "EnviousWispr");
+        var uatCredentialSuffix = Environment.GetEnvironmentVariable(
+            "ENVIOUSWISPR_UAT_CREDENTIAL_SUFFIX");
+        _credentialStore = string.IsNullOrWhiteSpace(uatCredentialSuffix)
+            ? new WindowsCredentialApiKeyStore()
+            : WindowsCredentialApiKeyStore.CreateForIsolatedUat(uatCredentialSuffix);
+
+        var dataDirectory = Environment.GetEnvironmentVariable("ENVIOUSWISPR_DATA_DIRECTORY");
+        if (string.IsNullOrWhiteSpace(dataDirectory))
+        {
+            dataDirectory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Envious Labs",
+                "EnviousWispr");
+        }
+
+        dataDirectory = Path.GetFullPath(dataDirectory);
         _logger = new JsonLineFileLogger(Path.Combine(dataDirectory, "diagnostics", "app.jsonl"));
         _settingsStore = new JsonSettingsStore(Path.Combine(dataDirectory, "settings.json"));
+        _historyStore = new JsonHistoryStore(Path.Combine(dataDirectory, "history.json"));
 
         UnhandledException += (_, eventArgs) =>
         {
@@ -95,6 +118,7 @@ public partial class App : Application, IAsyncDisposable
         {
             LaunchCount = checked(loadResult.Settings.LaunchCount + 1),
         };
+        _settings = settings;
         _customWords = settings.UserData.CustomWords;
         _deterministicTextOptions = DeterministicTextOptions.From(settings.Preferences.Dictation);
         ConfigurePolish(settings.Preferences.Polish);
@@ -136,9 +160,21 @@ public partial class App : Application, IAsyncDisposable
                 AppFailureCategory.AccessDenied));
         }
 
-        _window = new MainWindow(settings, loadResult.Status);
+        _window = new MainWindow(
+            settings,
+            loadResult.Status,
+            _settingsStore,
+            _profileService,
+            _historyStore,
+            _credentialStore);
+        _window.SettingsChanged += OnSettingsChanged;
+        _window.SessionStatusChanged += OnSessionStatusChanged;
+        _window.AppWindow.Closing += OnAppWindowClosing;
         _window.Closed += OnWindowClosed;
         _window.Activate();
+        ConfigureTrayIcon();
+        await _window.InitializeProductDataAsync().ConfigureAwait(true);
+        _window.FocusInitialControl();
         _window.SetCloudPolishNotice(_cloudPolishConsent?.Notice);
         _window.SetOllamaPolishNotice(_localPolishNotice);
         _window.SetSessionStatus("Preparing local transcription...");
@@ -153,15 +189,112 @@ public partial class App : Application, IAsyncDisposable
             _polishWarmup = ProbeOllamaRuntimeAsync(ollamaProvider, _polishLifetime.Token);
         }
 
+        ApplyOverlayUatState();
+
         _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.ShellShown));
     }
 
     private async void OnWindowClosed(object sender, WindowEventArgs args)
     {
+        _window?.ShutdownProductWindows();
         (_polishProvider as EgOnePolishProvider)?.TerminateRuntimeImmediately();
         _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.ShellClosed));
         await DisposeAsync().ConfigureAwait(true);
+        if (_window is not null)
+        {
+            _window.SettingsChanged -= OnSettingsChanged;
+            _window.SessionStatusChanged -= OnSessionStatusChanged;
+            _window.AppWindow.Closing -= OnAppWindowClosing;
+        }
         _window = null;
+    }
+
+    private void OnSettingsChanged(AppSettings settings)
+    {
+        _settings = settings;
+        _customWords = settings.UserData.CustomWords;
+        _deterministicTextOptions = DeterministicTextOptions.From(settings.Preferences.Dictation);
+    }
+
+    private void ApplyOverlayUatState()
+    {
+        var requested = Environment.GetEnvironmentVariable("ENVIOUSWISPR_UAT_OVERLAY_STATE");
+        var status = requested?.Trim().ToLowerInvariant() switch
+        {
+            "recording" => "Recording — release to finish, Escape to cancel",
+            "processing" => "Transcribing locally...",
+            "success" => "Inserted safely in the app you started in",
+            "warning" => "Protected field — copied only; paste manually if intended",
+            "error" => "Local transcription failed safely",
+            _ => null,
+        };
+        if (status is not null)
+        {
+            _window?.SetSessionStatus(status);
+        }
+    }
+
+    private void OnSessionStatusChanged(string status)
+    {
+        try
+        {
+            _trayIcon?.SetStatus(status);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private void ConfigureTrayIcon()
+    {
+        _trayIcon = new WindowsTrayIcon();
+        _trayIcon.ShowWindowRequested += () => ShowMainWindow(openSettings: false);
+        _trayIcon.OpenSettingsRequested += () => ShowMainWindow(openSettings: true);
+        _trayIcon.ExitRequested += ExitFromTray;
+        _trayIcon.SetStatus("ready");
+    }
+
+    private void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
+    {
+        if (_exitRequested)
+        {
+            return;
+        }
+
+        args.Cancel = true;
+        sender.Hide();
+        if (!_backgroundNoticeShown)
+        {
+            _backgroundNoticeShown = true;
+            _trayIcon?.ShowBackgroundNotice();
+        }
+    }
+
+    private void ShowMainWindow(bool openSettings)
+    {
+        _window?.DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_window is null)
+            {
+                return;
+            }
+
+            _window.AppWindow.Show();
+            _window.Activate();
+            if (openSettings)
+            {
+                _window.OpenSettings();
+            }
+        });
+    }
+
+    private void ExitFromTray()
+    {
+        _window?.DispatcherQueue.TryEnqueue(() =>
+        {
+            _exitRequested = true;
+            _window?.Close();
+        });
     }
 
     public async ValueTask DisposeAsync()
@@ -230,6 +363,9 @@ public partial class App : Application, IAsyncDisposable
         _resourceArbiter.Dispose();
         _polishLifetime.Dispose();
         _previewGate.Dispose();
+        _trayIcon?.Dispose();
+        _trayIcon = null;
+        _historyStore.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -254,7 +390,10 @@ public partial class App : Application, IAsyncDisposable
         _textDelivery = new ContextAwareTextDelivery(_textTargetAdapter);
         _sessionController = new PushToTalkSessionController(
             _audioCapture,
-            new WindowsForegroundTargetProvider());
+            new WindowsForegroundTargetProvider(),
+            preferredAudioDevice: string.IsNullOrWhiteSpace(_settings.PreferredMicrophoneId)
+                ? null
+                : new EnviousWispr.Core.Audio.AudioDeviceId(_settings.PreferredMicrophoneId));
         _pushToTalkHook.Signalled += OnPushToTalkSignalled;
         _window?.SetHotkeyReady(_pushToTalkHook.Gesture.ToString());
         _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.HotkeyReady));
@@ -272,7 +411,6 @@ public partial class App : Application, IAsyncDisposable
 
         if (provider is PolishProvider.OpenAI or PolishProvider.Anthropic or PolishProvider.Gemini)
         {
-            var credentialStore = new WindowsCredentialApiKeyStore();
             var configuredModel = CloudPolishOptions.ModelIdLooksLikeProvider(
                 preferences.ModelId,
                 provider)
@@ -280,9 +418,9 @@ public partial class App : Application, IAsyncDisposable
                 : CloudPolishOptions.DefaultModel(provider);
             _polishProvider = provider switch
             {
-                PolishProvider.OpenAI => new OpenAiPolishProvider(credentialStore, configuredModel),
-                PolishProvider.Anthropic => new AnthropicPolishProvider(credentialStore, configuredModel),
-                PolishProvider.Gemini => new GeminiPolishProvider(credentialStore, configuredModel),
+                PolishProvider.OpenAI => new OpenAiPolishProvider(_credentialStore, configuredModel),
+                PolishProvider.Anthropic => new AnthropicPolishProvider(_credentialStore, configuredModel),
+                PolishProvider.Gemini => new GeminiPolishProvider(_credentialStore, configuredModel),
                 _ => null,
             };
             _cloudPolishConsent = CloudPolishConsent.For(provider);
@@ -876,6 +1014,11 @@ public partial class App : Application, IAsyncDisposable
                             pendingSession.DeliveryOptions)).ConfigureAwait(false);
                     deliveryTimer.Stop();
                     WriteDeliveryEvent(delivery, deliveryTimer.ElapsedMilliseconds);
+                    await SaveHistoryAsync(
+                        transcript,
+                        processed.Output.Text,
+                        polishResult is { Status: PolishAttemptStatus.Polished },
+                        delivery.Delivered).ConfigureAwait(false);
                     await controller.CompleteAsync(sessionId).ConfigureAwait(false);
                     await controller.ResetAsync().ConfigureAwait(false);
                     _window?.DispatcherQueue.TryEnqueue(() =>
@@ -884,6 +1027,11 @@ public partial class App : Application, IAsyncDisposable
                 }
             }
 
+            await SaveHistoryAsync(
+                transcript,
+                processed.Output.Text,
+                polishResult is { Status: PolishAttemptStatus.Polished },
+                wasDelivered: false).ConfigureAwait(false);
             await controller.CompleteAsync(sessionId).ConfigureAwait(false);
             await controller.ResetAsync().ConfigureAwait(false);
             var status = string.IsNullOrWhiteSpace(processed.Output.Text)
@@ -913,6 +1061,39 @@ public partial class App : Application, IAsyncDisposable
             await controller.ResetAsync().ConfigureAwait(false);
             _window?.DispatcherQueue.TryEnqueue(() =>
                 _window?.SetSessionStatus("Local transcription failed safely"));
+        }
+    }
+
+    private async Task SaveHistoryAsync(
+        Transcript transcript,
+        string text,
+        bool wasPolished,
+        bool wasDelivered)
+    {
+        var historyPreferences = _settings.Preferences.History;
+        if (!historyPreferences.IsEnabled || string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        var result = await _historyStore.AddAsync(
+            DictationHistoryEntry.Create(
+                DateTimeOffset.UtcNow,
+                text,
+                transcript.EngineId,
+                wasPolished,
+                wasDelivered),
+            historyPreferences.RetentionDays,
+            DateTimeOffset.UtcNow).ConfigureAwait(false);
+        if (result.Succeeded)
+        {
+            _window?.DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_window is not null)
+                {
+                    _ = _window.NotifyHistoryChangedAsync();
+                }
+            });
         }
     }
 

--- a/src/Production/EnviousWispr.App/DictationOverlayWindow.xaml
+++ b/src/Production/EnviousWispr.App/DictationOverlayWindow.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="EnviousWispr.App.DictationOverlayWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="EnviousWispr dictation status">
+    <Border
+        x:Name="OverlayRoot"
+        AutomationProperties.LiveSetting="Polite"
+        Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource BrandAccentBrush}"
+        BorderThickness="1"
+        CornerRadius="18"
+        Padding="18,14">
+        <Grid ColumnSpacing="12">
+            <Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+            <FontIcon x:Name="StateIcon" AutomationProperties.AccessibilityView="Raw" FontSize="22" Foreground="{ThemeResource BrandAccentBrush}" Glyph="&#xE720;" />
+            <StackPanel Grid.Column="1" Spacing="3">
+                <TextBlock x:Name="StateTitle" FontSize="15" FontWeight="SemiBold" Text="Listening" TextWrapping="Wrap" />
+                <TextBlock x:Name="StateDetail" Foreground="{ThemeResource TextFillColorSecondaryBrush}" MaxLines="2" Text="Release your key to finish" TextWrapping="Wrap" />
+                <TextBlock x:Name="PreviewText" AutomationProperties.Name="Live transcription preview" Foreground="{ThemeResource TextFillColorSecondaryBrush}" MaxLines="2" TextWrapping="Wrap" Visibility="Collapsed" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/src/Production/EnviousWispr.App/DictationOverlayWindow.xaml.cs
+++ b/src/Production/EnviousWispr.App/DictationOverlayWindow.xaml.cs
@@ -1,0 +1,144 @@
+using System.Runtime.InteropServices;
+using EnviousWispr.Core.Presentation;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Windows.Graphics;
+
+namespace EnviousWispr.App;
+
+public enum DictationOverlayState
+{
+    Hidden,
+    Recording,
+    Processing,
+    Success,
+    Warning,
+    Error,
+}
+
+public sealed partial class DictationOverlayWindow : Window
+{
+    private const uint MonitorDefaultToNearest = 2;
+    private const int OverlayWidth = 380;
+    private const int OverlayHeight = 108;
+    private const int WorkAreaMargin = 28;
+
+    private readonly DispatcherTimer _hideTimer = new();
+
+    public DictationOverlayWindow()
+    {
+        InitializeComponent();
+        AppWindow.Resize(new SizeInt32(OverlayWidth, OverlayHeight));
+        AppWindow.IsShownInSwitchers = false;
+        if (AppWindow.Presenter is OverlappedPresenter presenter)
+        {
+            presenter.IsAlwaysOnTop = true;
+            presenter.IsResizable = false;
+            presenter.IsMaximizable = false;
+            presenter.IsMinimizable = false;
+            presenter.SetBorderAndTitleBar(hasBorder: false, hasTitleBar: false);
+        }
+
+        _hideTimer.Tick += (_, _) =>
+        {
+            _hideTimer.Stop();
+            AppWindow.Hide();
+        };
+    }
+
+    public void ShowState(DictationOverlayState state, string detail)
+    {
+        _hideTimer.Stop();
+        if (state == DictationOverlayState.Hidden)
+        {
+            AppWindow.Hide();
+            return;
+        }
+
+        var presentation = state switch
+        {
+            DictationOverlayState.Recording => ("Listening", "\uE720", "Release your key to finish · Escape cancels"),
+            DictationOverlayState.Processing => ("Working locally", "\uE895", detail),
+            DictationOverlayState.Success => ("Dictation complete", "\uE73E", detail),
+            DictationOverlayState.Warning => ("Your text is safe", "\uE7BA", detail),
+            DictationOverlayState.Error => ("Dictation stopped safely", "\uEA39", detail),
+            _ => ("EnviousWispr", "\uE720", detail),
+        };
+        StateTitle.Text = presentation.Item1;
+        StateIcon.Glyph = presentation.Item2;
+        StateDetail.Text = presentation.Item3;
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+            OverlayRoot,
+            $"{presentation.Item1}. {presentation.Item3}");
+        PositionOnForegroundMonitor();
+        AppWindow.Show(activateWindow: false);
+
+        if (state is DictationOverlayState.Success or DictationOverlayState.Warning or DictationOverlayState.Error)
+        {
+            _hideTimer.Interval = TimeSpan.FromSeconds(state == DictationOverlayState.Error ? 5 : 3);
+            _hideTimer.Start();
+        }
+    }
+
+    public void SetPreview(string? text)
+    {
+        PreviewText.Text = text ?? string.Empty;
+        PreviewText.Visibility = string.IsNullOrWhiteSpace(text) ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    public void Shutdown()
+    {
+        _hideTimer.Stop();
+        Close();
+    }
+
+    private void PositionOnForegroundMonitor()
+    {
+        var foreground = GetForegroundWindow();
+        var monitor = MonitorFromWindow(foreground, MonitorDefaultToNearest);
+        var info = new MonitorInfo { Size = Marshal.SizeOf<MonitorInfo>() };
+        if (monitor == nint.Zero || !GetMonitorInfo(monitor, ref info))
+        {
+            return;
+        }
+
+        var position = OverlayPlacement.BottomCenter(
+            new DisplayWorkArea(
+                info.WorkArea.Left,
+                info.WorkArea.Top,
+                info.WorkArea.Right,
+                info.WorkArea.Bottom),
+            OverlayWidth,
+            OverlayHeight,
+            WorkAreaMargin);
+        AppWindow.Move(new PointInt32(position.X, position.Y));
+    }
+
+    [DllImport("user32.dll")]
+    private static extern nint GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern nint MonitorFromWindow(nint windowHandle, uint flags);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetMonitorInfo(nint monitor, ref MonitorInfo monitorInfo);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct MonitorInfo
+    {
+        public int Size;
+        public NativeRect Monitor;
+        public NativeRect WorkArea;
+        public uint Flags;
+    }
+}

--- a/src/Production/EnviousWispr.App/EnviousWispr.App.csproj
+++ b/src/Production/EnviousWispr.App/EnviousWispr.App.csproj
@@ -13,6 +13,7 @@
     <EnableMsixTooling>false</EnableMsixTooling>
     <PublishReadyToRun>false</PublishReadyToRun>
     <PublishTrimmed>false</PublishTrimmed>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Production/EnviousWispr.App/MainWindow.xaml
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml
@@ -4,98 +4,142 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="EnviousWispr">
-    <Window.SystemBackdrop>
-        <MicaBackdrop />
-    </Window.SystemBackdrop>
+    <Window.SystemBackdrop><MicaBackdrop /></Window.SystemBackdrop>
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+    <Grid x:Name="WindowRoot" Background="{ThemeResource ProductCanvasBrush}">
+        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="*" /></Grid.RowDefinitions>
+        <TitleBar x:Name="AppTitleBar" AutomationProperties.Name="EnviousWispr window title" IsTabStop="False" Title="EnviousWispr" Subtitle="Private voice dictation for Windows" />
 
-        <TitleBar x:Name="AppTitleBar" Title="EnviousWispr" Subtitle="Windows production shell" />
-
-        <ScrollViewer Grid.Row="1">
-            <StackPanel MaxWidth="760" Padding="32" Spacing="20" HorizontalAlignment="Stretch">
-                <StackPanel Spacing="6">
-                    <TextBlock FontSize="30" FontWeight="SemiBold" Text="Speak naturally. Keep working." />
-                    <TextBlock
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="The production Windows foundation is running. The founder-tested dictation proof remains intact while each capability moves into this architecture."
-                        TextWrapping="Wrap" />
-                </StackPanel>
-
-                <InfoBar
-                    x:Name="FoundationInfoBar"
-                    IsClosable="False"
-                    IsOpen="True"
-                    Message="The production shell now owns settings, WASAPI capture, configurable push-to-talk, frozen target identity, and safe session cancellation. Final ASR and text delivery are still being moved from the verified proof."
-                    Severity="Informational"
-                    Title="Native dictation foundation active" />
-
-                <Grid ColumnSpacing="16">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-
-                    <Border Padding="20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="12">
-                        <StackPanel Spacing="8">
-                            <TextBlock FontSize="16" FontWeight="SemiBold" Text="Local-first contract" />
-                            <TextBlock Text="Audio and deterministic processing stay on this PC. Optional cloud polish is direct BYOK and receives text only." TextWrapping="Wrap" />
-                        </StackPanel>
-                    </Border>
-
-                    <Border Grid.Column="1" Padding="20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="12">
-                        <StackPanel Spacing="8">
-                            <TextBlock FontSize="16" FontWeight="SemiBold" Text="Reliable by design" />
-                            <TextBlock Text="Every later stage will fall back to the last valid result instead of losing a dictation." TextWrapping="Wrap" />
+        <Grid Grid.Row="1">
+            <ScrollViewer x:Name="OnboardingView" AutomationProperties.Name="Welcome to EnviousWispr" HorizontalScrollMode="Disabled" Visibility="Collapsed">
+                <Grid MaxWidth="980" Padding="40,28,40,48" HorizontalAlignment="Center">
+                    <Grid.ColumnDefinitions><ColumnDefinition Width="1.1*" /><ColumnDefinition Width="0.9*" /></Grid.ColumnDefinitions>
+                    <StackPanel Margin="0,28,48,0" Spacing="18">
+                        <Border Width="60" Height="6" HorizontalAlignment="Left" Background="{ThemeResource BrandAccentBrush}" CornerRadius="3" />
+                        <TextBlock x:Uid="OnboardingTitle" Style="{StaticResource PageTitleStyle}" Text="Your voice, instantly captured." />
+                        <TextBlock FontSize="18" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Speak naturally in any Windows app. EnviousWispr transcribes locally, cleans the result, and delivers it back where you started." TextWrapping="Wrap" />
+                        <Border Style="{StaticResource CardStyle}">
+                            <StackPanel Spacing="12">
+                                <TextBlock Style="{StaticResource SectionTitleStyle}" Text="Private by default" />
+                                <TextBlock Text="Audio and transcription stay on this PC. Optional cloud polish receives text only, goes directly to your chosen provider, and is off until you enable it." TextWrapping="Wrap" />
+                            </StackPanel>
+                        </Border>
+                        <TextBlock FontSize="16" FontWeight="SemiBold" Text="How to dictate" />
+                        <TextBlock Text="1. Put the cursor where your words should go.&#x0a;2. Hold the configured key while you speak.&#x0a;3. Release to transcribe and insert. Press Escape to cancel safely." TextWrapping="Wrap" />
+                    </StackPanel>
+                    <Border Grid.Column="1" Style="{StaticResource CardStyle}">
+                        <StackPanel Spacing="18">
+                            <TextBlock Style="{StaticResource SectionTitleStyle}" Text="Ready on this PC" />
+                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="These checks are honest snapshots. Missing models or permissions can be fixed later without blocking access to your data and settings." TextWrapping="Wrap" />
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="32" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                                <FontIcon Glyph="&#xE720;" Foreground="{ThemeResource BrandAccentBrush}" />
+                                <StackPanel Grid.Column="1" Spacing="6"><TextBlock FontWeight="SemiBold" Text="Microphone" /><TextBlock x:Name="OnboardingMicrophoneText" Text="Checking Windows audio devices…" TextWrapping="Wrap" /><Button AutomationProperties.HelpText="Opens the Windows microphone privacy controls." Click="OpenMicrophonePrivacyButton_Click" Content="Open microphone privacy settings" HorizontalAlignment="Left" TabIndex="10" /></StackPanel>
+                            </Grid>
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="32" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                                <FontIcon Glyph="&#xE9D9;" Foreground="{ThemeResource BrandAccentBrush}" />
+                                <StackPanel Grid.Column="1" Spacing="2"><TextBlock FontWeight="SemiBold" Text="Local transcription" /><TextBlock x:Name="OnboardingModelText" Text="Checking installed model packs…" TextWrapping="Wrap" /></StackPanel>
+                            </Grid>
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="32" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                                <FontIcon Glyph="&#xE765;" Foreground="{ThemeResource BrandAccentBrush}" />
+                                <StackPanel Grid.Column="1" Spacing="2"><TextBlock FontWeight="SemiBold" Text="Push-to-talk" /><TextBlock x:Name="OnboardingHotkeyText" Text="F8 will start and stop dictation." TextWrapping="Wrap" /></StackPanel>
+                            </Grid>
+                            <Button x:Name="FinishOnboardingButton" x:Uid="FinishOnboardingButton" AccessKey="G" AutomationProperties.HelpText="Completes setup and opens the EnviousWispr home page. Press Control plus Enter from anywhere on this screen." Click="FinishOnboardingButton_Click" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Style="{StaticResource AccentButtonStyle}" Content="Get started" TabIndex="0">
+                                <Button.KeyboardAccelerators><KeyboardAccelerator Key="Enter" Modifiers="Control" /></Button.KeyboardAccelerators>
+                            </Button>
+                            <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="You can change every choice later in Settings. No account is required." TextAlignment="Center" TextWrapping="Wrap" />
                         </StackPanel>
                     </Border>
                 </Grid>
+            </ScrollViewer>
 
-                <Border Padding="20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="12">
-                    <Grid ColumnSpacing="20">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <StackPanel Spacing="4">
-                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Settings state" />
-                            <TextBlock x:Name="SettingsStatusText" FontWeight="SemiBold" />
-                        </StackPanel>
-                        <StackPanel Grid.Column="1" Spacing="4">
-                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Production-shell launches" />
-                            <TextBlock x:Name="LaunchCountText" FontWeight="SemiBold" />
-                        </StackPanel>
-                    </Grid>
-                </Border>
+            <NavigationView x:Name="ProductNavigation" AutomationProperties.Name="EnviousWispr navigation" IsBackButtonVisible="Collapsed" IsSettingsVisible="False" IsTitleBarAutoPaddingEnabled="False" PaneDisplayMode="Auto" SelectionChanged="ProductNavigation_SelectionChanged">
+                <NavigationView.MenuItems>
+                    <NavigationViewItem x:Name="HomeNavItem" x:Uid="HomeNavItem" AccessKey="M" Content="Home" Icon="Home" Tag="home" />
+                    <NavigationViewItem x:Uid="HistoryNavItem" AccessKey="Y" Content="History" Icon="Clock" Tag="history" />
+                    <NavigationViewItem x:Uid="DictionaryNavItem" AccessKey="D" Content="Dictionary" Icon="Character" Tag="dictionary" />
+                    <NavigationViewItem x:Uid="SnippetsNavItem" AccessKey="S" Content="Snippets" Icon="Document" Tag="snippets" />
+                    <NavigationViewItem x:Uid="HelpNavItem" AccessKey="P" Content="Help and privacy" Icon="Help" Tag="help" />
+                </NavigationView.MenuItems>
+                <NavigationView.FooterMenuItems>
+                    <NavigationViewItem x:Name="SettingsNavItem" x:Uid="SettingsNavItem" AccessKey="T" Content="Settings" Icon="Setting" Tag="settings" />
+                </NavigationView.FooterMenuItems>
+                <Grid Padding="28,18,28,32">
+                    <InfoBar x:Name="OperationInfoBar" Margin="0,0,0,12" Canvas.ZIndex="10" IsOpen="False" IsClosable="True" VerticalAlignment="Top" />
 
-                <Border Padding="20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="12">
-                    <Grid ColumnSpacing="20">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <StackPanel Spacing="4">
-                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Push-to-talk" />
-                            <TextBlock x:Name="HotkeyStatusText" FontWeight="SemiBold" Text="Starting…" />
+                    <ScrollViewer x:Name="HomePage" AutomationProperties.Name="Home page" HorizontalScrollMode="Disabled">
+                        <StackPanel MaxWidth="900" Spacing="18">
+                            <StackPanel Spacing="6"><TextBlock x:Uid="HomeTitle" Style="{StaticResource PageTitleStyle}" Text="Speak naturally. Keep working." /><TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="EnviousWispr is ready in the background. Put your cursor in any app, hold your key, speak, and release." TextWrapping="Wrap" /></StackPanel>
+                            <InfoBar x:Name="FoundationInfoBar" IsClosable="False" IsOpen="True" Message="Local transcription, deterministic cleanup, optional AI polish, context-aware insertion, and safe clipboard recovery are active." Severity="Success" Title="Private dictation pipeline active" />
+                            <Grid ColumnSpacing="14" RowSpacing="14">
+                                <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="7"><TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Push-to-talk" /><TextBlock x:Name="HotkeyStatusText" FontSize="18" FontWeight="SemiBold" Text="Starting…" TextWrapping="Wrap" /></StackPanel></Border>
+                                <Border Grid.Column="1" Style="{StaticResource CardStyle}"><StackPanel Spacing="7"><TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Session" /><TextBlock x:Name="SessionStatusText" AutomationProperties.LiveSetting="Polite" FontSize="18" FontWeight="SemiBold" Text="Idle" TextWrapping="Wrap" /><TextBlock x:Name="LivePreviewText" AutomationProperties.Name="Live transcription preview" Foreground="{ThemeResource TextFillColorSecondaryBrush}" MaxLines="3" TextWrapping="Wrap" Visibility="Collapsed" /></StackPanel></Border>
+                                <Border Grid.Row="1" Style="{StaticResource CardStyle}"><StackPanel Spacing="7"><TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Transcription engine" /><TextBlock x:Name="EngineReadinessText" FontWeight="SemiBold" Text="Checking…" TextWrapping="Wrap" /></StackPanel></Border>
+                                <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource CardStyle}"><StackPanel Spacing="7"><TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Microphone" /><TextBlock x:Name="MicrophoneReadinessText" FontWeight="SemiBold" Text="Checking…" TextWrapping="Wrap" /></StackPanel></Border>
+                            </Grid>
+                            <Border Style="{StaticResource CardStyle}"><Grid ColumnSpacing="20"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><StackPanel Spacing="5"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Recent dictations" /><TextBlock x:Name="HistorySummaryText" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Loading local history…" TextWrapping="Wrap" /></StackPanel><Button Grid.Column="1" Click="OpenHistoryButton_Click" Content="Open history" VerticalAlignment="Center" /></Grid></Border>
                         </StackPanel>
-                        <StackPanel Grid.Column="1" Spacing="4">
-                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Session" />
-                            <TextBlock x:Name="SessionStatusText" FontWeight="SemiBold" Text="Idle" />
-                            <TextBlock
-                                x:Name="LivePreviewText"
-                                AutomationProperties.Name="Live transcription preview"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                MaxLines="3"
-                                TextWrapping="Wrap"
-                                Visibility="Collapsed" />
+                    </ScrollViewer>
+
+                    <ScrollViewer x:Name="HistoryPage" AutomationProperties.Name="History page" HorizontalScrollMode="Disabled" Visibility="Collapsed">
+                        <StackPanel MaxWidth="900" Spacing="16">
+                            <TextBlock Style="{StaticResource PageTitleStyle}" Text="History" />
+                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Past dictations stay in a private file on this PC. Search, copy, remove, or turn history off at any time." TextWrapping="Wrap" />
+                            <Grid ColumnSpacing="12"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBox x:Name="HistorySearchBox" AutomationProperties.Name="Search dictation history" PlaceholderText="Search local history" TextChanged="HistorySearchBox_TextChanged" /><Button Grid.Column="1" Click="CopyHistoryButton_Click" Content="Copy selected" /><Button Grid.Column="2" Click="DeleteHistoryButton_Click" Content="Delete selected" /></Grid>
+                            <ListView x:Name="HistoryList" AutomationProperties.Name="Local dictation history" SelectionMode="Single"><ListView.ItemTemplate><DataTemplate><StackPanel Padding="6" Spacing="5"><TextBlock FontWeight="SemiBold" Text="{Binding CreatedDisplay}" /><TextBlock MaxLines="4" Text="{Binding Text}" TextWrapping="Wrap" /><TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{Binding Details}" /></StackPanel></DataTemplate></ListView.ItemTemplate></ListView>
+                            <Button HorizontalAlignment="Right" Click="ClearHistoryButton_Click" Content="Delete all history" />
                         </StackPanel>
-                    </Grid>
-                </Border>
-            </StackPanel>
-        </ScrollViewer>
+                    </ScrollViewer>
+
+                    <ScrollViewer x:Name="DictionaryPage" AutomationProperties.Name="Dictionary page" HorizontalScrollMode="Disabled" Visibility="Collapsed">
+                        <StackPanel MaxWidth="820" Spacing="16">
+                            <TextBlock Style="{StaticResource PageTitleStyle}" Text="Dictionary" />
+                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Teach deterministic word correction how a spoken form should be written. These entries stay local and are included in portable profile exports." TextWrapping="Wrap" />
+                            <Border Style="{StaticResource CardStyle}"><Grid ColumnSpacing="12"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions><TextBox x:Name="SpokenFormBox" Header="When I say" MaxLength="256" PlaceholderText="envy wisper" /><TextBox x:Name="ReplacementBox" Grid.Column="1" Header="Write" MaxLength="256" PlaceholderText="EnviousWispr" /><Button Grid.Column="2" Margin="0,28,0,0" Click="AddWordButton_Click" Content="Add word" /></Grid></Border>
+                            <ListView x:Name="DictionaryList" AutomationProperties.Name="Custom dictionary entries" SelectionMode="Single"><ListView.ItemTemplate><DataTemplate><Grid Padding="6" ColumnSpacing="16"><Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions><TextBlock Text="{Binding SpokenForm}" TextWrapping="Wrap" /><TextBlock Grid.Column="1" FontWeight="SemiBold" Text="{Binding Replacement}" TextWrapping="Wrap" /></Grid></DataTemplate></ListView.ItemTemplate></ListView>
+                            <Button HorizontalAlignment="Right" Click="RemoveWordButton_Click" Content="Remove selected" />
+                        </StackPanel>
+                    </ScrollViewer>
+
+                    <ScrollViewer x:Name="SnippetsPage" AutomationProperties.Name="Snippets page" HorizontalScrollMode="Disabled" Visibility="Collapsed">
+                        <StackPanel MaxWidth="820" Spacing="16">
+                            <TextBlock Style="{StaticResource PageTitleStyle}" Text="Snippets" />
+                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Keep reusable text beside your dictation settings. Snippets stay local and are included in portable profile exports." TextWrapping="Wrap" />
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="10"><TextBox x:Name="SnippetNameBox" Header="Name" MaxLength="128" PlaceholderText="Email sign-off" /><TextBox x:Name="SnippetBodyBox" AcceptsReturn="True" Header="Text" MaxLength="10000" MinHeight="100" PlaceholderText="Kind regards," TextWrapping="Wrap" /><Button HorizontalAlignment="Right" Click="AddSnippetButton_Click" Content="Add snippet" /></StackPanel></Border>
+                            <ListView x:Name="SnippetList" AutomationProperties.Name="Saved snippets" SelectionMode="Single"><ListView.ItemTemplate><DataTemplate><StackPanel Padding="6" Spacing="4"><TextBlock FontWeight="SemiBold" Text="{Binding Name}" /><TextBlock MaxLines="4" Text="{Binding Body}" TextWrapping="Wrap" /></StackPanel></DataTemplate></ListView.ItemTemplate></ListView>
+                            <Button HorizontalAlignment="Right" Click="RemoveSnippetButton_Click" Content="Remove selected" />
+                        </StackPanel>
+                    </ScrollViewer>
+
+                    <ScrollViewer x:Name="SettingsPage" AutomationProperties.Name="Settings page" HorizontalScrollMode="Disabled" Visibility="Collapsed">
+                        <StackPanel MaxWidth="820" Spacing="18">
+                            <TextBlock Style="{StaticResource PageTitleStyle}" Text="Settings" />
+                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Choose how EnviousWispr records, transcribes, cleans, and stores your dictation." TextWrapping="Wrap" />
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="14"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Record and transcribe" /><ComboBox x:Name="MicrophoneComboBox" DisplayMemberPath="DisplayName" Header="Microphone" HorizontalAlignment="Stretch" /><Button AutomationProperties.HelpText="Opens the Windows microphone privacy controls." Click="OpenMicrophonePrivacyButton_Click" Content="Open microphone privacy settings" HorizontalAlignment="Left" /><ComboBox x:Name="EngineComboBox" Header="Final transcription engine" HorizontalAlignment="Stretch"><x:String>Automatic</x:String><x:String>Parakeet</x:String><x:String>Whisper</x:String></ComboBox><TextBox x:Name="HotkeyTextBox" Header="Push-to-talk shortcut" MaxLength="64" PlaceholderText="F8" /><TextBlock x:Name="ModelInventoryText" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Model downloads are managed by the signed model-delivery system in Phase 16. Installed packs are usable now." TextWrapping="Wrap" /></StackPanel></Border>
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="12"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Deterministic cleanup" /><ToggleSwitch x:Name="WordCorrectionToggle" Header="Use dictionary corrections" /><ToggleSwitch x:Name="FillerRemovalToggle" Header="Remove filler words" /><ToggleSwitch x:Name="EmojiFormatterToggle" Header="Format spoken emoji" /><ToggleSwitch x:Name="SpokenPunctuationToggle" Header="Convert spoken punctuation" /></StackPanel></Border>
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="12"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="AI polish" /><ComboBox x:Name="PolishProviderComboBox" Header="Provider" HorizontalAlignment="Stretch" SelectionChanged="PolishProviderComboBox_SelectionChanged"><x:String>None</x:String><x:String>EG-1</x:String><x:String>Ollama</x:String><x:String>OpenAI</x:String><x:String>Anthropic</x:String><x:String>Gemini</x:String></ComboBox><TextBox x:Name="PolishModelTextBox" Header="Model ID" MaxLength="256" /><TextBox x:Name="OllamaEndpointTextBox" Header="Ollama endpoint on this PC" MaxLength="2048" PlaceholderText="http://127.0.0.1:11434" /><PasswordBox x:Name="ApiKeyPasswordBox" AutomationProperties.HelpText="Write-only field for the selected direct cloud provider. Existing keys are never displayed." Header="API key for selected cloud provider" MaxLength="1280" /><StackPanel Orientation="Horizontal" Spacing="10"><Button x:Name="SaveApiKeyButton" Click="SaveApiKeyButton_Click" Content="Save API key" /><Button x:Name="RemoveApiKeyButton" Click="RemoveApiKeyButton_Click" Content="Remove stored key" /></StackPanel><TextBlock x:Name="ApiKeyStatusText" AutomationProperties.LiveSetting="Polite" Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap" /><TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="API keys are stored separately in Windows Credential Manager and are never written to settings or exports. Credential storage changes are immediate; provider and model selections apply after the next launch." TextWrapping="Wrap" /></StackPanel></Border>
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="12"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="History and appearance" /><ToggleSwitch x:Name="HistoryEnabledToggle" Header="Save dictation history on this PC" /><NumberBox x:Name="RetentionDaysBox" Header="Delete history after this many days (0 keeps it until you delete it)" Minimum="0" Maximum="3650" SpinButtonPlacementMode="Inline" /><ComboBox x:Name="ThemeComboBox" Header="Theme" HorizontalAlignment="Stretch" SelectionChanged="ThemeComboBox_SelectionChanged"><x:String>Use Windows setting</x:String><x:String>Light</x:String><x:String>Dark</x:String></ComboBox></StackPanel></Border>
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="12"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Portable profile" /><TextBlock Text="Export or import settings, dictionary entries, and snippets. Machine-specific microphone choices, API keys, history, audio, and lifecycle state are never included." TextWrapping="Wrap" /><StackPanel Orientation="Horizontal" Spacing="10"><Button Click="ExportProfileButton_Click" Content="Export profile" /><Button Click="ImportProfileButton_Click" Content="Import profile" /></StackPanel></StackPanel></Border>
+                            <Button HorizontalAlignment="Right" Click="SaveSettingsButton_Click" Style="{StaticResource AccentButtonStyle}" Content="Save settings" />
+                        </StackPanel>
+                    </ScrollViewer>
+
+                    <ScrollViewer x:Name="HelpPage" AutomationProperties.Name="Help and privacy page" HorizontalScrollMode="Disabled" Visibility="Collapsed">
+                        <StackPanel MaxWidth="820" Spacing="18">
+                            <TextBlock Style="{StaticResource PageTitleStyle}" Text="Help and privacy" />
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="10"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Keyboard guide" /><TextBlock Text="Hold your push-to-talk key to record. Release it to transcribe. Press Escape while recording to cancel without delivering text. Use the navigation pane to move through this window." TextWrapping="Wrap" /></StackPanel></Border>
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="10"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Privacy contract" /><TextBlock Text="Audio, local models, dictionaries, snippets, and history stay on this PC. Optional cloud polish sends text directly to the selected provider. EnviousWispr diagnostics never include dictated text, audio, keys, clipboard contents, or surrounding context." TextWrapping="Wrap" /></StackPanel></Border>
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="10"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Updates" /><TextBlock Text="This development build can report update readiness but does not install updates. Signed Velopack channels, rollback, and install safety are owned by Phase 19." TextWrapping="Wrap" /><Button IsEnabled="False" Content="No signed update channel in this build" /></StackPanel></Border>
+                            <Border Style="{StaticResource CardStyle}"><StackPanel Spacing="10"><TextBlock Style="{StaticResource SectionTitleStyle}" Text="Open source and support" /><TextBlock Text="EnviousWispr is GPLv3 open-source software. Third-party model and runtime notices will ship beside each signed model pack." TextWrapping="Wrap" /><HyperlinkButton Content="View the EnviousWispr source" NavigateUri="https://github.com/Envious-Labs-LLC" /></StackPanel></Border>
+                            <TextBlock x:Name="BuildInfoText" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+            </NavigationView>
+        </Grid>
     </Grid>
 </Window>

--- a/src/Production/EnviousWispr.App/MainWindow.xaml.cs
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml.cs
@@ -1,45 +1,141 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+using System.Security;
+using EnviousWispr.Audio;
+using EnviousWispr.Core.Credentials;
+using EnviousWispr.Core.History;
+using EnviousWispr.Core.Input;
 using EnviousWispr.Core.Settings;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics;
+using Windows.Storage.Pickers;
 
 namespace EnviousWispr.App;
 
 public sealed partial class MainWindow : Window
 {
-    public MainWindow(AppSettings settings, SettingsLoadStatus settingsLoadStatus)
-    {
-        InitializeComponent();
+    private readonly ISettingsStore _settingsStore;
+    private readonly IPortableProfileService _profileService;
+    private readonly IHistoryStore _historyStore;
+    private readonly IApiKeyStore _apiKeyStore;
+    private readonly DictationOverlayWindow _overlayWindow;
+    private readonly List<HistoryItemViewModel> _history = [];
+    private IReadOnlyList<MicrophoneChoice> _microphones = [];
+    private AppSettings _settings;
+    private bool _isApplyingSettings;
+    private bool _initialFocusAssigned;
 
+    public MainWindow(
+        AppSettings settings,
+        SettingsLoadStatus settingsLoadStatus,
+        ISettingsStore settingsStore,
+        IPortableProfileService profileService,
+        IHistoryStore historyStore,
+        IApiKeyStore apiKeyStore)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(settingsStore);
+        ArgumentNullException.ThrowIfNull(profileService);
+        ArgumentNullException.ThrowIfNull(historyStore);
+        ArgumentNullException.ThrowIfNull(apiKeyStore);
+
+        _settings = settings;
+        _settingsStore = settingsStore;
+        _profileService = profileService;
+        _historyStore = historyStore;
+        _apiKeyStore = apiKeyStore;
+
+        InitializeComponent();
+        _overlayWindow = new DictationOverlayWindow();
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
-        AppWindow.Resize(new SizeInt32(860, 620));
+        AppWindow.Resize(new SizeInt32(1120, 760));
+        AppWindow.SetIcon(Path.Combine(AppContext.BaseDirectory, "EnviousWispr.App.exe"));
+        Activated += OnWindowActivated;
 
-        SettingsStatusText.Text = settingsLoadStatus switch
+        ApplyTheme(settings.Preferences.Theme);
+        ApplySettingsToControls();
+        ShowOnboarding(!settings.HasCompletedOnboarding);
+        ProductNavigation.SelectedItem = HomeNavItem;
+        BuildInfoText.Text = $"EnviousWispr {Assembly.GetExecutingAssembly().GetName().Version} · Windows 11 x64 development build";
+        if (settingsLoadStatus is SettingsLoadStatus.Invalid or SettingsLoadStatus.Migrated)
         {
-            SettingsLoadStatus.Loaded => "Restored",
-            SettingsLoadStatus.Missing => "Created safely",
-            SettingsLoadStatus.Migrated => "Migrated safely",
-            SettingsLoadStatus.Invalid => "Recovered from invalid data",
-            SettingsLoadStatus.NewerVersion => "Newer data preserved",
-            SettingsLoadStatus.Unavailable => "Using safe defaults",
-            _ => "Using safe defaults",
-        };
-        LaunchCountText.Text = settings.LaunchCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            FoundationInfoBar.Message += " Previous settings were recovered safely.";
+        }
+    }
+
+    public event Action<AppSettings>? SettingsChanged;
+
+    public event Action<string>? SessionStatusChanged;
+
+    public AppSettings CurrentSettings => _settings;
+
+    public void FocusInitialControl()
+    {
+        if (_settings.HasCompletedOnboarding)
+        {
+            HomeNavItem.Focus(FocusState.Programmatic);
+        }
+        else
+        {
+            FinishOnboardingButton.Focus(FocusState.Programmatic);
+        }
+    }
+
+    private void OnWindowActivated(object sender, WindowActivatedEventArgs args)
+    {
+        if (_initialFocusAssigned || args.WindowActivationState == WindowActivationState.Deactivated)
+        {
+            return;
+        }
+
+        _initialFocusAssigned = true;
+        DispatcherQueue.TryEnqueue(FocusInitialControl);
+    }
+
+    public async Task InitializeProductDataAsync()
+    {
+        await LoadMicrophonesAsync().ConfigureAwait(true);
+        await ReloadHistoryAsync().ConfigureAwait(true);
     }
 
     public void SetHotkeyReady(string gesture)
     {
         HotkeyStatusText.Text = $"Hold {gesture}";
+        OnboardingHotkeyText.Text = $"Hold {gesture} while speaking; release to finish.";
         SessionStatusText.Text = "Idle";
+        SessionStatusChanged?.Invoke($"ready · {gesture}");
     }
 
     public void SetHotkeyUnavailable(string status)
     {
         HotkeyStatusText.Text = status;
+        OnboardingHotkeyText.Text = status;
         SessionStatusText.Text = "Unavailable";
+        SessionStatusChanged?.Invoke("shortcut unavailable");
     }
 
-    public void SetSessionStatus(string status) => SessionStatusText.Text = status;
+    public void SetSessionStatus(string status)
+    {
+        SessionStatusText.Text = status;
+        SessionStatusChanged?.Invoke(status);
+        _overlayWindow.ShowState(OverlayStateFor(status), status);
+        if (status.Contains("ready", StringComparison.OrdinalIgnoreCase))
+        {
+            EngineReadinessText.Text = status;
+            OnboardingModelText.Text = status;
+        }
+        else if (status.Contains("model is not installed", StringComparison.OrdinalIgnoreCase) ||
+                 status.Contains("transcription is unavailable", StringComparison.OrdinalIgnoreCase) ||
+                 status.Contains("worker could not start", StringComparison.OrdinalIgnoreCase))
+        {
+            EngineReadinessText.Text = status;
+            OnboardingModelText.Text = status;
+        }
+    }
 
     public void SetCloudPolishNotice(string? notice)
     {
@@ -69,5 +165,721 @@ public sealed partial class MainWindow : Window
         LivePreviewText.Visibility = string.IsNullOrWhiteSpace(text)
             ? Visibility.Collapsed
             : Visibility.Visible;
+        _overlayWindow.SetPreview(text);
+    }
+
+    public async Task NotifyHistoryChangedAsync() => await ReloadHistoryAsync().ConfigureAwait(true);
+
+    public void OpenSettings()
+    {
+        ShowOnboarding(show: false);
+        ProductNavigation.SelectedItem = SettingsNavItem;
+        ShowPage("settings");
+    }
+
+    public void ShutdownProductWindows() => _overlayWindow.Shutdown();
+
+    private async void FinishOnboardingButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_settings.HasCompletedOnboarding)
+        {
+            ShowOnboarding(show: false);
+            return;
+        }
+
+        var next = _settings with { HasCompletedOnboarding = true };
+        if (await TrySaveAsync(next, "Setup complete", "Your choices were saved on this PC.").ConfigureAwait(true))
+        {
+            ShowOnboarding(show: false);
+            ProductNavigation.SelectedItem = HomeNavItem;
+            HomeNavItem.Focus(FocusState.Programmatic);
+        }
+    }
+
+    private void ProductNavigation_SelectionChanged(
+        NavigationView sender,
+        NavigationViewSelectionChangedEventArgs args)
+    {
+        var tag = (args.SelectedItemContainer as NavigationViewItem)?.Tag?.ToString() ?? "home";
+        ShowPage(tag);
+    }
+
+    private void OpenHistoryButton_Click(object sender, RoutedEventArgs e)
+    {
+        var historyItem = ProductNavigation.MenuItems
+            .OfType<NavigationViewItem>()
+            .First(item => string.Equals(item.Tag?.ToString(), "history", StringComparison.Ordinal));
+        ProductNavigation.SelectedItem = historyItem;
+    }
+
+    private async void SaveSettingsButton_Click(object sender, RoutedEventArgs e)
+    {
+        var parsedHotkey = HotkeyGestureParser.Parse(HotkeyTextBox.Text);
+        if (!parsedHotkey.Succeeded)
+        {
+            ShowMessage("Shortcut needs attention", "Use a supported key such as F8 or Ctrl+F8.", InfoBarSeverity.Error);
+            HotkeyTextBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        var dictation = new DictationPreferences(
+            (FinalAsrEngine)Math.Clamp(EngineComboBox.SelectedIndex, 0, 2),
+            parsedHotkey.Gesture!.Value.ToString(),
+            WordCorrectionToggle.IsOn,
+            FillerRemovalToggle.IsOn,
+            EmojiFormatterToggle.IsOn,
+            SpokenPunctuationToggle.IsOn);
+        var polish = new PolishPreferences(
+            PolishProviderFromIndex(PolishProviderComboBox.SelectedIndex),
+            NullIfBlank(PolishModelTextBox.Text),
+            NullIfBlank(OllamaEndpointTextBox.Text));
+        var history = new HistoryPreferences(
+            HistoryEnabledToggle.IsOn,
+            (int)Math.Clamp(double.IsNaN(RetentionDaysBox.Value) ? 30 : RetentionDaysBox.Value, 0, 3650));
+        var theme = ThemeFromIndex(ThemeComboBox.SelectedIndex);
+        var microphoneId = (MicrophoneComboBox.SelectedItem as MicrophoneChoice)?.Id;
+        var next = _settings with
+        {
+            PreferredMicrophoneId = microphoneId,
+            Preferences = new UserPreferences(dictation, polish, history, theme),
+        };
+
+        if (await TrySaveAsync(
+                next,
+                "Settings saved",
+                "Theme and local data choices apply now. Engine, microphone, shortcut, and polish changes apply safely on the next launch.")
+            .ConfigureAwait(true))
+        {
+            ApplyTheme(theme);
+        }
+    }
+
+    private void ThemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!_isApplyingSettings)
+        {
+            ApplyTheme(ThemeFromIndex(ThemeComboBox.SelectedIndex));
+        }
+    }
+
+    private void PolishProviderComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isApplyingSettings)
+        {
+            return;
+        }
+
+        ApiKeyPasswordBox.Password = string.Empty;
+        RefreshApiKeyStatus();
+    }
+
+    private void SaveApiKeyButton_Click(object sender, RoutedEventArgs e)
+    {
+        var provider = PolishProviderFromIndex(PolishProviderComboBox.SelectedIndex);
+        if (!IsCloudProvider(provider))
+        {
+            ShowMessage(
+                "No cloud key needed",
+                "Choose OpenAI, Anthropic, or Gemini before storing a provider key.",
+                InfoBarSeverity.Informational);
+            return;
+        }
+
+        var value = ApiKeyPasswordBox.Password.Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            ShowMessage("Enter an API key", "The key field is empty.", InfoBarSeverity.Warning);
+            ApiKeyPasswordBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        try
+        {
+            _apiKeyStore.Store(provider, value);
+            ApiKeyPasswordBox.Password = string.Empty;
+            RefreshApiKeyStatus();
+            ShowMessage(
+                $"{ProviderDisplayName(provider)} key saved",
+                "The key is stored in Windows Credential Manager. It is not part of settings, profiles, history, or diagnostics.",
+                InfoBarSeverity.Success);
+        }
+        catch (Exception exception) when (IsCredentialStorageFailure(exception))
+        {
+            ApiKeyPasswordBox.Password = string.Empty;
+            RefreshApiKeyStatus();
+            ShowMessage(
+                "API key was not saved",
+                "Windows Credential Manager is unavailable. No key was written to settings or exports.",
+                InfoBarSeverity.Error);
+        }
+    }
+
+    private async void RemoveApiKeyButton_Click(object sender, RoutedEventArgs e)
+    {
+        var provider = PolishProviderFromIndex(PolishProviderComboBox.SelectedIndex);
+        if (!IsCloudProvider(provider))
+        {
+            return;
+        }
+
+        if (_apiKeyStore.GetStatus(provider) == ApiKeyReadStatus.Missing)
+        {
+            RefreshApiKeyStatus();
+            ShowMessage(
+                "No stored key to remove",
+                $"No {ProviderDisplayName(provider)} key is stored for EnviousWispr in Windows Credential Manager.",
+                InfoBarSeverity.Informational);
+            return;
+        }
+
+        var dialog = new ContentDialog
+        {
+            XamlRoot = WindowRoot.XamlRoot,
+            Title = $"Remove the stored {ProviderDisplayName(provider)} key?",
+            Content = "This deletes the EnviousWispr credential from Windows Credential Manager. Settings, history, dictionary entries, and snippets are not affected.",
+            PrimaryButtonText = "Remove key",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+        };
+        if (await dialog.ShowAsync() != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        try
+        {
+            _apiKeyStore.Delete(provider);
+            ApiKeyPasswordBox.Password = string.Empty;
+            RefreshApiKeyStatus();
+            ShowMessage(
+                $"{ProviderDisplayName(provider)} key removed",
+                "The stored credential was removed from Windows Credential Manager.",
+                InfoBarSeverity.Success);
+        }
+        catch (Exception exception) when (IsCredentialStorageFailure(exception))
+        {
+            RefreshApiKeyStatus();
+            ShowMessage(
+                "API key could not be removed",
+                "Windows Credential Manager is unavailable. Existing settings were not changed.",
+                InfoBarSeverity.Error);
+        }
+    }
+
+    private async void OpenMicrophonePrivacyButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var opened = await Windows.System.Launcher.LaunchUriAsync(
+                new Uri("ms-settings:privacy-microphone"));
+            if (!opened)
+            {
+                ShowMessage(
+                    "Microphone privacy settings did not open",
+                    "Open Windows Settings, then choose Privacy & security > Microphone.",
+                    InfoBarSeverity.Warning);
+            }
+        }
+        catch
+        {
+            ShowMessage(
+                "Microphone privacy settings did not open",
+                "Open Windows Settings, then choose Privacy & security > Microphone.",
+                InfoBarSeverity.Warning);
+        }
+    }
+
+    private async void AddWordButton_Click(object sender, RoutedEventArgs e)
+    {
+        var spoken = SpokenFormBox.Text.Trim();
+        var replacement = ReplacementBox.Text.Trim();
+        if (string.IsNullOrWhiteSpace(spoken) || string.IsNullOrWhiteSpace(replacement))
+        {
+            ShowMessage("Both fields are required", "Enter the spoken form and the exact replacement.", InfoBarSeverity.Warning);
+            return;
+        }
+
+        var words = _settings.UserData.CustomWords
+            .Where(entry => !string.Equals(entry.SpokenForm, spoken, StringComparison.OrdinalIgnoreCase))
+            .Append(new CustomWordEntry(spoken, replacement))
+            .OrderBy(entry => entry.SpokenForm, StringComparer.CurrentCultureIgnoreCase)
+            .ToArray();
+        await SaveUserDataAsync(new ReusableUserData(words, _settings.UserData.Snippets), "Dictionary saved").ConfigureAwait(true);
+        SpokenFormBox.Text = string.Empty;
+        ReplacementBox.Text = string.Empty;
+    }
+
+    private async void RemoveWordButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (DictionaryList.SelectedItem is not CustomWordEntry selected)
+        {
+            ShowMessage("Select a word first", "Choose the dictionary row you want to remove.", InfoBarSeverity.Informational);
+            return;
+        }
+
+        var words = _settings.UserData.CustomWords.Where(entry => entry != selected).ToArray();
+        await SaveUserDataAsync(new ReusableUserData(words, _settings.UserData.Snippets), "Dictionary entry removed").ConfigureAwait(true);
+    }
+
+    private async void AddSnippetButton_Click(object sender, RoutedEventArgs e)
+    {
+        var name = SnippetNameBox.Text.Trim();
+        var body = SnippetBodyBox.Text;
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(body))
+        {
+            ShowMessage("Name and text are required", "Give this snippet a name and some reusable text.", InfoBarSeverity.Warning);
+            return;
+        }
+
+        var snippets = _settings.UserData.Snippets
+            .Where(entry => !string.Equals(entry.Name, name, StringComparison.OrdinalIgnoreCase))
+            .Append(new SnippetEntry(name, body))
+            .OrderBy(entry => entry.Name, StringComparer.CurrentCultureIgnoreCase)
+            .ToArray();
+        await SaveUserDataAsync(new ReusableUserData(_settings.UserData.CustomWords, snippets), "Snippet saved").ConfigureAwait(true);
+        SnippetNameBox.Text = string.Empty;
+        SnippetBodyBox.Text = string.Empty;
+    }
+
+    private async void RemoveSnippetButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (SnippetList.SelectedItem is not SnippetEntry selected)
+        {
+            ShowMessage("Select a snippet first", "Choose the snippet you want to remove.", InfoBarSeverity.Informational);
+            return;
+        }
+
+        var snippets = _settings.UserData.Snippets.Where(entry => entry != selected).ToArray();
+        await SaveUserDataAsync(new ReusableUserData(_settings.UserData.CustomWords, snippets), "Snippet removed").ConfigureAwait(true);
+    }
+
+    private void HistorySearchBox_TextChanged(object sender, TextChangedEventArgs e) => RefreshHistoryView();
+
+    private void CopyHistoryButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (HistoryList.SelectedItem is not HistoryItemViewModel selected)
+        {
+            ShowMessage("Select a dictation first", "Choose the history entry you want to copy.", InfoBarSeverity.Informational);
+            return;
+        }
+
+        var package = new DataPackage();
+        package.SetText(selected.Text);
+        Clipboard.SetContent(package);
+        Clipboard.Flush();
+        ShowMessage("Copied", "The selected dictation is on your clipboard.", InfoBarSeverity.Success);
+    }
+
+    private async void DeleteHistoryButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (HistoryList.SelectedItem is not HistoryItemViewModel selected)
+        {
+            ShowMessage("Select a dictation first", "Choose the history entry you want to delete.", InfoBarSeverity.Informational);
+            return;
+        }
+
+        var result = await _historyStore.DeleteAsync(selected.Id).ConfigureAwait(true);
+        if (result.Succeeded)
+        {
+            await ReloadHistoryAsync().ConfigureAwait(true);
+            ShowMessage("History entry deleted", "The local copy was removed.", InfoBarSeverity.Success);
+        }
+        else
+        {
+            ShowMessage("History could not be changed", "The private history file was left untouched.", InfoBarSeverity.Error);
+        }
+    }
+
+    private async void ClearHistoryButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ContentDialog
+        {
+            XamlRoot = WindowRoot.XamlRoot,
+            Title = "Delete all dictation history?",
+            Content = "This permanently removes every locally saved transcript. Settings, dictionary entries, and snippets are not affected.",
+            PrimaryButtonText = "Delete all",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+        };
+        if (await dialog.ShowAsync() != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        var result = await _historyStore.ClearAsync().ConfigureAwait(true);
+        if (result.Succeeded)
+        {
+            await ReloadHistoryAsync().ConfigureAwait(true);
+            ShowMessage("History cleared", "All locally saved dictations were removed.", InfoBarSeverity.Success);
+        }
+        else
+        {
+            ShowMessage("History could not be cleared", "The private history file was left untouched.", InfoBarSeverity.Error);
+        }
+    }
+
+    private async void ExportProfileButton_Click(object sender, RoutedEventArgs e)
+    {
+        var picker = new FileSavePicker
+        {
+            SuggestedFileName = "EnviousWispr-profile",
+            DefaultFileExtension = ".json",
+        };
+        picker.FileTypeChoices.Add("EnviousWispr profile", [".json"]);
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, WinRT.Interop.WindowNative.GetWindowHandle(this));
+        var file = await picker.PickSaveFileAsync();
+        if (file is null)
+        {
+            return;
+        }
+
+        var result = await _profileService.ExportAsync(_settings.ToPortableProfile(), file.Path).ConfigureAwait(true);
+        ShowMessage(
+            result.Succeeded ? "Profile exported" : "Profile export failed safely",
+            result.Succeeded ? "Settings, dictionary entries, and snippets were written without private machine data." : "No existing destination data was intentionally replaced with an invalid profile.",
+            result.Succeeded ? InfoBarSeverity.Success : InfoBarSeverity.Error);
+    }
+
+    private async void ImportProfileButton_Click(object sender, RoutedEventArgs e)
+    {
+        var picker = new FileOpenPicker();
+        picker.FileTypeFilter.Add(".json");
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, WinRT.Interop.WindowNative.GetWindowHandle(this));
+        var file = await picker.PickSingleFileAsync();
+        if (file is null)
+        {
+            return;
+        }
+
+        var imported = await _profileService.ImportAsync(file.Path).ConfigureAwait(true);
+        if (imported.Status != PortableProfileImportStatus.Imported || imported.Profile is null)
+        {
+            ShowMessage("Profile not imported", ImportFailureMessage(imported.Status), InfoBarSeverity.Error);
+            return;
+        }
+
+        var next = _settings.Apply(imported.Profile);
+        if (await TrySaveAsync(next, "Profile imported", "Settings, dictionary entries, and snippets are ready. Machine-local choices and history were preserved.").ConfigureAwait(true))
+        {
+            ApplySettingsToControls();
+        }
+    }
+
+    private async Task LoadMicrophonesAsync()
+    {
+        try
+        {
+            using var catalog = new WasapiDeviceCatalog();
+            var devices = await catalog.GetCaptureDevicesAsync().ConfigureAwait(true);
+            _microphones = [
+                new MicrophoneChoice(null, "Use the Windows default microphone"),
+                .. devices.Select(device => new MicrophoneChoice(
+                    device.Id.Value,
+                    device.IsDefault ? $"{device.DisplayName} (Windows default)" : device.DisplayName)),
+            ];
+            MicrophoneComboBox.ItemsSource = _microphones;
+            var selected = _microphones.FirstOrDefault(choice =>
+                string.Equals(choice.Id, _settings.PreferredMicrophoneId, StringComparison.Ordinal)) ?? _microphones[0];
+            MicrophoneComboBox.SelectedItem = selected;
+            var defaultDevice = devices.FirstOrDefault(device => device.IsDefault) ??
+                (devices.Count == 0 ? null : devices[0]);
+            var status = defaultDevice is null
+                ? "No active recording device found. Windows microphone privacy or device settings may need attention."
+                : $"{defaultDevice.DisplayName} is available.";
+            MicrophoneReadinessText.Text = status;
+            OnboardingMicrophoneText.Text = status;
+        }
+        catch
+        {
+            _microphones = [new MicrophoneChoice(null, "Use the Windows default microphone")];
+            MicrophoneComboBox.ItemsSource = _microphones;
+            MicrophoneComboBox.SelectedIndex = 0;
+            const string status = "Windows could not enumerate microphones. Settings remain available and dictation will fail safely.";
+            MicrophoneReadinessText.Text = status;
+            OnboardingMicrophoneText.Text = status;
+        }
+    }
+
+    private async Task ReloadHistoryAsync()
+    {
+        var result = await _historyStore.LoadAsync(
+            _settings.Preferences.History.RetentionDays,
+            DateTimeOffset.UtcNow).ConfigureAwait(true);
+        _history.Clear();
+        _history.AddRange(result.Entries.Select(entry => new HistoryItemViewModel(entry)));
+        RefreshHistoryView();
+        HistorySummaryText.Text = result.Status switch
+        {
+            HistoryLoadStatus.Invalid => "History is unavailable because its local file is invalid; the source was preserved for recovery.",
+            HistoryLoadStatus.Unavailable => "Windows could not open the private history file.",
+            _ when !_settings.Preferences.History.IsEnabled => "History is off. New dictations will not be saved.",
+            _ when _history.Count == 0 => "No dictations saved yet.",
+            _ => $"{_history.Count.ToString(CultureInfo.CurrentCulture)} local dictation{(_history.Count == 1 ? string.Empty : "s")} saved.",
+        };
+    }
+
+    private void RefreshHistoryView()
+    {
+        var query = HistorySearchBox.Text.Trim();
+        HistoryList.ItemsSource = string.IsNullOrWhiteSpace(query)
+            ? _history.ToArray()
+            : _history.Where(item => item.Text.Contains(query, StringComparison.CurrentCultureIgnoreCase)).ToArray();
+    }
+
+    private async Task SaveUserDataAsync(ReusableUserData userData, string title)
+    {
+        if (await TrySaveAsync(_settings with { UserData = userData }, title, "The change was saved locally.").ConfigureAwait(true))
+        {
+            DictionaryList.ItemsSource = _settings.UserData.CustomWords;
+            SnippetList.ItemsSource = _settings.UserData.Snippets;
+        }
+    }
+
+    private async Task<bool> TrySaveAsync(AppSettings next, string title, string message)
+    {
+        try
+        {
+            await _settingsStore.SaveAsync(next).ConfigureAwait(true);
+            _settings = next;
+            SettingsChanged?.Invoke(next);
+            ApplySettingsToControls();
+            ShowMessage(title, message, InfoBarSeverity.Success);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            ShowMessage("Settings were not saved", "One or more values are invalid. Your previous settings remain active.", InfoBarSeverity.Error);
+        }
+        catch (IOException)
+        {
+            ShowMessage("Settings storage is unavailable", "Your previous settings remain active.", InfoBarSeverity.Error);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            ShowMessage("Windows blocked settings storage", "Your previous settings remain active.", InfoBarSeverity.Error);
+        }
+
+        return false;
+    }
+
+    private void ApplySettingsToControls()
+    {
+        _isApplyingSettings = true;
+        try
+        {
+            var preferences = _settings.Preferences;
+            EngineComboBox.SelectedIndex = (int)preferences.Dictation.FinalEngine;
+            HotkeyTextBox.Text = preferences.Dictation.PushToTalkGesture;
+            WordCorrectionToggle.IsOn = preferences.Dictation.WordCorrectionEnabled;
+            FillerRemovalToggle.IsOn = preferences.Dictation.FillerRemovalEnabled;
+            EmojiFormatterToggle.IsOn = preferences.Dictation.EmojiFormatterEnabled;
+            SpokenPunctuationToggle.IsOn = preferences.Dictation.SpokenPunctuationEnabled;
+            PolishProviderComboBox.SelectedIndex = PolishProviderIndex(preferences.Polish.Provider);
+            PolishModelTextBox.Text = preferences.Polish.ModelId ?? string.Empty;
+            OllamaEndpointTextBox.Text = preferences.Polish.OllamaEndpoint ?? string.Empty;
+            HistoryEnabledToggle.IsOn = preferences.History.IsEnabled;
+            RetentionDaysBox.Value = preferences.History.RetentionDays;
+            ThemeComboBox.SelectedIndex = ThemeIndex(preferences.Theme);
+            DictionaryList.ItemsSource = _settings.UserData.CustomWords;
+            SnippetList.ItemsSource = _settings.UserData.Snippets;
+        }
+        finally
+        {
+            _isApplyingSettings = false;
+        }
+
+        ApiKeyPasswordBox.Password = string.Empty;
+        RefreshApiKeyStatus();
+    }
+
+    private void RefreshApiKeyStatus()
+    {
+        var provider = PolishProviderFromIndex(PolishProviderComboBox.SelectedIndex);
+        var isCloudProvider = IsCloudProvider(provider);
+        ApiKeyPasswordBox.IsEnabled = isCloudProvider;
+        SaveApiKeyButton.IsEnabled = isCloudProvider;
+        RemoveApiKeyButton.IsEnabled = isCloudProvider;
+        ApiKeyPasswordBox.PlaceholderText = isCloudProvider
+            ? $"Enter {ProviderDisplayName(provider)} API key"
+            : "Choose a direct cloud provider to manage its key";
+
+        if (!isCloudProvider)
+        {
+            ApiKeyStatusText.Text = provider switch
+            {
+                PolishProvider.Ollama => "Ollama runs on this PC and does not use a cloud API key.",
+                PolishProvider.EgOne => "EG-1 runs on this PC and does not use a cloud API key.",
+                _ => "AI polish is off; no provider key is used.",
+            };
+            return;
+        }
+
+        ApiKeyStatusText.Text = _apiKeyStore.GetStatus(provider) switch
+        {
+            ApiKeyReadStatus.Found =>
+                $"{CredentialArticle(provider)} {ProviderDisplayName(provider)} key is stored in Windows Credential Manager.",
+            ApiKeyReadStatus.Missing =>
+                $"No {ProviderDisplayName(provider)} key is stored on this PC.",
+            _ => "Windows Credential Manager status is unavailable. No key value was revealed.",
+        };
+    }
+
+    private void ShowOnboarding(bool show)
+    {
+        OnboardingView.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+        ProductNavigation.Visibility = show ? Visibility.Collapsed : Visibility.Visible;
+        if (show)
+        {
+            FinishOnboardingButton.Focus(FocusState.Programmatic);
+        }
+    }
+
+    private void ShowPage(string tag)
+    {
+        HomePage.Visibility = tag == "home" ? Visibility.Visible : Visibility.Collapsed;
+        HistoryPage.Visibility = tag == "history" ? Visibility.Visible : Visibility.Collapsed;
+        DictionaryPage.Visibility = tag == "dictionary" ? Visibility.Visible : Visibility.Collapsed;
+        SnippetsPage.Visibility = tag == "snippets" ? Visibility.Visible : Visibility.Collapsed;
+        SettingsPage.Visibility = tag == "settings" ? Visibility.Visible : Visibility.Collapsed;
+        HelpPage.Visibility = tag == "help" ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void ShowMessage(string title, string message, InfoBarSeverity severity)
+    {
+        OperationInfoBar.Title = title;
+        OperationInfoBar.Message = message;
+        OperationInfoBar.Severity = severity;
+        OperationInfoBar.IsOpen = true;
+    }
+
+    private void ApplyTheme(AppTheme theme) => WindowRoot.RequestedTheme = theme switch
+    {
+        AppTheme.Light => ElementTheme.Light,
+        AppTheme.Dark => ElementTheme.Dark,
+        _ => ElementTheme.Default,
+    };
+
+    private static AppTheme ThemeFromIndex(int index) => index switch
+    {
+        1 => AppTheme.Light,
+        2 => AppTheme.Dark,
+        _ => AppTheme.System,
+    };
+
+    private static int ThemeIndex(AppTheme theme) => theme switch
+    {
+        AppTheme.Light => 1,
+        AppTheme.Dark => 2,
+        _ => 0,
+    };
+
+    private static PolishProvider PolishProviderFromIndex(int index) => index switch
+    {
+        1 => PolishProvider.EgOne,
+        2 => PolishProvider.Ollama,
+        3 => PolishProvider.OpenAI,
+        4 => PolishProvider.Anthropic,
+        5 => PolishProvider.Gemini,
+        _ => PolishProvider.None,
+    };
+
+    private static bool IsCloudProvider(PolishProvider provider) =>
+        provider is PolishProvider.OpenAI or PolishProvider.Anthropic or PolishProvider.Gemini;
+
+    private static string ProviderDisplayName(PolishProvider provider) => provider switch
+    {
+        PolishProvider.OpenAI => "OpenAI",
+        PolishProvider.Anthropic => "Anthropic",
+        PolishProvider.Gemini => "Gemini",
+        _ => provider.ToString(),
+    };
+
+    private static string CredentialArticle(PolishProvider provider) => provider is
+        PolishProvider.OpenAI or PolishProvider.Anthropic
+            ? "An"
+            : "A";
+
+    private static bool IsCredentialStorageFailure(Exception exception) => exception is
+        Win32Exception or
+        UnauthorizedAccessException or
+        SecurityException or
+        ArgumentException;
+
+    private static int PolishProviderIndex(PolishProvider provider) => provider switch
+    {
+        PolishProvider.EgOne => 1,
+        PolishProvider.Ollama => 2,
+        PolishProvider.OpenAI => 3,
+        PolishProvider.Anthropic => 4,
+        PolishProvider.Gemini => 5,
+        _ => 0,
+    };
+
+    private static string? NullIfBlank(string text) => string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+
+    private static string ImportFailureMessage(PortableProfileImportStatus status) => status switch
+    {
+        PortableProfileImportStatus.NewerVersion => "This profile was created by a newer EnviousWispr version. The file was left untouched.",
+        PortableProfileImportStatus.Invalid => "This is not a valid EnviousWispr portable profile. The file and current settings were left untouched.",
+        _ => "Windows could not read this profile. The file and current settings were left untouched.",
+    };
+
+    private static DictationOverlayState OverlayStateFor(string status)
+    {
+        if (status.StartsWith("Recording", StringComparison.OrdinalIgnoreCase))
+        {
+            return DictationOverlayState.Recording;
+        }
+
+        if (status.StartsWith("Transcribing", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Delivering", StringComparison.OrdinalIgnoreCase))
+        {
+            return DictationOverlayState.Processing;
+        }
+
+        if (status.Contains("copied only", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Copied", StringComparison.OrdinalIgnoreCase) ||
+            status.Contains("held safely", StringComparison.OrdinalIgnoreCase))
+        {
+            return DictationOverlayState.Warning;
+        }
+
+        if (status.StartsWith("Local transcription failed", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Session failed", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Text delivery stopped", StringComparison.OrdinalIgnoreCase))
+        {
+            return DictationOverlayState.Error;
+        }
+
+        if (status.StartsWith("Inserted", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Pasted", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Transcribed", StringComparison.OrdinalIgnoreCase) ||
+            status.StartsWith("Cleaned", StringComparison.OrdinalIgnoreCase))
+        {
+            return DictationOverlayState.Success;
+        }
+
+        return DictationOverlayState.Hidden;
+    }
+
+    private sealed record MicrophoneChoice(string? Id, string DisplayName);
+
+    private sealed class HistoryItemViewModel
+    {
+        public HistoryItemViewModel(DictationHistoryEntry entry)
+        {
+            Id = entry.Id;
+            Text = entry.Text;
+            CreatedDisplay = entry.CreatedAt.ToLocalTime().ToString("f", CultureInfo.CurrentCulture);
+            Details = $"{entry.EngineId} · {(entry.WasPolished ? "AI polished" : "deterministic cleanup")} · {(entry.WasDelivered ? "delivered" : "held safely")}";
+        }
+
+        public Guid Id { get; }
+
+        public string Text { get; }
+
+        public string CreatedDisplay { get; }
+
+        public string Details { get; }
     }
 }

--- a/src/Production/EnviousWispr.App/Strings/en-US/Resources.resw
+++ b/src/Production/EnviousWispr.App/Strings/en-US/Resources.resw
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata"><xsd:complexType><xsd:sequence><xsd:element name="value" type="xsd:string" minOccurs="0" /></xsd:sequence><xsd:attribute name="name" use="required" type="xsd:string" /><xsd:attribute name="type" type="xsd:string" /><xsd:attribute name="mimetype" type="xsd:string" /><xsd:attribute ref="xml:space" /></xsd:complexType></xsd:element>
+          <xsd:element name="assembly"><xsd:complexType><xsd:attribute name="alias" type="xsd:string" /><xsd:attribute name="name" type="xsd:string" /></xsd:complexType></xsd:element>
+          <xsd:element name="data"><xsd:complexType><xsd:sequence><xsd:element name="value" type="xsd:string" minOccurs="0" /><xsd:element name="comment" type="xsd:string" minOccurs="0" /></xsd:sequence><xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" /><xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" /><xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" /><xsd:attribute ref="xml:space" /></xsd:complexType></xsd:element>
+          <xsd:element name="resheader"><xsd:complexType><xsd:sequence><xsd:element name="value" type="xsd:string" minOccurs="0" /></xsd:sequence><xsd:attribute name="name" type="xsd:string" use="required" /></xsd:complexType></xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="OnboardingTitle.Text" xml:space="preserve"><value>Your voice, instantly captured.</value></data>
+  <data name="FinishOnboardingButton.Content" xml:space="preserve"><value>Get started</value></data>
+  <data name="FinishOnboardingButton.AccessKey" xml:space="preserve"><value>G</value></data>
+  <data name="HomeNavItem.Content" xml:space="preserve"><value>Home</value></data>
+  <data name="HomeNavItem.AccessKey" xml:space="preserve"><value>M</value></data>
+  <data name="HistoryNavItem.Content" xml:space="preserve"><value>History</value></data>
+  <data name="HistoryNavItem.AccessKey" xml:space="preserve"><value>Y</value></data>
+  <data name="DictionaryNavItem.Content" xml:space="preserve"><value>Dictionary</value></data>
+  <data name="DictionaryNavItem.AccessKey" xml:space="preserve"><value>D</value></data>
+  <data name="SnippetsNavItem.Content" xml:space="preserve"><value>Snippets</value></data>
+  <data name="SnippetsNavItem.AccessKey" xml:space="preserve"><value>S</value></data>
+  <data name="HelpNavItem.Content" xml:space="preserve"><value>Help and privacy</value></data>
+  <data name="HelpNavItem.AccessKey" xml:space="preserve"><value>P</value></data>
+  <data name="SettingsNavItem.Content" xml:space="preserve"><value>Settings</value></data>
+  <data name="SettingsNavItem.AccessKey" xml:space="preserve"><value>T</value></data>
+  <data name="HomeTitle.Text" xml:space="preserve"><value>Speak naturally. Keep working.</value></data>
+</root>

--- a/src/Production/EnviousWispr.Architecture.Tests/JsonHistoryStoreTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/JsonHistoryStoreTests.cs
@@ -1,0 +1,97 @@
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.History;
+using EnviousWispr.Services.History;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class JsonHistoryStoreTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task AddLoadDeleteAndClearRoundTripLocalEntries()
+    {
+        await JsonSettingsStoreTests.WithTestDirectoryAsync(async directory =>
+        {
+            var store = new JsonHistoryStore(Path.Combine(directory, "history.json"));
+            var first = CreateEntry(Now.AddMinutes(-2), "first local transcript");
+            var second = CreateEntry(Now.AddMinutes(-1), "second local transcript");
+
+            Assert.True((await store.AddAsync(first, 30, Now)).Succeeded);
+            Assert.True((await store.AddAsync(second, 30, Now)).Succeeded);
+
+            var loaded = await store.LoadAsync(30, Now);
+            Assert.Equal(HistoryLoadStatus.Loaded, loaded.Status);
+            Assert.Equal([second.Id, first.Id], loaded.Entries.Select(entry => entry.Id));
+
+            Assert.True((await store.DeleteAsync(second.Id)).Succeeded);
+            Assert.Equal(first.Id, Assert.Single((await store.LoadAsync(30, Now)).Entries).Id);
+
+            Assert.True((await store.ClearAsync()).Succeeded);
+            Assert.Empty((await store.LoadAsync(30, Now)).Entries);
+            Assert.Empty(Directory.GetFiles(directory, "*.tmp"));
+        });
+    }
+
+    [Fact]
+    public async Task LoadPrunesExpiredEntriesAndZeroRetentionKeepsEntries()
+    {
+        await JsonSettingsStoreTests.WithTestDirectoryAsync(async directory =>
+        {
+            var store = new JsonHistoryStore(Path.Combine(directory, "history.json"));
+            var old = CreateEntry(Now.AddDays(-31), "expired local transcript");
+            var recent = CreateEntry(Now.AddDays(-1), "recent local transcript");
+            Assert.True((await store.AddAsync(old, 0, Now)).Succeeded);
+            Assert.True((await store.AddAsync(recent, 0, Now)).Succeeded);
+
+            Assert.Equal(2, (await store.LoadAsync(0, Now)).Entries.Count);
+            Assert.Equal(recent.Id, Assert.Single((await store.LoadAsync(30, Now)).Entries).Id);
+            Assert.Equal(recent.Id, Assert.Single((await store.LoadAsync(0, Now)).Entries).Id);
+        });
+    }
+
+    [Fact]
+    public async Task CorruptHistoryFailsClosedWithoutChangingSource()
+    {
+        await JsonSettingsStoreTests.WithTestDirectoryAsync(async directory =>
+        {
+            var path = Path.Combine(directory, "history.json");
+            const string corrupt = "{not-history";
+            await File.WriteAllTextAsync(path, corrupt);
+            var store = new JsonHistoryStore(path);
+
+            var loaded = await store.LoadAsync(30, Now);
+            var add = await store.AddAsync(CreateEntry(Now, "must not replace corruption"), 30, Now);
+
+            Assert.Equal(HistoryLoadStatus.Invalid, loaded.Status);
+            Assert.Equal(AppErrorCode.InvalidData, loaded.Error?.Code);
+            Assert.False(add.Succeeded);
+            Assert.Equal(corrupt, await File.ReadAllTextAsync(path));
+        });
+    }
+
+    [Fact]
+    public async Task InvalidEntryIsRejectedWithoutCreatingHistory()
+    {
+        await JsonSettingsStoreTests.WithTestDirectoryAsync(async directory =>
+        {
+            var path = Path.Combine(directory, "history.json");
+            var store = new JsonHistoryStore(path);
+            var invalid = CreateEntry(Now, "") with { Id = Guid.Empty };
+
+            var result = await store.AddAsync(invalid, 30, Now);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(AppErrorCode.InvalidData, result.Error?.Code);
+            Assert.False(File.Exists(path));
+        });
+    }
+
+    private static DictationHistoryEntry CreateEntry(DateTimeOffset createdAt, string text) => new(
+        Guid.NewGuid(),
+        createdAt,
+        text,
+        "synthetic-engine",
+        WasPolished: false,
+        WasDelivered: true);
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/JsonSettingsStoreTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/JsonSettingsStoreTests.cs
@@ -169,6 +169,45 @@ public sealed class JsonSettingsStoreTests
     }
 
     [Fact]
+    public async Task LoadMigratesPhaseThirteenSettingsWithMachineLocalMicrophoneDefault()
+    {
+        await WithTestDirectoryAsync(async directory =>
+        {
+            var path = Path.Combine(directory, "settings.json");
+            const string legacyJson =
+                """
+                {
+                  "schemaVersion": 4,
+                  "launchCount": 14,
+                  "hasCompletedOnboarding": true,
+                  "preferences": {
+                    "dictation": {
+                      "finalEngine": "Automatic",
+                      "pushToTalkGesture": "F8",
+                      "wordCorrectionEnabled": true,
+                      "fillerRemovalEnabled": true,
+                      "emojiFormatterEnabled": true,
+                      "spokenPunctuationEnabled": false
+                    },
+                    "polish": { "provider": "None", "modelId": null, "ollamaEndpoint": null },
+                    "history": { "isEnabled": true, "retentionDays": 30 },
+                    "theme": "System"
+                  },
+                  "userData": { "customWords": [], "snippets": [] }
+                }
+                """;
+            await File.WriteAllTextAsync(path, legacyJson);
+
+            var result = await new JsonSettingsStore(path).LoadAsync();
+
+            Assert.Equal(SettingsLoadStatus.Migrated, result.Status);
+            Assert.Equal(4, result.SourceSchemaVersion);
+            Assert.Equal(AppSettings.CurrentSchemaVersion, result.Settings.SchemaVersion);
+            Assert.Null(result.Settings.PreferredMicrophoneId);
+        });
+    }
+
+    [Fact]
     public async Task LoadRejectsFutureSchemaWithoutChangingSource()
     {
         await WithTestDirectoryAsync(async directory =>
@@ -211,6 +250,7 @@ public sealed class JsonSettingsStoreTests
     {
         LaunchCount = 7,
         HasCompletedOnboarding = true,
+        PreferredMicrophoneId = "synthetic-device-id",
         Preferences = UserPreferences.Default with
         {
             Dictation = new DictationPreferences(

--- a/src/Production/EnviousWispr.Architecture.Tests/OverlayPlacementTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/OverlayPlacementTests.cs
@@ -1,0 +1,49 @@
+using EnviousWispr.Core.Presentation;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class OverlayPlacementTests
+{
+    [Theory]
+    [InlineData(0, 0, 2560, 1392, 1090, 1256)]
+    [InlineData(-1920, 0, 0, 1040, -1150, 904)]
+    [InlineData(2560, -180, 4480, 860, 3330, 724)]
+    public void BottomCenterUsesTheTargetMonitorsSignedWorkArea(
+        int left,
+        int top,
+        int right,
+        int bottom,
+        int expectedX,
+        int expectedY)
+    {
+        var position = OverlayPlacement.BottomCenter(
+            new DisplayWorkArea(left, top, right, bottom),
+            overlayWidth: 380,
+            overlayHeight: 108,
+            margin: 28);
+
+        Assert.Equal(new OverlayPosition(expectedX, expectedY), position);
+    }
+
+    [Fact]
+    public void OversizedOverlayStaysInsideTheWorkAreasTopLeftBoundary()
+    {
+        var position = OverlayPlacement.BottomCenter(
+            new DisplayWorkArea(-100, -50, 100, 50),
+            overlayWidth: 380,
+            overlayHeight: 108,
+            margin: 28);
+
+        Assert.Equal(new OverlayPosition(-100, -50), position);
+    }
+
+    [Fact]
+    public void InvalidWorkAreaIsRejected()
+    {
+        Assert.Throws<ArgumentException>(() => OverlayPlacement.BottomCenter(
+            new DisplayWorkArea(0, 0, 0, 100),
+            overlayWidth: 380,
+            overlayHeight: 108,
+            margin: 28));
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/PortableProfileServiceTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/PortableProfileServiceTests.cs
@@ -27,6 +27,7 @@ public sealed class PortableProfileServiceTests
             var propertyNames = DescendantPropertyNames(document.RootElement).ToHashSet(StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain("launchCount", propertyNames);
             Assert.DoesNotContain("hasCompletedOnboarding", propertyNames);
+            Assert.DoesNotContain("preferredMicrophoneId", propertyNames);
             Assert.DoesNotContain("credential", propertyNames);
             Assert.DoesNotContain("apiKey", propertyNames);
             Assert.DoesNotContain("secret", propertyNames);
@@ -132,13 +133,19 @@ public sealed class PortableProfileServiceTests
     [Fact]
     public void ApplyingImportedProfilePreservesMachineLocalLifecycleState()
     {
-        var current = AppSettings.Default with { LaunchCount = 42, HasCompletedOnboarding = true };
+        var current = AppSettings.Default with
+        {
+            LaunchCount = 42,
+            HasCompletedOnboarding = true,
+            PreferredMicrophoneId = "machine-local-microphone",
+        };
         var imported = JsonSettingsStoreTests.CreatePopulatedSettings().ToPortableProfile();
 
         var applied = current.Apply(imported);
 
         Assert.Equal(42, applied.LaunchCount);
         Assert.True(applied.HasCompletedOnboarding);
+        Assert.Equal("machine-local-microphone", applied.PreferredMicrophoneId);
         Assert.Equal(imported.Preferences, applied.Preferences);
         Assert.Equal(imported.UserData, applied.UserData);
     }

--- a/src/Production/EnviousWispr.Architecture.Tests/PushToTalkSessionControllerTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/PushToTalkSessionControllerTests.cs
@@ -31,6 +31,21 @@ public sealed class PushToTalkSessionControllerTests
     }
 
     [Fact]
+    public async Task PressRoutesCaptureToConfiguredMachineLocalMicrophone()
+    {
+        var audio = new FakeAudioCapture();
+        var microphone = new AudioDeviceId("synthetic-microphone");
+        await using var controller = new PushToTalkSessionController(
+            audio,
+            new FakeTargetProvider(101),
+            preferredAudioDevice: microphone);
+
+        await controller.PressAsync();
+
+        Assert.Equal(microphone, audio.LastRequest?.DeviceId);
+    }
+
+    [Fact]
     public async Task EscapeCancellationDeliversNothingAndAllowsReset()
     {
         var audio = new FakeAudioCapture();
@@ -170,6 +185,8 @@ public sealed class PushToTalkSessionControllerTests
 
         public bool Disposed { get; private set; }
 
+        public AudioCaptureRequest? LastRequest { get; private set; }
+
         public Func<DictationSessionId, CapturedAudio>? StopResultFactory { get; init; }
 
         public Task<AudioOperationResult> StartAsync(
@@ -178,6 +195,7 @@ public sealed class PushToTalkSessionControllerTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             StartCount++;
+            LastRequest = request;
             _sessionId = request.SessionId;
             IsCapturing = true;
             return Task.FromResult(new AudioOperationResult(Succeeded: true));

--- a/src/Production/EnviousWispr.Architecture.Tests/WindowsCredentialApiKeyStoreTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/WindowsCredentialApiKeyStoreTests.cs
@@ -14,8 +14,10 @@ public sealed class WindowsCredentialApiKeyStoreTests
         try
         {
             Assert.Equal(ApiKeyReadStatus.Missing, store.Read(PolishProvider.OpenAI).Status);
+            Assert.Equal(ApiKeyReadStatus.Missing, store.GetStatus(PolishProvider.OpenAI));
 
             store.Store(PolishProvider.OpenAI, "first-test-value");
+            Assert.Equal(ApiKeyReadStatus.Found, store.GetStatus(PolishProvider.OpenAI));
             var first = store.Read(PolishProvider.OpenAI);
             Assert.Equal(ApiKeyReadStatus.Found, first.Status);
             Assert.Equal("first-test-value", first.Value);
@@ -28,6 +30,7 @@ public sealed class WindowsCredentialApiKeyStoreTests
             store.Delete(PolishProvider.OpenAI);
             store.Delete(PolishProvider.OpenAI);
             Assert.Equal(ApiKeyReadStatus.Missing, store.Read(PolishProvider.OpenAI).Status);
+            Assert.Equal(ApiKeyReadStatus.Missing, store.GetStatus(PolishProvider.OpenAI));
         }
         finally
         {
@@ -42,7 +45,19 @@ public sealed class WindowsCredentialApiKeyStoreTests
             $"EnviousLabs.EnviousWispr.Tests.{Guid.NewGuid():N}");
 
         Assert.Throws<ArgumentOutOfRangeException>(() => store.Read(PolishProvider.EgOne));
+        Assert.Throws<ArgumentOutOfRangeException>(() => store.GetStatus(PolishProvider.EgOne));
         Assert.Throws<ArgumentOutOfRangeException>(() => store.Store(PolishProvider.None, "value"));
         Assert.Throws<ArgumentOutOfRangeException>(() => store.Delete(PolishProvider.Ollama));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("contains spaces")]
+    [InlineData("contains.period")]
+    [InlineData("contains/slash")]
+    public void IsolatedUatScopeRejectsUnsafeSuffixes(string suffix)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            WindowsCredentialApiKeyStore.CreateForIsolatedUat(suffix));
     }
 }

--- a/src/Production/EnviousWispr.Core/Credentials/IApiKeyStore.cs
+++ b/src/Production/EnviousWispr.Core/Credentials/IApiKeyStore.cs
@@ -22,6 +22,8 @@ public interface IApiKeyStore
 {
     ApiKeyReadResult Read(PolishProvider provider);
 
+    ApiKeyReadStatus GetStatus(PolishProvider provider) => Read(provider).Status;
+
     void Store(PolishProvider provider, string value);
 
     void Delete(PolishProvider provider);

--- a/src/Production/EnviousWispr.Core/Errors/AppError.cs
+++ b/src/Production/EnviousWispr.Core/Errors/AppError.cs
@@ -57,6 +57,8 @@ public enum AppErrorStage
     SettingsReset,
     ProfileImport,
     ProfileExport,
+    HistoryLoad,
+    HistorySave,
     AudioDeviceEnumeration,
     AudioCapture,
     HotkeyConfiguration,

--- a/src/Production/EnviousWispr.Core/History/HistoryContracts.cs
+++ b/src/Production/EnviousWispr.Core/History/HistoryContracts.cs
@@ -1,0 +1,70 @@
+using EnviousWispr.Core.Errors;
+
+namespace EnviousWispr.Core.History;
+
+public sealed record DictationHistoryEntry(
+    Guid Id,
+    DateTimeOffset CreatedAt,
+    string Text,
+    string EngineId,
+    bool WasPolished,
+    bool WasDelivered)
+{
+    public const int MaximumTextLength = 100_000;
+
+    public static DictationHistoryEntry Create(
+        DateTimeOffset createdAt,
+        string text,
+        string engineId,
+        bool wasPolished,
+        bool wasDelivered) => new(
+            Guid.NewGuid(),
+            createdAt,
+            text,
+            engineId,
+            wasPolished,
+            wasDelivered);
+
+    public bool IsValid =>
+        Id != Guid.Empty &&
+        CreatedAt != default &&
+        !string.IsNullOrWhiteSpace(Text) &&
+        Text.Length <= MaximumTextLength &&
+        !string.IsNullOrWhiteSpace(EngineId) &&
+        EngineId.Length <= 256;
+}
+
+public enum HistoryLoadStatus
+{
+    Loaded,
+    Missing,
+    Invalid,
+    Unavailable,
+}
+
+public sealed record HistoryLoadResult(
+    IReadOnlyList<DictationHistoryEntry> Entries,
+    HistoryLoadStatus Status,
+    AppError? Error = null);
+
+public sealed record HistoryOperationResult(bool Succeeded, AppError? Error = null);
+
+public interface IHistoryStore
+{
+    Task<HistoryLoadResult> LoadAsync(
+        int retentionDays,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+
+    Task<HistoryOperationResult> AddAsync(
+        DictationHistoryEntry entry,
+        int retentionDays,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+
+    Task<HistoryOperationResult> DeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+
+    Task<HistoryOperationResult> ClearAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Production/EnviousWispr.Core/Presentation/OverlayPlacement.cs
+++ b/src/Production/EnviousWispr.Core/Presentation/OverlayPlacement.cs
@@ -1,0 +1,33 @@
+namespace EnviousWispr.Core.Presentation;
+
+public readonly record struct DisplayWorkArea(int Left, int Top, int Right, int Bottom)
+{
+    public int Width => Math.Max(0, Right - Left);
+
+    public int Height => Math.Max(0, Bottom - Top);
+}
+
+public readonly record struct OverlayPosition(int X, int Y);
+
+public static class OverlayPlacement
+{
+    public static OverlayPosition BottomCenter(
+        DisplayWorkArea workArea,
+        int overlayWidth,
+        int overlayHeight,
+        int margin)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(overlayWidth);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(overlayHeight);
+        ArgumentOutOfRangeException.ThrowIfNegative(margin);
+        if (workArea.Width == 0 || workArea.Height == 0)
+        {
+            throw new ArgumentException("The display work area must have positive dimensions.", nameof(workArea));
+        }
+
+        var x = workArea.Left + Math.Max(0, (workArea.Width - overlayWidth) / 2);
+        var y = workArea.Bottom - overlayHeight - margin;
+        y = Math.Max(workArea.Top, y);
+        return new OverlayPosition(x, y);
+    }
+}

--- a/src/Production/EnviousWispr.Core/Settings/AppSettings.cs
+++ b/src/Production/EnviousWispr.Core/Settings/AppSettings.cs
@@ -5,16 +5,18 @@ public sealed record AppSettings(
     int LaunchCount,
     bool HasCompletedOnboarding,
     UserPreferences Preferences,
-    ReusableUserData UserData)
+    ReusableUserData UserData,
+    string? PreferredMicrophoneId = null)
 {
-    public const int CurrentSchemaVersion = 4;
+    public const int CurrentSchemaVersion = 5;
 
     public static AppSettings Default { get; } = new(
         CurrentSchemaVersion,
         LaunchCount: 0,
         HasCompletedOnboarding: false,
         UserPreferences.Default,
-        ReusableUserData.Empty);
+        ReusableUserData.Empty,
+        PreferredMicrophoneId: null);
 
     public PortableProfile ToPortableProfile() => new(
         PortableProfile.CurrentSchemaVersion,

--- a/src/Production/EnviousWispr.Core/Settings/AppSettingsValidator.cs
+++ b/src/Production/EnviousWispr.Core/Settings/AppSettingsValidator.cs
@@ -13,6 +13,9 @@ public static class AppSettingsValidator
         if (settings is null ||
             settings.SchemaVersion != AppSettings.CurrentSchemaVersion ||
             settings.LaunchCount is < 0 or int.MaxValue ||
+            (settings.PreferredMicrophoneId is not null &&
+                (string.IsNullOrWhiteSpace(settings.PreferredMicrophoneId) ||
+                 settings.PreferredMicrophoneId.Length > 2_048)) ||
             !IsValid(settings.Preferences) ||
             !IsValid(settings.UserData))
         {

--- a/src/Production/EnviousWispr.Pipeline/PushToTalkSessionController.cs
+++ b/src/Production/EnviousWispr.Pipeline/PushToTalkSessionController.cs
@@ -31,6 +31,7 @@ public sealed class PushToTalkSessionController : IAsyncDisposable
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _minimumHoldDuration;
     private readonly TextDeliveryOptions _deliveryOptions;
+    private readonly AudioDeviceId? _preferredAudioDevice;
     private readonly SemaphoreSlim _gate = new(1, 1);
     private bool _disposed;
 
@@ -39,7 +40,8 @@ public sealed class PushToTalkSessionController : IAsyncDisposable
         IForegroundTargetProvider targetProvider,
         TimeProvider? timeProvider = null,
         TimeSpan? minimumHoldDuration = null,
-        TextDeliveryOptions? deliveryOptions = null)
+        TextDeliveryOptions? deliveryOptions = null,
+        AudioDeviceId? preferredAudioDevice = null)
     {
         ArgumentNullException.ThrowIfNull(audioCapture);
         ArgumentNullException.ThrowIfNull(targetProvider);
@@ -48,6 +50,7 @@ public sealed class PushToTalkSessionController : IAsyncDisposable
         _timeProvider = timeProvider ?? TimeProvider.System;
         _minimumHoldDuration = minimumHoldDuration ?? TimeSpan.FromMilliseconds(100);
         _deliveryOptions = deliveryOptions ?? TextDeliveryOptions.Default;
+        _preferredAudioDevice = preferredAudioDevice;
         ArgumentOutOfRangeException.ThrowIfLessThan(_minimumHoldDuration, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(
             _minimumHoldDuration,
@@ -81,7 +84,7 @@ public sealed class PushToTalkSessionController : IAsyncDisposable
 
             var sessionId = DictationSessionId.Create();
             var started = await _audioCapture
-                .StartAsync(new AudioCaptureRequest(sessionId), cancellationToken)
+                .StartAsync(new AudioCaptureRequest(sessionId, _preferredAudioDevice), cancellationToken)
                 .ConfigureAwait(false);
             if (!started.Succeeded)
             {

--- a/src/Production/EnviousWispr.Services/Credentials/WindowsCredentialApiKeyStore.cs
+++ b/src/Production/EnviousWispr.Services/Credentials/WindowsCredentialApiKeyStore.cs
@@ -20,6 +20,19 @@ public sealed class WindowsCredentialApiKeyStore : IApiKeyStore
     {
     }
 
+    public static WindowsCredentialApiKeyStore CreateForIsolatedUat(string suffix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
+        if (suffix.Length > 64 || suffix.Any(character => !char.IsAsciiLetterOrDigit(character) && character != '-'))
+        {
+            throw new ArgumentException(
+                "The isolated UAT credential suffix must contain only ASCII letters, digits, or hyphens.",
+                nameof(suffix));
+        }
+
+        return new WindowsCredentialApiKeyStore($"{ProductionTargetPrefix}.Uat.{suffix}");
+    }
+
     internal WindowsCredentialApiKeyStore(string targetPrefix)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(targetPrefix);
@@ -49,6 +62,29 @@ public sealed class WindowsCredentialApiKeyStore : IApiKeyStore
             return string.IsNullOrWhiteSpace(value)
                 ? ApiKeyReadResult.Unavailable
                 : ApiKeyReadResult.Found(value);
+        }
+        finally
+        {
+            CredFree(nativeCredential);
+        }
+    }
+
+    public ApiKeyReadStatus GetStatus(PolishProvider provider)
+    {
+        var targetName = TargetName(provider);
+        if (!CredRead(targetName, CredTypeGeneric, 0, out var nativeCredential))
+        {
+            return Marshal.GetLastWin32Error() == ErrorNotFound
+                ? ApiKeyReadStatus.Missing
+                : ApiKeyReadStatus.Unavailable;
+        }
+
+        try
+        {
+            var credential = Marshal.PtrToStructure<Credential>(nativeCredential);
+            return credential.CredentialBlob != IntPtr.Zero && credential.CredentialBlobSize > 0
+                ? ApiKeyReadStatus.Found
+                : ApiKeyReadStatus.Unavailable;
         }
         finally
         {

--- a/src/Production/EnviousWispr.Services/History/JsonHistoryStore.cs
+++ b/src/Production/EnviousWispr.Services/History/JsonHistoryStore.cs
@@ -1,0 +1,270 @@
+using System.Security;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EnviousWispr.Core.Errors;
+using EnviousWispr.Core.History;
+
+namespace EnviousWispr.Services.History;
+
+public sealed class JsonHistoryStore : IHistoryStore, IDisposable
+{
+    private const int CurrentSchemaVersion = 1;
+    private const int MaximumEntries = 10_000;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly string _historyPath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public JsonHistoryStore(string historyPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(historyPath);
+        _historyPath = Path.GetFullPath(historyPath);
+    }
+
+    public async Task<HistoryLoadResult> LoadAsync(
+        int retentionDays,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRetention(retentionDays);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var loaded = await ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (loaded.Status is not HistoryLoadStatus.Loaded)
+            {
+                return loaded;
+            }
+
+            var retained = Retain(loaded.Entries, retentionDays, now);
+            if (retained.Length != loaded.Entries.Count)
+            {
+                await WriteAsync(retained, cancellationToken).ConfigureAwait(false);
+            }
+
+            return loaded with { Entries = retained };
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<HistoryOperationResult> AddAsync(
+        DictationHistoryEntry entry,
+        int retentionDays,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ValidateRetention(retentionDays);
+        if (!entry.IsValid)
+        {
+            return Failure(AppErrorCode.InvalidData, canRetry: false);
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var loaded = await ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (loaded.Status is HistoryLoadStatus.Invalid or HistoryLoadStatus.Unavailable)
+            {
+                return new HistoryOperationResult(false, loaded.Error);
+            }
+
+            var entries = Retain(loaded.Entries, retentionDays, now)
+                .Where(existing => existing.Id != entry.Id)
+                .Prepend(entry)
+                .OrderByDescending(existing => existing.CreatedAt)
+                .Take(MaximumEntries)
+                .ToArray();
+            await WriteAsync(entries, cancellationToken).ConfigureAwait(false);
+            return new HistoryOperationResult(true);
+        }
+        catch (IOException)
+        {
+            return Failure(AppErrorCode.StorageUnavailable);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Failure(AppErrorCode.AccessDenied);
+        }
+        catch (SecurityException)
+        {
+            return Failure(AppErrorCode.AccessDenied);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public Task<HistoryOperationResult> DeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default) =>
+        MutateAsync(entries => entries.Where(entry => entry.Id != id).ToArray(), cancellationToken);
+
+    public Task<HistoryOperationResult> ClearAsync(CancellationToken cancellationToken = default) =>
+        MutateAsync(_ => Array.Empty<DictationHistoryEntry>(), cancellationToken);
+
+    public void Dispose() => _gate.Dispose();
+
+    private async Task<HistoryOperationResult> MutateAsync(
+        Func<IReadOnlyList<DictationHistoryEntry>, IReadOnlyList<DictationHistoryEntry>> mutation,
+        CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var loaded = await ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (loaded.Status is HistoryLoadStatus.Invalid or HistoryLoadStatus.Unavailable)
+            {
+                return new HistoryOperationResult(false, loaded.Error);
+            }
+
+            await WriteAsync(mutation(loaded.Entries), cancellationToken).ConfigureAwait(false);
+            return new HistoryOperationResult(true);
+        }
+        catch (IOException)
+        {
+            return Failure(AppErrorCode.StorageUnavailable);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Failure(AppErrorCode.AccessDenied);
+        }
+        catch (SecurityException)
+        {
+            return Failure(AppErrorCode.AccessDenied);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<HistoryLoadResult> ReadAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_historyPath))
+        {
+            return new HistoryLoadResult([], HistoryLoadStatus.Missing);
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(_historyPath, cancellationToken).ConfigureAwait(false);
+            var document = JsonSerializer.Deserialize<HistoryDocument>(json, SerializerOptions);
+            if (document is null ||
+                document.SchemaVersion != CurrentSchemaVersion ||
+                document.Entries is null ||
+                document.Entries.Count > MaximumEntries ||
+                document.Entries.Any(entry => entry is null || !entry.IsValid))
+            {
+                return Invalid();
+            }
+
+            return new HistoryLoadResult(
+                document.Entries.OrderByDescending(entry => entry.CreatedAt).ToArray(),
+                HistoryLoadStatus.Loaded);
+        }
+        catch (JsonException)
+        {
+            return Invalid();
+        }
+        catch (IOException)
+        {
+            return Unavailable(AppErrorCode.StorageUnavailable);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Unavailable(AppErrorCode.AccessDenied);
+        }
+        catch (SecurityException)
+        {
+            return Unavailable(AppErrorCode.AccessDenied);
+        }
+    }
+
+    private async Task WriteAsync(
+        IReadOnlyList<DictationHistoryEntry> entries,
+        CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(_historyPath)
+            ?? throw new InvalidOperationException("The history path must have a parent directory.");
+        Directory.CreateDirectory(directory);
+        var temporaryPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(_historyPath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            var json = JsonSerializer.Serialize(
+                new HistoryDocument(CurrentSchemaVersion, entries),
+                SerializerOptions);
+            await File.WriteAllTextAsync(temporaryPath, json, cancellationToken).ConfigureAwait(false);
+            File.Move(temporaryPath, _historyPath, overwrite: true);
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private static DictationHistoryEntry[] Retain(
+        IReadOnlyList<DictationHistoryEntry> entries,
+        int retentionDays,
+        DateTimeOffset now)
+    {
+        if (retentionDays == 0)
+        {
+            return entries.OrderByDescending(entry => entry.CreatedAt).ToArray();
+        }
+
+        var cutoff = now - TimeSpan.FromDays(retentionDays);
+        return entries
+            .Where(entry => entry.CreatedAt >= cutoff)
+            .OrderByDescending(entry => entry.CreatedAt)
+            .ToArray();
+    }
+
+    private static void ValidateRetention(int retentionDays)
+    {
+        if (retentionDays is < 0 or > 3_650)
+        {
+            throw new ArgumentOutOfRangeException(nameof(retentionDays));
+        }
+    }
+
+    private static HistoryLoadResult Invalid() => new(
+        [],
+        HistoryLoadStatus.Invalid,
+        new AppError(AppErrorCode.InvalidData, AppErrorStage.HistoryLoad, CanRetry: false));
+
+    private static HistoryLoadResult Unavailable(AppErrorCode code) => new(
+        [],
+        HistoryLoadStatus.Unavailable,
+        new AppError(code, AppErrorStage.HistoryLoad, CanRetry: true));
+
+    private static HistoryOperationResult Failure(AppErrorCode code, bool canRetry = true) => new(
+        false,
+        new AppError(code, AppErrorStage.HistorySave, canRetry));
+
+    private sealed record HistoryDocument(
+        int SchemaVersion,
+        IReadOnlyList<DictationHistoryEntry> Entries);
+}

--- a/src/Production/EnviousWispr.Services/Lifecycle/WindowsTrayIcon.cs
+++ b/src/Production/EnviousWispr.Services/Lifecycle/WindowsTrayIcon.cs
@@ -1,0 +1,59 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace EnviousWispr.Services.Lifecycle;
+
+public sealed class WindowsTrayIcon : IDisposable
+{
+    private readonly NotifyIcon _notifyIcon;
+    private bool _disposed;
+
+    public WindowsTrayIcon()
+    {
+        var menu = new ContextMenuStrip();
+        menu.Items.Add("Open EnviousWispr", image: null, (_, _) => ShowWindowRequested?.Invoke());
+        menu.Items.Add("Settings", image: null, (_, _) => OpenSettingsRequested?.Invoke());
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add("Exit EnviousWispr", image: null, (_, _) => ExitRequested?.Invoke());
+
+        _notifyIcon = new NotifyIcon
+        {
+            ContextMenuStrip = menu,
+            Icon = Icon.ExtractAssociatedIcon(Environment.ProcessPath!) ?? SystemIcons.Application,
+            Text = "EnviousWispr — starting",
+            Visible = true,
+        };
+        _notifyIcon.DoubleClick += (_, _) => ShowWindowRequested?.Invoke();
+    }
+
+    public event Action? ShowWindowRequested;
+
+    public event Action? OpenSettingsRequested;
+
+    public event Action? ExitRequested;
+
+    public void SetStatus(string status)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var text = $"EnviousWispr — {status}";
+        _notifyIcon.Text = text.Length <= 63 ? text : text[..63];
+    }
+
+    public void ShowBackgroundNotice() => _notifyIcon.ShowBalloonTip(
+        2500,
+        "EnviousWispr is still ready",
+        "Use the tray icon to reopen settings. Push-to-talk keeps working in the background.",
+        ToolTipIcon.Info);
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _notifyIcon.Visible = false;
+        _notifyIcon.Dispose();
+    }
+}

--- a/src/Production/EnviousWispr.Services/Settings/JsonSettingsStore.cs
+++ b/src/Production/EnviousWispr.Services/Settings/JsonSettingsStore.cs
@@ -56,6 +56,7 @@ public sealed class JsonSettingsStore : ISettingsStore
                 1 => MigrateFromV1(json),
                 2 => MigrateFromV2(json),
                 3 => MigrateFromV3(json),
+                4 => MigrateFromV4(json),
                 AppSettings.CurrentSchemaVersion => JsonSerializer.Deserialize<AppSettings>(json, SerializerOptions),
                 _ => null,
             };
@@ -191,7 +192,8 @@ public sealed class JsonSettingsStore : ISettingsStore
                     legacy.Preferences.Polish,
                     legacy.Preferences.History,
                     legacy.Preferences.Theme),
-                legacy.UserData);
+                legacy.UserData,
+                PreferredMicrophoneId: null);
     }
 
     private static AppSettings? MigrateFromV3(string json)
@@ -200,6 +202,18 @@ public sealed class JsonSettingsStore : ISettingsStore
         return legacy is null
             ? null
             : legacy with { SchemaVersion = AppSettings.CurrentSchemaVersion };
+    }
+
+    private static AppSettings? MigrateFromV4(string json)
+    {
+        var legacy = JsonSerializer.Deserialize<AppSettings>(json, SerializerOptions);
+        return legacy is null
+            ? null
+            : legacy with
+            {
+                SchemaVersion = AppSettings.CurrentSchemaVersion,
+                PreferredMicrophoneId = null,
+            };
     }
 
     private static SettingsLoadResult Invalid(


### PR DESCRIPTION
## Summary

- replace the production placeholder with a native WinUI product shell for onboarding, Home, History, Dictionary, Snippets, Settings, and Help/privacy
- add a non-activating per-monitor dictation overlay and notification-area close-to-tray lifecycle
- add private atomic history with retention, machine-local microphone routing, portable profile UX, themes, access keys, and an en-US localization seam
- add write-only direct-cloud credential management backed by Windows Credential Manager; presence checks never expose the secret
- preserve truthful boundaries for the Phase 16 model downloader, Phase 17 full accessibility/localization matrix, and Phase 19 updater

## Validation

- `powershell -ExecutionPolicy Bypass -File .\scripts\validate.ps1`
  - preserved founder proof: 34/34
  - production architecture: 258/258
  - WinUI x64 Release and all existing native harnesses: zero warnings/errors
- `git diff --check`
- isolated native WinUI UAT at the host's actual 150% scale
  - clean onboarding readiness and deterministic Get started focus
  - Home/settings/history/dictionary/snippet persistence with synthetic data only
  - light/dark rendering and UI Automation names/live regions
  - recording overlay visible without focus theft
  - close-to-tray kept the exact process alive
  - microphone privacy action opened Windows Settings without reading or changing any setting
  - isolated synthetic OpenAI key was masked, stored, reported by presence only, removed, and verified absent

## Explicitly unobserved before Phase 14 exit

- physical multi-monitor overlay movement and tray-menu restore
- live 100% and 200% DPI configurations (150% was observed)
- Narrator and a complete keyboard-only journey
- native file-picker import/export
- founder acceptance

The deterministic contracts and locally available UAT are complete, but these items remain open rather than being represented as runtime proof.

## Boundaries

- stacked on Phase 13 PR #31; review against `codex/phase13-context-delivery`
- founder-tested WPF proof untouched
- no real credentials, user text, model weights, external provider calls, protected port 8081 runtime, or unrelated model server touched
- do not merge without Saurabh's explicit approval

Tracks #32