### PR TITLE
Phase 20: compatibility matrix and fail-closed CUDA selection

### DIFF
--- a/docs/compatibility/windows-matrix.md
+++ b/docs/compatibility/windows-matrix.md
@@ -1,0 +1,78 @@
+# Windows compatibility matrix
+
+## Evidence rule
+
+This matrix records completed product evidence, not assumptions from a compile. Run
+`scripts/run-compatibility.ps1` on every machine class and keep the generated JSON under ignored `out/`.
+Post the content-free result summary to GitHub issue #44. Never commit machine paths, device names or IDs,
+account names, audio, transcripts, clipboard contents, or surrounding text.
+
+As of 2026-08-26, Microsoft lists Windows 11 x64 builds 26100 (24H2), 26200 (25H2), and 28000 (26H1)
+as supported client versions. The release candidate must be checked against Microsoft's current lifecycle
+page again because supported versions change over time.
+
+## Measured cells
+
+| Cell | Machine class | Product evidence | Result |
+| --- | --- | --- | --- |
+| Primary NVIDIA desktop | Windows 11 25H2 build 26200.9168; Intel, 24 physical/32 logical cores; 32–63 GiB; NVIDIA with one CUDA device; QHD single display at 100–124%; one default capture device; one endpoint-security provider | 34 preserved-proof tests; 350 production tests; physical WASAPI default/selected capture; global hotkey conflict, hold/release, cancel, and teardown; isolated worker start/crash recovery/stop/timeout; Parakeet CPU model acceptance | Partial pass |
+
+The machine's NVIDIA driver is healthy, but the pinned ONNX Runtime 1.29 CUDA 13/cuDNN 9 dependency set is
+not installed or delivered. Automatic Parakeet selection now detects that condition and chooses the tested
+CPU fallback. Explicit CUDA acceptance remains failed and is tracked in issue #45. This is not a completed
+NVIDIA product cell until a licensed, signed, hash-pinned runtime pack is delivered and retested.
+
+## Required operating-system cells
+
+| OS cell | Required evidence |
+| --- | --- |
+| Windows 11 24H2, build 26100 | Clean signed install/update/uninstall plus the complete compatibility runner on a currently patched Home/Pro machine; Enterprise remains relevant while Microsoft supports it. |
+| Windows 11 25H2, build 26200 | Complete compatibility runner and signed lifecycle on a current patch. The primary rig covers only the high-end NVIDIA/single-display subset. |
+| Windows 11 26H1, build 28000 | Clean compatibility runner and signed lifecycle; do not infer results from 24H2/25H2. |
+
+## Required hardware and workflow coverage
+
+| Dimension | Cells that need measured runs |
+| --- | --- |
+| CPU and memory | Intel and AMD CPU-only laptops at 8 GiB and 16 GiB; older supported 4-core and 8-core classes; 32 GiB desktop baseline. |
+| Graphics | NVIDIA with complete CUDA runtime; NVIDIA without runtime (CPU fallback); AMD discrete; Intel integrated; no usable accelerator. |
+| Microphone | Built-in array, USB microphone/headset, Bluetooth headset, default-device change, unplug during capture, privacy permission denied. |
+| Displays | 100%, 125%, 150%, and 200%; 1080p, QHD, and 4K; mixed-scale two-monitor placement and movement. |
+| Endpoint security | Microsoft Defender default policy plus at least two representative third-party products; allow, quarantine/block, repair, update, and uninstall behavior. |
+| Target apps | Notepad, Word, Outlook, Chrome contenteditable, Slack, Teams, VS Code, protected password fields, elevated targets, and clipboard-unavailable fallback. |
+| Power and mobility | AC and battery use, sleep/resume, microphone change, lid/monitor topology change, memory pressure, and thermal throttling. |
+| Release lifecycle | Signed fresh install, update, interrupted update, rollback, repair, and uninstall with user-data preservation for stable/founder/beta isolation. |
+
+## Runbook
+
+On a prepared Windows 11 x64 machine:
+
+```powershell
+pwsh -NoProfile -File .\scripts\run-compatibility.ps1 -RunLabel <coarse-machine-label>
+```
+
+When the local signed model/runtime packs and public fixtures are available, also run:
+
+```powershell
+pwsh -NoProfile -File .\scripts\run-compatibility.ps1 `
+  -RunLabel <coarse-machine-label>-runtime `
+  -IncludeLocalRuntime
+```
+
+The runner intentionally continues after a failed step so the report captures all safe evidence from the
+machine. A nonzero final exit means the cell failed. Native target-app delivery, multi-monitor movement,
+endpoint-security allow/block behavior, and the signed release lifecycle remain interactive checks and must
+be added to the issue with exact app/version and observed behavior.
+
+## Requirement status
+
+No public minimum or recommended hardware requirement is approved yet. One high-end desktop cannot prove an
+ordinary laptop minimum. The only current product-level requirement is Windows 11 x64; CPU execution remains
+mandatory. Publish numeric CPU, memory, GPU, and latency requirements only after the required low-end,
+midrange, and high-end cells above have real results.
+
+## Primary sources
+
+- [Microsoft supported Windows client versions](https://learn.microsoft.com/en-us/windows/release-health/supported-versions-windows-client)
+- [Microsoft Windows 11 Home and Pro lifecycle](https://learn.microsoft.com/en-us/lifecycle/products/windows-11-home-and-pro)
+- [ONNX Runtime CUDA execution-provider requirements](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html)

--- a/notes/phase-twenty-compatibility-matrix.md
+++ b/notes/phase-twenty-compatibility-matrix.md
@@ -1,0 +1,56 @@
+# Phase 20 compatibility evidence
+
+Date: 2026-08-26
+
+## Reusable runner
+
+`scripts/run-compatibility.ps1` now creates an ignored JSON report for one coarse machine label. It runs the
+canonical repository validation, a privacy-safe machine probe, physical WASAPI capture, synthetic global
+hotkey behavior, and isolated runtime recovery. `-IncludeLocalRuntime` adds the real model-dependent gates.
+The runner continues after individual failures so one broken provider does not erase evidence from other
+stages, then returns nonzero if any stage failed.
+
+The machine probe records only product-relevant classes: exact Windows build/revision, architecture, CPU
+vendor and core counts, a memory tier, active graphics vendors, DirectML/CUDA capability, completeness of
+the pinned ONNX Runtime CUDA dependency set, display count/scale/resolution tiers, capture-device count,
+default-device presence, endpoint-security provider count, and probe status. Tests reject string fields and
+property names that could hold device names, identifiers, paths, accounts, text, audio, or clipboard data.
+
+## Primary-rig results
+
+The first complete non-model run passed:
+
+- Windows 11 25H2 build 26200.9168, x64.
+- Intel, 24 physical cores and 32 logical processors, 32–63 GiB memory tier.
+- One active NVIDIA adapter and CUDA device; DirectML available.
+- QHD single display at the 100–124% scale tier.
+- One capture device and one default capture device.
+- Endpoint-security query available with one registered provider.
+- Canonical validation passed 34 preserved-proof and 346 production tests.
+- Default and explicitly selected physical microphone capture produced 16 kHz mono audio, level events,
+  overlap refusal, and clean cancel.
+- Global hotkey installation, conflict detection, hold/release, cancel, and teardown passed.
+- Runtime worker start, forced crash recovery, clean stop, startup-timeout rejection, and resource arbitration
+  passed.
+
+## Model-dependent finding
+
+The real CPU Parakeet gate passed. The 10 s and 20 s clips completed in 405 ms and 711 ms; the 91.467 s clip
+completed in 3,758 ms. CUDA failed before inference because ONNX Runtime 1.29 requires CUDA 13/cuDNN 9 and
+`cublasLt64_13.dll` was absent. The NVIDIA driver alone was therefore a false-positive capability signal.
+
+The production probe and automatic Parakeet selector now require the complete pinned DLL-name set before
+choosing CUDA. On this machine the new probe reports driver available, dependency set unavailable, and
+automatic provider CPU. CPU fallback and isolated worker recovery pass. Issue #45 remains open for delivery
+of a licensed, signed, hash-pinned CUDA runtime pack and a rerun of explicit CUDA acceptance.
+
+The final hardened non-model rerun passed 34 preserved-proof and 350 production tests, the exact
+26200.9168 revision probe, physical microphone capture, global hotkey behavior, and isolated runtime
+recovery. A malformed CUDA search-directory test also confirms that untrusted `PATH` state fails closed.
+
+## Unobserved
+
+Only one high-end NVIDIA desktop is available in this run. AMD, Intel integrated, CPU-only laptop, low-memory,
+multi-display, mixed-DPI, Bluetooth, privacy-denied, sleep/resume, third-party endpoint security, current
+Windows 11 24H2/26H1, real target-app delivery, and signed release-lifecycle cells remain unobserved. No
+minimum or recommended hardware requirement can be inferred yet.

--- a/scripts/run-compatibility.ps1
+++ b/scripts/run-compatibility.ps1
@@ -1,0 +1,120 @@
+param(
+    [ValidatePattern('^[a-z0-9][a-z0-9-]{0,39}$')]
+    [string]$RunLabel = 'local',
+
+    [string]$OutputDirectory,
+
+    [switch]$IncludeLocalRuntime
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $repoRoot 'out\compatibility'
+}
+$OutputDirectory = [IO.Path]::GetFullPath($OutputDirectory)
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+function Resolve-DotNet10 {
+    $candidates = @(
+        (Join-Path ([Environment]::GetFolderPath('UserProfile')) '.dotnet\dotnet.exe'),
+        (Get-Command dotnet -ErrorAction SilentlyContinue).Source
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($candidate in $candidates) {
+        if (-not (Test-Path -LiteralPath $candidate)) {
+            continue
+        }
+
+        $sdks = & $candidate --list-sdks
+        if ($LASTEXITCODE -eq 0 -and $sdks -match '^10\.') {
+            return $candidate
+        }
+    }
+
+    throw '.NET 10 SDK is required for compatibility UAT.'
+}
+
+function Invoke-CompatibilityStep {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][scriptblock]$Action
+    )
+
+    Write-Host "Running compatibility step: $Name"
+    $started = [DateTimeOffset]::UtcNow
+    $lines = @(& $Action 2>&1 | ForEach-Object { $_.ToString() })
+    $exitCode = $LASTEXITCODE
+    if ($null -eq $exitCode) {
+        $exitCode = 0
+    }
+    foreach ($line in $lines) {
+        Write-Host $line
+    }
+
+    [ordered]@{
+        name = $Name
+        succeeded = $exitCode -eq 0
+        exitCode = $exitCode
+        elapsedMilliseconds = [int64]([DateTimeOffset]::UtcNow - $started).TotalMilliseconds
+    }
+}
+
+$dotnet10 = Resolve-DotNet10
+$timestamp = [DateTimeOffset]::UtcNow.ToString('yyyyMMddTHHmmssZ')
+$probePath = Join-Path $OutputDirectory "$RunLabel-$timestamp-machine.json"
+$reportPath = Join-Path $OutputDirectory "$RunLabel-$timestamp-run.json"
+$steps = [System.Collections.Generic.List[object]]::new()
+
+Push-Location $repoRoot
+try {
+    $steps.Add((Invoke-CompatibilityStep -Name 'portable-validation' -Action {
+        if ($IncludeLocalRuntime) {
+            & pwsh -NoProfile -File '.\scripts\validate.ps1' -IncludeLocalRuntime
+        }
+        else {
+            & pwsh -NoProfile -File '.\scripts\validate.ps1'
+        }
+    }))
+    $steps.Add((Invoke-CompatibilityStep -Name 'machine-probe' -Action {
+        & $dotnet10 run --project '.\tools\compatibility-uat\EnviousWispr.Compatibility.Uat.csproj' `
+            -c Release -- --output $probePath
+    }))
+    $steps.Add((Invoke-CompatibilityStep -Name 'physical-microphone' -Action {
+        & $dotnet10 run --project '.\tools\audio-uat\EnviousWispr.Audio.Uat.csproj' -c Release
+    }))
+    $steps.Add((Invoke-CompatibilityStep -Name 'global-hotkey' -Action {
+        & $dotnet10 run --project '.\tools\hotkey-uat\EnviousWispr.Hotkey.Uat.csproj' -c Release
+    }))
+    $steps.Add((Invoke-CompatibilityStep -Name 'isolated-runtime' -Action {
+        & $dotnet10 run --project '.\tools\runtime-uat\EnviousWispr.Runtime.Uat.csproj' -c Release
+    }))
+
+    $machine = if (Test-Path -LiteralPath $probePath) {
+        Get-Content -LiteralPath $probePath -Raw | ConvertFrom-Json
+    }
+    else {
+        $null
+    }
+    $report = [ordered]@{
+        schemaVersion = 1
+        runLabel = $RunLabel
+        capturedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+        machine = $machine
+        steps = @($steps)
+        succeeded = @($steps | Where-Object { -not $_.succeeded }).Count -eq 0
+        privacy = 'No device identifiers, device names, account names, paths, audio, transcripts, clipboard contents, or surrounding text are recorded.'
+        unobserved = @(
+            'real target-app delivery',
+            'multi-monitor overlay movement',
+            'endpoint-security allow and block behavior',
+            'signed install and update lifecycle'
+        )
+    }
+    $report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $reportPath -Encoding utf8NoBOM
+    Write-Host "Compatibility report: $reportPath"
+    exit $(if ($report.succeeded) { 0 } else { 5 })
+}
+finally {
+    Pop-Location
+}

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -103,6 +103,9 @@ try {
     Write-Host "Building privacy-safe observability UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/observability-uat/EnviousWispr.Observability.Uat.csproj", "-c", "Release", "--nologo")
 
+    Write-Host "Building privacy-safe compatibility UAT harness (Release)..."
+    Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/compatibility-uat/EnviousWispr.Compatibility.Uat.csproj", "-c", "Release", "--nologo")
+
     Write-Host "Building native ASR UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/asr-uat/EnviousWispr.Asr.Uat.csproj", "-c", "Release", "--nologo")
 

--- a/src/Production/EnviousWispr.ASR/ParakeetRuntimeSelector.cs
+++ b/src/Production/EnviousWispr.ASR/ParakeetRuntimeSelector.cs
@@ -49,6 +49,7 @@ public static class ParakeetRuntimeSelector
     {
         if (hardware.Cuda.IsDriverAvailable &&
             hardware.Cuda.DeviceCount > 0 &&
+            hardware.IsOnnxRuntimeCudaDependencySetAvailable &&
             hardware.HasActiveAdapter(GraphicsVendor.Nvidia) &&
             models.Fp32Complete)
         {
@@ -90,6 +91,7 @@ public static class ParakeetRuntimeSelector
     {
         if (!hardware.Cuda.IsDriverAvailable ||
             hardware.Cuda.DeviceCount == 0 ||
+            !hardware.IsOnnxRuntimeCudaDependencySetAvailable ||
             !hardware.HasActiveAdapter(GraphicsVendor.Nvidia))
         {
             return Failure(

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -1172,7 +1172,8 @@ public partial class App : Application, IAsyncDisposable
         var useCuda = !forceCpu &&
             hardware.Architecture == ProcessorArchitectureKind.X64 &&
             hardware.Cuda.IsDriverAvailable &&
-            hardware.Cuda.DeviceCount > 0;
+            hardware.Cuda.DeviceCount > 0 &&
+            hardware.IsOnnxRuntimeCudaDependencySetAvailable;
         var provider = useCuda ? RuntimeProviderKind.Cuda : RuntimeProviderKind.Cpu;
         var threads = Math.Clamp(
             hardware.PhysicalCoreCount > 0

--- a/src/Production/EnviousWispr.Architecture.Tests/CompatibilityTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/CompatibilityTests.cs
@@ -1,0 +1,74 @@
+using EnviousWispr.Core.Compatibility;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class CompatibilityTests
+{
+    [Theory]
+    [InlineData(7, PhysicalMemoryTier.Below8GiB)]
+    [InlineData(8, PhysicalMemoryTier.From8To15GiB)]
+    [InlineData(15, PhysicalMemoryTier.From8To15GiB)]
+    [InlineData(16, PhysicalMemoryTier.From16To31GiB)]
+    [InlineData(32, PhysicalMemoryTier.From32To63GiB)]
+    [InlineData(64, PhysicalMemoryTier.AtLeast64GiB)]
+    public void PhysicalMemoryUsesStablePublicBuckets(
+        ulong gibibytes,
+        PhysicalMemoryTier expected)
+    {
+        Assert.Equal(
+            expected,
+            CompatibilityBuckets.ClassifyMemory(gibibytes * 1024UL * 1024 * 1024));
+    }
+
+    [Theory]
+    [InlineData(96, DisplayScaleTier.From100To124Percent)]
+    [InlineData(120, DisplayScaleTier.From125To149Percent)]
+    [InlineData(144, DisplayScaleTier.From150To199Percent)]
+    [InlineData(192, DisplayScaleTier.AtLeast200Percent)]
+    public void DisplayDpiUsesStablePublicBuckets(uint dpi, DisplayScaleTier expected)
+    {
+        Assert.Equal(expected, CompatibilityBuckets.ClassifyDisplayScale(dpi));
+    }
+
+    [Theory]
+    [InlineData(1366, 768, PrimaryResolutionTier.Below1080p)]
+    [InlineData(1920, 1080, PrimaryResolutionTier.FullHd)]
+    [InlineData(2560, 1440, PrimaryResolutionTier.QuadHd)]
+    [InlineData(3840, 2160, PrimaryResolutionTier.FourKOrHigher)]
+    public void ResolutionUsesOrientationIndependentPublicBuckets(
+        int width,
+        int height,
+        PrimaryResolutionTier expected)
+    {
+        Assert.Equal(expected, CompatibilityBuckets.ClassifyResolution(width, height));
+        Assert.Equal(expected, CompatibilityBuckets.ClassifyResolution(height, width));
+    }
+
+    [Fact]
+    public void CompatibilitySnapshotCannotHoldNamesIdentifiersOrPaths()
+    {
+        var forbiddenTokens = new[]
+        {
+            "name",
+            "identifier",
+            "path",
+            "model",
+            "serial",
+            "account",
+            "user",
+            "text",
+            "audio",
+            "clipboard",
+        };
+        var propertyNames = typeof(WindowsCompatibilitySnapshot)
+            .GetProperties()
+            .Select(property => property.Name)
+            .ToArray();
+
+        Assert.DoesNotContain(propertyNames, propertyName =>
+            forbiddenTokens.Any(token => propertyName.Contains(token, StringComparison.OrdinalIgnoreCase)));
+        Assert.DoesNotContain(
+            typeof(WindowsCompatibilitySnapshot).GetProperties(),
+            property => property.PropertyType == typeof(string));
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/CudaRuntimeDependencyProbeTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/CudaRuntimeDependencyProbeTests.cs
@@ -1,0 +1,60 @@
+using EnviousWispr.Services.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class CudaRuntimeDependencyProbeTests : IDisposable
+{
+    private readonly string _scratch = Path.Combine(
+        Path.GetTempPath(),
+        $"EnviousWisprCudaProbeTests-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void CompleteDependencySetMaySpanPinnedRuntimeDirectories()
+    {
+        var cuda = Path.Combine(_scratch, "cuda");
+        var cudnn = Path.Combine(_scratch, "cudnn");
+        Directory.CreateDirectory(cuda);
+        Directory.CreateDirectory(cudnn);
+        foreach (var library in CudaRuntimeDependencyProbe.RequiredLibraryNames)
+        {
+            File.WriteAllBytes(
+                Path.Combine(library.StartsWith("cudnn", StringComparison.Ordinal) ? cudnn : cuda, library),
+                [0]);
+        }
+
+        Assert.True(CudaRuntimeDependencyProbe.IsCompleteInDirectories([cuda, cudnn]));
+    }
+
+    [Fact]
+    public void MissingSingleDependencyFailsClosed()
+    {
+        Directory.CreateDirectory(_scratch);
+        foreach (var library in CudaRuntimeDependencyProbe.RequiredLibraryNames.Skip(1))
+        {
+            File.WriteAllBytes(Path.Combine(_scratch, library), [0]);
+        }
+
+        Assert.False(CudaRuntimeDependencyProbe.IsCompleteInDirectories([_scratch]));
+    }
+
+    [Fact]
+    public void MalformedSearchDirectoryFailsClosed()
+    {
+        Assert.False(CudaRuntimeDependencyProbe.IsCompleteInDirectories(["\0invalid"]));
+    }
+
+    public void Dispose()
+    {
+        if (!Directory.Exists(_scratch))
+        {
+            return;
+        }
+
+        var resolved = Path.GetFullPath(_scratch);
+        var expectedRoot = Path.GetFullPath(Path.GetTempPath()) + Path.DirectorySeparatorChar;
+        if (resolved.StartsWith(expectedRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            Directory.Delete(resolved, recursive: true);
+        }
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/ParakeetRuntimeSelectorTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/ParakeetRuntimeSelectorTests.cs
@@ -36,6 +36,21 @@ public sealed class ParakeetRuntimeSelectorTests
     }
 
     [Fact]
+    public void AutomaticFallsBackToCpuWhenCudaDependencySetIsIncomplete()
+    {
+        var result = ParakeetRuntimeSelector.Select(
+            Snapshot(cuda: true, GraphicsVendor.Nvidia) with
+            {
+                IsOnnxRuntimeCudaDependencySetAvailable = false,
+            },
+            new ParakeetModelInventory(Int8Complete: true, Fp32Complete: true));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(RuntimeProviderKind.Cpu, result.Provider);
+        Assert.Equal(RuntimeSelectionReason.TunedCpuUniversalFallback, result.Reason);
+    }
+
+    [Fact]
     public void ManualCudaRejectsMissingQdqFreeModelInsteadOfUsingSlowQdqGraph()
     {
         var result = ParakeetRuntimeSelector.Select(
@@ -107,5 +122,6 @@ public sealed class ParakeetRuntimeSelectorTests
         TotalPhysicalMemoryBytes: 64UL * 1024 * 1024 * 1024,
         GraphicsAdapters: [new GraphicsAdapterCapability(vendor, true, true)],
         IsDirectMlRuntimeAvailable: true,
-        new CudaDriverCapability(cuda, cuda ? 1 : 0, cuda ? 13_000 : null));
+        new CudaDriverCapability(cuda, cuda ? 1 : 0, cuda ? 13_000 : null),
+        IsOnnxRuntimeCudaDependencySetAvailable: cuda);
 }

--- a/src/Production/EnviousWispr.Architecture.Tests/WhisperRuntimeSelectorTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/WhisperRuntimeSelectorTests.cs
@@ -65,5 +65,6 @@ public sealed class WhisperRuntimeSelectorTests
         TotalPhysicalMemoryBytes: 64UL * 1024 * 1024 * 1024,
         GraphicsAdapters: [],
         IsDirectMlRuntimeAvailable: true,
-        new CudaDriverCapability(cuda, cuda ? 1 : 0, cuda ? 13_000 : null));
+        new CudaDriverCapability(cuda, cuda ? 1 : 0, cuda ? 13_000 : null),
+        IsOnnxRuntimeCudaDependencySetAvailable: false);
 }

--- a/src/Production/EnviousWispr.Core/Compatibility/CompatibilityContracts.cs
+++ b/src/Production/EnviousWispr.Core/Compatibility/CompatibilityContracts.cs
@@ -1,0 +1,100 @@
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Core.Compatibility;
+
+public enum PhysicalMemoryTier
+{
+    Below8GiB,
+    From8To15GiB,
+    From16To31GiB,
+    From32To63GiB,
+    AtLeast64GiB,
+}
+
+public enum DisplayScaleTier
+{
+    Below100Percent,
+    From100To124Percent,
+    From125To149Percent,
+    From150To199Percent,
+    AtLeast200Percent,
+}
+
+public enum PrimaryResolutionTier
+{
+    Below1080p,
+    FullHd,
+    QuadHd,
+    FourKOrHigher,
+}
+
+public sealed record WindowsCompatibilitySnapshot(
+    int SchemaVersion,
+    int OperatingSystemBuild,
+    int OperatingSystemRevision,
+    bool IsWindows11OrLater,
+    ProcessorArchitectureKind Architecture,
+    ProcessorVendor ProcessorVendor,
+    int PhysicalCoreCount,
+    int LogicalProcessorCount,
+    PhysicalMemoryTier MemoryTier,
+    IReadOnlyList<GraphicsVendor> ActiveGraphicsVendors,
+    bool IsDirectMlRuntimeAvailable,
+    bool IsCudaDriverAvailable,
+    bool IsOnnxRuntimeCudaDependencySetAvailable,
+    int CudaDeviceCount,
+    int? CudaDriverVersion,
+    int DisplayCount,
+    DisplayScaleTier PrimaryDisplayScale,
+    PrimaryResolutionTier PrimaryResolution,
+    int CaptureDeviceCount,
+    bool HasDefaultCaptureDevice,
+    bool EndpointSecurityProbeAvailable,
+    int EndpointSecurityProviderCount,
+    HardwareProbeStatus HardwareProbeStatus);
+
+public static class CompatibilityBuckets
+{
+    private const ulong GiB = 1024UL * 1024 * 1024;
+
+    public static PhysicalMemoryTier ClassifyMemory(ulong bytes) => bytes switch
+    {
+        < 8 * GiB => PhysicalMemoryTier.Below8GiB,
+        < 16 * GiB => PhysicalMemoryTier.From8To15GiB,
+        < 32 * GiB => PhysicalMemoryTier.From16To31GiB,
+        < 64 * GiB => PhysicalMemoryTier.From32To63GiB,
+        _ => PhysicalMemoryTier.AtLeast64GiB,
+    };
+
+    public static DisplayScaleTier ClassifyDisplayScale(uint dpi)
+    {
+        var percent = checked((int)Math.Round(dpi * 100d / 96d));
+        return percent switch
+        {
+            < 100 => DisplayScaleTier.Below100Percent,
+            < 125 => DisplayScaleTier.From100To124Percent,
+            < 150 => DisplayScaleTier.From125To149Percent,
+            < 200 => DisplayScaleTier.From150To199Percent,
+            _ => DisplayScaleTier.AtLeast200Percent,
+        };
+    }
+
+    public static PrimaryResolutionTier ClassifyResolution(int width, int height)
+    {
+        var shortEdge = Math.Min(width, height);
+        var longEdge = Math.Max(width, height);
+        if (shortEdge >= 2160 && longEdge >= 3840)
+        {
+            return PrimaryResolutionTier.FourKOrHigher;
+        }
+
+        if (shortEdge >= 1440 && longEdge >= 2560)
+        {
+            return PrimaryResolutionTier.QuadHd;
+        }
+
+        return shortEdge >= 1080 && longEdge >= 1920
+            ? PrimaryResolutionTier.FullHd
+            : PrimaryResolutionTier.Below1080p;
+    }
+}

--- a/src/Production/EnviousWispr.Core/Runtime/HardwareContracts.cs
+++ b/src/Production/EnviousWispr.Core/Runtime/HardwareContracts.cs
@@ -51,6 +51,7 @@ public sealed record HardwareSnapshot(
     IReadOnlyList<GraphicsAdapterCapability> GraphicsAdapters,
     bool IsDirectMlRuntimeAvailable,
     CudaDriverCapability Cuda,
+    bool IsOnnxRuntimeCudaDependencySetAvailable,
     AppError? Error = null)
 {
     public bool HasActiveAdapter(GraphicsVendor vendor) =>

--- a/src/Production/EnviousWispr.Services/Runtime/CudaRuntimeDependencyProbe.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/CudaRuntimeDependencyProbe.cs
@@ -1,0 +1,71 @@
+namespace EnviousWispr.Services.Runtime;
+
+public static class CudaRuntimeDependencyProbe
+{
+    internal static IReadOnlyList<string> RequiredLibraryNames { get; } =
+    [
+        "cublasLt64_13.dll",
+        "cublas64_13.dll",
+        "cufft64_12.dll",
+        "cudart64_13.dll",
+        "cudnn64_9.dll",
+        "cudnn_adv64_9.dll",
+        "cudnn_engines_precompiled64_9.dll",
+        "cudnn_engines_runtime_compiled64_9.dll",
+        "cudnn_engines_tensor_ir64_9.dll",
+        "cudnn_graph64_9.dll",
+        "cudnn_heuristic64_9.dll",
+        "cudnn_ops64_9.dll",
+    ];
+
+    public static bool IsComplete(string? preferredRuntimeDirectory)
+    {
+        var searchDirectories = new List<string>();
+        AddDirectory(searchDirectories, preferredRuntimeDirectory);
+        AddDirectory(searchDirectories, AppContext.BaseDirectory);
+        foreach (var pathEntry in (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+                     .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            AddDirectory(searchDirectories, pathEntry);
+        }
+
+        return IsCompleteInDirectories(searchDirectories);
+    }
+
+    internal static bool IsCompleteInDirectories(IEnumerable<string> searchDirectories)
+    {
+        var resolvedDirectories = searchDirectories
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Select(TryResolveExistingDirectory)
+            .OfType<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return RequiredLibraryNames.All(library =>
+            resolvedDirectories.Any(directory => File.Exists(Path.Combine(directory, library))));
+    }
+
+    private static string? TryResolveExistingDirectory(string candidate)
+    {
+        try
+        {
+            var resolved = Path.GetFullPath(candidate);
+            return Directory.Exists(resolved) ? resolved : null;
+        }
+        catch (Exception exception) when (exception is
+                                          ArgumentException or
+                                          IOException or
+                                          NotSupportedException or
+                                          UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static void AddDirectory(List<string> directories, string? candidate)
+    {
+        if (!string.IsNullOrWhiteSpace(candidate))
+        {
+            directories.Add(candidate);
+        }
+    }
+}

--- a/src/Production/EnviousWispr.Services/Runtime/WindowsHardwareDiscovery.cs
+++ b/src/Production/EnviousWispr.Services/Runtime/WindowsHardwareDiscovery.cs
@@ -46,6 +46,8 @@ public sealed class WindowsHardwareDiscovery : IHardwareDiscovery
 
         var directMlAvailable = ProbeNativeLibrary("DirectML.dll");
         var cuda = ProbeCudaDriver();
+        var onnxRuntimeCudaDependencies = CudaRuntimeDependencyProbe.IsComplete(
+            Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR"));
         return new HardwareSnapshot(
             status,
             CurrentArchitecture(),
@@ -56,6 +58,7 @@ public sealed class WindowsHardwareDiscovery : IHardwareDiscovery
             graphicsAdapters,
             directMlAvailable,
             cuda,
+            onnxRuntimeCudaDependencies,
             status == HardwareProbeStatus.Complete
                 ? null
                 : new AppError(

--- a/tools/compatibility-uat/EnviousWispr.Compatibility.Uat.csproj
+++ b/tools/compatibility-uat/EnviousWispr.Compatibility.Uat.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Audio\EnviousWispr.Audio.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Core\EnviousWispr.Core.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Services\EnviousWispr.Services.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Management" Version="10.0.11" />
+  </ItemGroup>
+</Project>

--- a/tools/compatibility-uat/Program.cs
+++ b/tools/compatibility-uat/Program.cs
@@ -1,0 +1,139 @@
+using System.Management;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EnviousWispr.Audio;
+using EnviousWispr.Core.Compatibility;
+using EnviousWispr.Core.Runtime;
+using EnviousWispr.Services.Runtime;
+using Microsoft.Win32;
+
+var outputPath = ArgumentValue(args, "--output");
+var hardware = await new WindowsHardwareDiscovery().ProbeAsync();
+using var deviceCatalog = new WasapiDeviceCatalog();
+var captureDevices = await deviceCatalog.GetCaptureDevicesAsync();
+var operatingSystem = Environment.OSVersion.Version;
+var activeGraphicsVendors = hardware.GraphicsAdapters
+    .Where(adapter => adapter.IsActive)
+    .Select(adapter => adapter.Vendor)
+    .Distinct()
+    .Order()
+    .ToArray();
+var (securityProbeAvailable, securityProviderCount) = ProbeEndpointSecurity();
+
+var snapshot = new WindowsCompatibilitySnapshot(
+    SchemaVersion: 1,
+    OperatingSystemBuild: operatingSystem.Build,
+    OperatingSystemRevision: ReadOperatingSystemRevision(operatingSystem.Revision),
+    IsWindows11OrLater: OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000),
+    hardware.Architecture,
+    hardware.ProcessorVendor,
+    hardware.PhysicalCoreCount,
+    hardware.LogicalProcessorCount,
+    CompatibilityBuckets.ClassifyMemory(hardware.TotalPhysicalMemoryBytes),
+    activeGraphicsVendors,
+    hardware.IsDirectMlRuntimeAvailable,
+    hardware.Cuda.IsDriverAvailable,
+    hardware.IsOnnxRuntimeCudaDependencySetAvailable,
+    hardware.Cuda.DeviceCount,
+    hardware.Cuda.DriverVersion,
+    DisplayCount: Math.Max(1, NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricMonitorCount)),
+    CompatibilityBuckets.ClassifyDisplayScale(NativeMethods.GetDpiForSystem()),
+    CompatibilityBuckets.ClassifyResolution(
+        NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricPrimaryWidth),
+        NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricPrimaryHeight)),
+    CaptureDeviceCount: captureDevices.Count,
+    HasDefaultCaptureDevice: captureDevices.Any(device => device.IsDefault),
+    securityProbeAvailable,
+    securityProviderCount,
+    hardware.Status);
+
+var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions
+{
+    WriteIndented = true,
+    Converters = { new JsonStringEnumConverter() },
+});
+Console.WriteLine(json);
+if (!string.IsNullOrWhiteSpace(outputPath))
+{
+    var resolvedOutput = Path.GetFullPath(outputPath);
+    Directory.CreateDirectory(Path.GetDirectoryName(resolvedOutput)
+                              ?? throw new InvalidOperationException("Compatibility output has no directory."));
+    await File.WriteAllTextAsync(resolvedOutput, json + Environment.NewLine);
+}
+
+return snapshot.IsWindows11OrLater &&
+       snapshot.Architecture == ProcessorArchitectureKind.X64 &&
+       snapshot.PhysicalCoreCount > 0 &&
+       snapshot.LogicalProcessorCount >= snapshot.PhysicalCoreCount &&
+       snapshot.DisplayCount > 0 &&
+       snapshot.CaptureDeviceCount > 0 &&
+       snapshot.HasDefaultCaptureDevice
+    ? 0
+    : 4;
+
+static string? ArgumentValue(string[] arguments, string name)
+{
+    for (var index = 0; index < arguments.Length - 1; index++)
+    {
+        if (string.Equals(arguments[index], name, StringComparison.OrdinalIgnoreCase))
+        {
+            return arguments[index + 1];
+        }
+    }
+
+    return null;
+}
+
+static (bool Available, int ProviderCount) ProbeEndpointSecurity()
+{
+    try
+    {
+        var scope = new ManagementScope(@"\\.\root\SecurityCenter2");
+        scope.Connect();
+        using var searcher = new ManagementObjectSearcher(
+            scope,
+            new ObjectQuery("SELECT productState FROM AntiVirusProduct"));
+        using var products = searcher.Get();
+        return (true, products.Count);
+    }
+    catch (Exception exception) when (exception is
+                                      ManagementException or
+                                      COMException or
+                                      UnauthorizedAccessException)
+    {
+        return (false, 0);
+    }
+}
+
+static int ReadOperatingSystemRevision(int fallback)
+{
+    try
+    {
+        using var currentVersion = Registry.LocalMachine.OpenSubKey(
+            @"SOFTWARE\Microsoft\Windows NT\CurrentVersion",
+            writable: false);
+        return currentVersion?.GetValue("UBR") is int updateBuildRevision
+            ? updateBuildRevision
+            : fallback;
+    }
+    catch (Exception exception) when (exception is
+                                      System.Security.SecurityException or
+                                      UnauthorizedAccessException)
+    {
+        return fallback;
+    }
+}
+
+internal static partial class NativeMethods
+{
+    internal const int SystemMetricPrimaryWidth = 0;
+    internal const int SystemMetricPrimaryHeight = 1;
+    internal const int SystemMetricMonitorCount = 80;
+
+    [DllImport("user32.dll")]
+    internal static extern int GetSystemMetrics(int index);
+
+    [DllImport("user32.dll")]
+    internal static extern uint GetDpiForSystem();
+}

--- a/tools/runtime-uat/Program.cs
+++ b/tools/runtime-uat/Program.cs
@@ -92,6 +92,7 @@ var summary = new
         graphicsVendors = hardware.GraphicsAdapters.Select(adapter => adapter.Vendor.ToString()).ToArray(),
         directMlRuntime = hardware.IsDirectMlRuntimeAvailable,
         cudaAvailable = hardware.Cuda.IsDriverAvailable,
+        onnxRuntimeCudaDependencies = hardware.IsOnnxRuntimeCudaDependencySetAvailable,
         cudaDevices = hardware.Cuda.DeviceCount,
         cudaDriverVersion = hardware.Cuda.DriverVersion,
     },


### PR DESCRIPTION
## Outcome

Adds a reusable privacy-safe Windows compatibility runner and matrix, then hardens Parakeet CUDA selection to fail closed when the ONNX Runtime 1.29 CUDA 13/cuDNN 9 runtime dependency set is incomplete.

## Measured evidence

- 34 preserved-proof tests passed.
- 350 production tests passed.
- Windows 11 25H2 build 26200.9168 machine probe passed without names, identifiers, paths, or user content.
- Physical default and selected WASAPI capture passed.
- Global hotkey conflict, hold/release, cancel, and teardown passed.
- Isolated runtime start, crash recovery, timeout, stop, and resource arbitration passed.
- NVIDIA driver is present, CUDA dependency set is incomplete, and automatic Parakeet now selects the tested quantized CPU fallback.
- Persisted report privacy scan passed; command output is never copied into JSON evidence.

## Honest limits

The current cell is only one high-end NVIDIA desktop. Windows 11 24H2/26H1, low-end laptops, AMD/Intel-integrated systems, multi-DPI displays, microphone failure modes, third-party endpoint security, target-app delivery, mobility, and signed release lifecycle remain unobserved. CUDA delivery still requires a licensed, signed, hash-pinned runtime pack and explicit acceptance rerun.

Advances #44.
Advances #45.

Stacked on the Phase 19 installer/update branch and should be rebased after that PR lands.