### PR TITLE
Phase 21: performance and laptop readiness gate

### DIFF
--- a/docs/performance/windows-laptop-readiness.md
+++ b/docs/performance/windows-laptop-readiness.md
@@ -1,0 +1,91 @@
+# Windows performance and laptop-readiness gate
+
+## Evidence rule
+
+Performance claims require the exact Windows build, coarse hardware class, power source, command, model
+pack, provider, and observed result. Reports stay under ignored `out/performance/` and contain only
+content-free timings, resource counts, coarse hardware classes, provider outcomes, and public-fixture
+quality metrics. They never contain audio, transcript text, clipboard or surrounding text, device names or
+identifiers, account names, process identifiers, event names, or paths.
+
+The budgets below are provisional engineering acceptance targets. They are not public minimum or
+recommended requirements. A high-end desktop passing them does not prove that an ordinary laptop passes.
+
+## Provisional budgets
+
+| Area | Provisional target |
+| --- | --- |
+| Shell ready | Empty-profile first launch and warm p95 at or below 5,000 ms. |
+| Full local runtime ready | App plus automatically selected final-ASR worker ready at or below 5,000 ms. |
+| Ready memory | App plus direct child workers at or below 2 GiB combined working set. |
+| Idle overhead | Normalized CPU at or below 5% and no sustained working-set growth. |
+| Recording overhead | Normalized CPU at or below 15%, working-set growth at or below 256 MiB, 16 kHz mono capture at least 90% of requested duration. |
+| Parakeet CPU final | 10 s at or below 3 s; 20 s at or below 5 s; 91.5 s at or below 15 s. |
+| Whisper CPU final | 10 s at or below 5 s; 20 s at or below 8 s; 91.5 s at or below 20 s. |
+| CPU preview | A snapshot update at or below 5 s for clips through 20 s; preview failure must not affect final transcription. |
+| Cancellation | Worker cancellation and removal at or below 2 s. |
+| Repeated lifecycle | 1,000 content-free recovery cycles, handle delta at or below 12, clean app exits, and no orphan worker. |
+| Thermal stability | A 30-minute AC run and a 30-minute battery run with zero failed dictations, no stuck hooks or orphan workers, and final-latency p95 drift at or below 25% from the first to last quartile. |
+
+The normalized CPU percentage divides process CPU time by elapsed time and the machine's logical processor
+count. This makes results comparable across runs but is not an energy measurement. Processor current/max
+frequency is only a throttling proxy. Battery discharge, package power, temperature, fan behavior, and
+energy per dictation need supported laptop instrumentation before a battery-mode decision.
+
+## Current measured cell
+
+Measured 2026-08-26 on Windows 11 25H2 build 26200.9168, Intel 24 physical/32 logical cores, 32–63 GiB,
+NVIDIA graphics with an incomplete ONNX Runtime CUDA dependency set, QHD at 100–124% scale, on AC power.
+Automatic Parakeet therefore selected its tested quantized CPU path.
+
+| Measurement | Result | Provisional budget |
+| --- | ---: | ---: |
+| Shell first ready | 592 ms | 5,000 ms |
+| Shell warm median / p95 | 572 / 609 ms | p95 5,000 ms |
+| Shell working set | 188–190 MB | 2 GiB |
+| Full runtime first ready | 2,281 ms | 5,000 ms |
+| Full runtime warm median / p95 | 2,275 / 2,313 ms | p95 5,000 ms |
+| Full runtime combined working set | 973–975 MB | 2 GiB |
+| Full runtime idle CPU | 0.195–0.439% | 5% |
+| 5 s recording CPU / working-set growth | 0.058% / 7.4 MB | 15% / 256 MiB |
+| Parakeet CPU, 10 s / 20 s / 91.5 s | 390 / 696 / 3,786 ms | 3,000 / 5,000 / 15,000 ms |
+| Whisper CPU, 10 s / 20 s / 91.5 s | 11,760 / 11,803 / 32,249 ms | 5,000 / 8,000 / 20,000 ms |
+| Preview CPU, 10 s / 20 s / 91.5 s | 2,489 / 2,723 / 7,485 ms | 5,000 ms through 20 s |
+| Parakeet / Whisper / preview cancellation | 165 / 596 / 603 ms | 2,000 ms |
+| Reliability cycles / handle delta | 1,000 / 9 | 1,000 / at most 12 |
+
+Parakeet, shell/runtime readiness, recording, cancellation, and repeated lifecycle pass on this machine.
+Whisper CPU final latency fails the provisional laptop budget even on this desktop. Its German language
+detection and Spanish public-fixture quality also failed in this run. Preview latency passes, French and
+German pass, and the known Spanish preview case remains at 52.38% WER. Quality failures are not relaxed to
+make a performance run green.
+
+## Runbook
+
+Run the portable shell, recording, power-proxy, and repeated-lifecycle gate:
+
+```powershell
+pwsh -NoProfile -File .\scripts\run-performance.ps1 -RunLabel <coarse-machine-label>
+```
+
+On a machine with the pinned local model packs, add the full app worker, Parakeet CPU, Whisper CPU, and
+preview CPU sequence:
+
+```powershell
+pwsh -NoProfile -File .\scripts\run-performance.ps1 `
+  -RunLabel <coarse-machine-label>-runtime `
+  -IncludeLocalRuntime
+```
+
+A nonzero exit means at least one gate failed. Do not rerun only the passing engine and describe the result
+as a full pass. Attach a content-free summary to issue #47 and keep raw ignored reports on the measured
+machine.
+
+## Remaining exit cells
+
+- Intel and AMD CPU-only laptops at 8 GiB and 16 GiB, on AC and battery.
+- Intel integrated and AMD integrated/discrete graphics, plus NVIDIA laptops with and without the complete
+  CUDA runtime pack.
+- 30-minute thermal runs, sleep/resume, lid/topology changes, memory pressure, and battery discharge.
+- Model switching during a live dictation session and preview-to-final resource handoff under load.
+- Final tuning or model-tier changes for Whisper CPU; no battery-saving mode is justified yet.

--- a/notes/phase-twenty-one-performance.md
+++ b/notes/phase-twenty-one-performance.md
@@ -1,0 +1,56 @@
+# Phase 21 performance evidence
+
+Date: 2026-08-26
+
+## Reusable gate
+
+`scripts/run-performance.ps1` builds and tests the repository, records a privacy-safe compatibility
+snapshot, measures five isolated WinUI launches, measures physical WASAPI recording overhead, and runs
+1,000 reliability cycles. `-IncludeLocalRuntime` adds five full app-plus-Parakeet-worker launches followed
+by public-fixture Parakeet CPU, Whisper CPU, and small-preview CPU gates. The ignored aggregate report
+persists only typed, content-free metrics.
+
+The app signals readiness through allowlisted, UAT-only named events after the shell is shown and, when
+requested, after the final-ASR worker has started. The harness uses an isolated data directory, never stops
+an application it did not create, samples the app and its direct children, waits for normal shutdown, and
+fails if an owned worker remains.
+
+## P1 runtime-worker packaging defect
+
+The first full-runtime measurement found that the visible WinUI app reported `Local transcription worker
+could not start` even though standalone runtime UAT passed. The build target copied stale RID output. Its
+runtime descriptor expected a self-contained host, but the development output had no `hostpolicy.dll`.
+After the development copy was corrected, full app runtime readiness passed.
+
+The new packaging launch assertion then caught a second form of the same defect: self-contained publish
+contained the worker executable and runtime descriptor but omitted `EnviousWispr.RuntimeWorker.dll`.
+The publish target now copies the complete current RID worker file set after publish. Both the canonical
+development build and self-contained package execute the worker and require the expected no-arguments exit
+code. An unsigned founder 0.21.1 package passed this assertion and completed Velopack packaging. Production
+signing remains unobserved.
+
+## Measured outcome
+
+The exact primary-rig numbers and provisional budgets are recorded in
+`docs/performance/windows-laptop-readiness.md`. Highlights:
+
+- Shell: 592 ms empty-profile ready; 572 ms warm median and 609 ms p95; about 188–190 MB.
+- Full app and Parakeet CPU worker: 2,281 ms first ready; 2,275 ms warm median and 2,313 ms p95;
+  about 973–975 MB combined.
+- Five shell and five runtime launches exited cleanly with no orphan workers.
+- Physical 5 s recording completed at 16 kHz mono with 0.058% normalized CPU and 7.4 MB working-set growth.
+- Parakeet CPU passed 390 ms, 696 ms, and 3,786 ms on the 10 s, 20 s, and 91.467 s fixtures.
+- Whisper CPU took 11,760 ms, 11,803 ms, and 32,249 ms and failed the provisional laptop latency budget.
+- Preview CPU took 2,489 ms, 2,723 ms, and 7,485 ms; its intended through-20-second cadence passes.
+- Cancellation completed in 165–603 ms with exact worker removal.
+- 1,000 reliability cycles passed with handle delta 9.
+
+Whisper CPU also failed German detection and the Spanish accuracy fixture. Small preview passed French and
+German but retained the known 52.38% Spanish WER. These are reported as product blockers, not performance
+noise.
+
+## Unobserved
+
+Only the AC-powered high-end NVIDIA desktop was measured. No-dedicated-GPU laptops, battery discharge,
+energy, temperature, sustained thermal throttling, sleep/resume, live model switching, and signed package
+runtime startup remain unobserved. The Phase 21 exit and public hardware requirements remain open.

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -111,12 +111,19 @@ try {
         'MainWindow.xbf',
         'DictationOverlayWindow.xbf',
         'EnviousWispr.RuntimeWorker.exe',
+        'EnviousWispr.RuntimeWorker.dll',
         'Microsoft.WindowsAppRuntime.Bootstrap.dll'
     )
     foreach ($required in $requiredPublishedFiles) {
         if (-not (Test-Path -LiteralPath (Join-Path $publishDirectory $required) -PathType Leaf)) {
             throw "Self-contained publish is missing required file: $required"
         }
+    }
+
+    Write-Host 'Validating the self-contained runtime worker can launch...'
+    & (Join-Path $publishDirectory 'EnviousWispr.RuntimeWorker.exe') 2>$null
+    if ($LASTEXITCODE -ne 2) {
+        throw "The self-contained runtime worker could not launch (exit $LASTEXITCODE)."
     }
 
     $packArguments = @(
@@ -214,7 +221,8 @@ try {
 finally {
     Pop-Location
     $resolvedScratch = [IO.Path]::GetFullPath($scratchRoot)
-    $resolvedTemp = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()) + [IO.Path]::DirectorySeparatorChar
+    $resolvedTemp = [IO.Path]::TrimEndingDirectorySeparator(
+        [IO.Path]::GetFullPath([IO.Path]::GetTempPath())) + [IO.Path]::DirectorySeparatorChar
     if ($resolvedScratch.StartsWith($resolvedTemp, [StringComparison]::OrdinalIgnoreCase) -and
         (Split-Path -Leaf $resolvedScratch).StartsWith('EnviousWisprPackage-', [StringComparison]::Ordinal)) {
         Remove-Item -LiteralPath $resolvedScratch -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/run-performance.ps1
+++ b/scripts/run-performance.ps1
@@ -1,0 +1,161 @@
+param(
+    [ValidatePattern('^[a-z0-9][a-z0-9-]{0,39}$')]
+    [string]$RunLabel = 'local',
+
+    [string]$OutputDirectory,
+
+    [switch]$IncludeLocalRuntime
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $repoRoot 'out\performance'
+}
+$OutputDirectory = [IO.Path]::GetFullPath($OutputDirectory)
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+function Resolve-DotNet10 {
+    $candidates = @(
+        (Join-Path ([Environment]::GetFolderPath('UserProfile')) '.dotnet\dotnet.exe'),
+        (Get-Command dotnet -ErrorAction SilentlyContinue).Source
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($candidate in $candidates) {
+        if (-not (Test-Path -LiteralPath $candidate)) {
+            continue
+        }
+
+        $sdks = & $candidate --list-sdks
+        if ($LASTEXITCODE -eq 0 -and $sdks -match '^10\.') {
+            return $candidate
+        }
+    }
+
+    throw '.NET 10 SDK is required for performance UAT.'
+}
+
+function Invoke-PerformanceStep {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [switch]$CaptureSafeJson
+    )
+
+    Write-Host "Running performance step: $Name"
+    $started = [DateTimeOffset]::UtcNow
+    $lines = @(& $Action 2>&1 | ForEach-Object { $_.ToString() })
+    $exitCode = $LASTEXITCODE
+    if ($null -eq $exitCode) {
+        $exitCode = 0
+    }
+    foreach ($line in $lines) {
+        Write-Host $line
+    }
+
+    $metrics = $null
+    if ($CaptureSafeJson) {
+        try {
+            $metrics = ($lines -join [Environment]::NewLine) | ConvertFrom-Json -ErrorAction Stop
+        }
+        catch {
+            # Only typed JSON from the public-fixture UAT tools is persisted.
+        }
+    }
+
+    [ordered]@{
+        name = $Name
+        succeeded = $exitCode -eq 0
+        exitCode = $exitCode
+        elapsedMilliseconds = [int64]([DateTimeOffset]::UtcNow - $started).TotalMilliseconds
+        metrics = $metrics
+    }
+}
+
+$dotnet10 = Resolve-DotNet10
+$timestamp = [DateTimeOffset]::UtcNow.ToString('yyyyMMddTHHmmssZ')
+$machinePath = Join-Path $OutputDirectory "$RunLabel-$timestamp-machine.json"
+$shellPath = Join-Path $OutputDirectory "$RunLabel-$timestamp-shell.json"
+$runtimePath = Join-Path $OutputDirectory "$RunLabel-$timestamp-runtime.json"
+$reportPath = Join-Path $OutputDirectory "$RunLabel-$timestamp-run.json"
+$steps = [System.Collections.Generic.List[object]]::new()
+
+Push-Location $repoRoot
+try {
+    $steps.Add((Invoke-PerformanceStep -Name 'portable-validation' -Action {
+        & pwsh -NoProfile -File '.\scripts\validate.ps1'
+    }))
+    $steps.Add((Invoke-PerformanceStep -Name 'machine-probe' -Action {
+        & $dotnet10 run --no-build --project '.\tools\compatibility-uat\EnviousWispr.Compatibility.Uat.csproj' `
+            -c Release -- --output $machinePath
+    }))
+    $steps.Add((Invoke-PerformanceStep -Name 'shell-startup-and-recording' -Action {
+        & $dotnet10 run --no-build --project '.\tools\performance-uat\EnviousWispr.Performance.Uat.csproj' `
+            -c Release -- --output $shellPath
+    }))
+    $steps.Add((Invoke-PerformanceStep -Name 'reliability-cycles-1000' -Action {
+        & $dotnet10 run --no-build --project '.\tools\reliability-uat\EnviousWispr.Reliability.Uat.csproj' `
+            -c Release -- --iterations 1000
+    } -CaptureSafeJson))
+
+    if ($IncludeLocalRuntime) {
+        $steps.Add((Invoke-PerformanceStep -Name 'full-runtime-startup-and-recording' -Action {
+            & $dotnet10 run --no-build --project '.\tools\performance-uat\EnviousWispr.Performance.Uat.csproj' `
+                -c Release -- --require-local-runtime --output $runtimePath
+        }))
+        $steps.Add((Invoke-PerformanceStep -Name 'parakeet-cpu-final-latency' -Action {
+            & $dotnet10 run --no-build --project '.\tools\asr-uat\EnviousWispr.Asr.Uat.csproj' -c Release -- cpu
+        } -CaptureSafeJson))
+        $steps.Add((Invoke-PerformanceStep -Name 'whisper-cpu-final-latency' -Action {
+            & $dotnet10 run --no-build --project '.\tools\whisper-uat\EnviousWispr.Whisper.Uat.csproj' -c Release -- cpu
+        } -CaptureSafeJson))
+        $steps.Add((Invoke-PerformanceStep -Name 'preview-cpu-cadence' -Action {
+            & $dotnet10 run --no-build --project '.\tools\whisper-uat\EnviousWispr.Whisper.Uat.csproj' `
+                -c Release -- cpu --preview-small
+        } -CaptureSafeJson))
+    }
+
+    $machine = if (Test-Path -LiteralPath $machinePath) {
+        Get-Content -LiteralPath $machinePath -Raw | ConvertFrom-Json
+    }
+    else {
+        $null
+    }
+    $shell = if (Test-Path -LiteralPath $shellPath) {
+        Get-Content -LiteralPath $shellPath -Raw | ConvertFrom-Json
+    }
+    else {
+        $null
+    }
+    $runtime = if (Test-Path -LiteralPath $runtimePath) {
+        Get-Content -LiteralPath $runtimePath -Raw | ConvertFrom-Json
+    }
+    else {
+        $null
+    }
+    $report = [ordered]@{
+        schemaVersion = 1
+        runLabel = $RunLabel
+        capturedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+        includeLocalRuntime = [bool]$IncludeLocalRuntime
+        machine = $machine
+        shell = $shell
+        runtime = $runtime
+        steps = @($steps)
+        succeeded = @($steps | Where-Object { -not $_.succeeded }).Count -eq 0
+        privacy = 'Only content-free timings, resource counts, coarse hardware classes, provider outcomes, and public-fixture quality metrics are recorded.'
+        unobserved = @(
+            'battery discharge and energy use',
+            'sustained thermal throttling',
+            'sleep and resume during a performance run',
+            'no-dedicated-GPU laptop classes',
+            'model switching during a live dictation session'
+        )
+    }
+    $report | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath $reportPath -Encoding utf8NoBOM
+    Write-Host "Performance report: $reportPath"
+    exit $(if ($report.succeeded) { 0 } else { 8 })
+}
+finally {
+    Pop-Location
+}

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -70,6 +70,13 @@ try {
     Write-Host "Building production WinUI app and module graph (Release, x64)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "src/Production/EnviousWispr.App/EnviousWispr.App.csproj", "-c", "Release", "--nologo", "-p:Platform=x64")
 
+    Write-Host "Validating the WinUI-bundled runtime worker can launch..."
+    $bundledWorker = Join-Path $repoRoot "src\Production\EnviousWispr.App\bin\x64\Release\net10.0-windows10.0.26100.0\win-x64\EnviousWispr.RuntimeWorker.exe"
+    & $bundledWorker 2>$null
+    if ($LASTEXITCODE -ne 2) {
+        throw "The WinUI-bundled runtime worker could not launch (exit $LASTEXITCODE)."
+    }
+
     Write-Host "Building native audio UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/audio-uat/EnviousWispr.Audio.Uat.csproj", "-c", "Release", "--nologo")
 
@@ -105,6 +112,9 @@ try {
 
     Write-Host "Building privacy-safe compatibility UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/compatibility-uat/EnviousWispr.Compatibility.Uat.csproj", "-c", "Release", "--nologo")
+
+    Write-Host "Building privacy-safe performance UAT harness (Release)..."
+    Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/performance-uat/EnviousWispr.Performance.Uat.csproj", "-c", "Release", "--nologo")
 
     Write-Host "Building native ASR UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/asr-uat/EnviousWispr.Asr.Uat.csproj", "-c", "Release", "--nologo")

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -306,9 +306,44 @@ public partial class App : Application, IAsyncDisposable
         }
 
         ApplyOverlayUatState();
-        ApplyReliabilityUatExit();
-
         _logger.Write(new AppLogEntry(DateTimeOffset.UtcNow, AppEventCode.ShellShown));
+        SignalPerformanceUatReady();
+        ApplyReliabilityUatExit();
+    }
+
+    private void SignalPerformanceUatReady()
+    {
+        SignalPerformanceUatEvent("ENVIOUSWISPR_UAT_READY_EVENT");
+        if (_transcriptionEngine is not null)
+        {
+            SignalPerformanceUatEvent("ENVIOUSWISPR_UAT_RUNTIME_READY_EVENT");
+        }
+    }
+
+    private static void SignalPerformanceUatEvent(string environmentVariable)
+    {
+        const string allowedPrefix = @"Local\EnviousLabs.EnviousWispr.PerformanceUat.";
+        var eventName = Environment.GetEnvironmentVariable(environmentVariable);
+        if (string.IsNullOrWhiteSpace(eventName) ||
+            eventName.Length > 200 ||
+            !eventName.StartsWith(allowedPrefix, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            using var readyEvent = EventWaitHandle.OpenExisting(eventName);
+            readyEvent.Set();
+        }
+        catch (Exception exception) when (exception is
+                                          ArgumentException or
+                                          WaitHandleCannotBeOpenedException or
+                                          UnauthorizedAccessException or
+                                          IOException)
+        {
+            // UAT instrumentation must never make normal startup fail.
+        }
     }
 
     private async Task<RecoveryTextLoadResult> LoadStartupRecoveryAsync()
@@ -1061,6 +1096,15 @@ public partial class App : Application, IAsyncDisposable
 
     private async Task ConfigureTranscriptionAsync(FinalAsrEngine configuredEngine)
     {
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("ENVIOUSWISPR_UAT_DISABLE_LOCAL_RUNTIME"),
+                "1",
+                StringComparison.Ordinal))
+        {
+            _window?.SetSessionStatus("Local transcription disabled for performance UAT");
+            return;
+        }
+
         var environmentEngine = Environment.GetEnvironmentVariable("ENVIOUSWISPR_ASR_ENGINE");
         if (Enum.TryParse<FinalAsrEngine>(environmentEngine, ignoreCase: true, out var parsedEngine))
         {

--- a/src/Production/EnviousWispr.App/EnviousWispr.App.csproj
+++ b/src/Production/EnviousWispr.App/EnviousWispr.App.csproj
@@ -43,11 +43,18 @@
     <ProjectReference Include="..\EnviousWispr.Services\EnviousWispr.Services.csproj" />
   </ItemGroup>
 
-  <Target Name="CopyRuntimeWorkerForApp" AfterTargets="Build">
+  <Target Name="CopyRuntimeWorkerForAppBuild" AfterTargets="Build" Condition="'$(SelfContained)' != 'true'">
     <ItemGroup>
-      <RuntimeWorkerFiles Include="..\EnviousWispr.RuntimeWorker\bin\$(Platform)\$(Configuration)\net10.0-windows10.0.26100.0\win-x64\EnviousWispr.RuntimeWorker*" />
+      <RuntimeWorkerBuildFiles Include="..\EnviousWispr.RuntimeWorker\bin\$(Platform)\$(Configuration)\net10.0-windows10.0.26100.0\EnviousWispr.RuntimeWorker*" />
     </ItemGroup>
-    <Copy SourceFiles="@(RuntimeWorkerFiles)" DestinationFiles="@(RuntimeWorkerFiles->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(RuntimeWorkerBuildFiles)" DestinationFiles="@(RuntimeWorkerBuildFiles->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CopyRuntimeWorkerForAppPublish" AfterTargets="Publish" Condition="'$(SelfContained)' == 'true'">
+    <ItemGroup>
+      <RuntimeWorkerPublishFiles Include="..\EnviousWispr.RuntimeWorker\bin\$(Platform)\$(Configuration)\net10.0-windows10.0.26100.0\$(RuntimeIdentifier)\EnviousWispr.RuntimeWorker*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RuntimeWorkerPublishFiles)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="CopyUnpackagedWinUiResourcesForPublish" AfterTargets="Publish">

--- a/tools/asr-uat/Program.cs
+++ b/tools/asr-uat/Program.cs
@@ -14,26 +14,39 @@ var clips = new Dictionary<string, float[]>(StringComparer.Ordinal)
     ["clip20"] = ReadWaveFile(Path.Combine(audioDirectory, "clip20.wav")),
     ["clip94"] = ReadWaveFile(Path.Combine(audioDirectory, "clip94.wav")),
 };
+var requestedProvider = args.FirstOrDefault()?.ToLowerInvariant() switch
+{
+    null => null,
+    "cpu" => "cpu",
+    "cuda" => "cuda",
+    _ => throw new ArgumentException("Use cpu or cuda, or omit the provider to test both."),
+};
 
-var cpu = await RunProviderSafelyAsync(
-    new ParakeetEngineOptions(
-        modelDirectory,
-        RuntimeProviderKind.Cpu,
-        ParakeetModelPack.Quantized,
-        IntraOpThreads: 8),
-    clips);
-var cuda = await RunProviderSafelyAsync(
-    new ParakeetEngineOptions(
-        modelDirectory,
-        RuntimeProviderKind.Cuda,
-        ParakeetModelPack.FullPrecision,
-        IntraOpThreads: 1,
-        CudaRuntimeDirectory: Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR")),
-    clips);
-var isolated = await RunIsolatedAsync(repositoryRoot, modelDirectory, clips);
+var cpu = requestedProvider is null or "cpu"
+    ? await RunProviderSafelyAsync(
+        new ParakeetEngineOptions(
+            modelDirectory,
+            RuntimeProviderKind.Cpu,
+            ParakeetModelPack.Quantized,
+            IntraOpThreads: 8),
+        clips)
+    : null;
+var cuda = requestedProvider is null or "cuda"
+    ? await RunProviderSafelyAsync(
+        new ParakeetEngineOptions(
+            modelDirectory,
+            RuntimeProviderKind.Cuda,
+            ParakeetModelPack.FullPrecision,
+            IntraOpThreads: 1,
+            CudaRuntimeDirectory: Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR")),
+        clips)
+    : null;
+var isolated = requestedProvider is null or "cuda"
+    ? await RunIsolatedAsync(repositoryRoot, modelDirectory, clips)
+    : null;
 
 Console.WriteLine(JsonSerializer.Serialize(new { cpu, cuda, isolated }));
-return cpu.Passed && cuda.Passed && isolated.Passed ? 0 : 6;
+return (cpu?.Passed ?? true) && (cuda?.Passed ?? true) && (isolated?.Passed ?? true) ? 0 : 6;
 
 static async Task<IsolatedResult> RunIsolatedAsync(
     string repositoryRoot,

--- a/tools/performance-uat/EnviousWispr.Performance.Uat.csproj
+++ b/tools/performance-uat/EnviousWispr.Performance.Uat.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.22000.0</TargetPlatformMinVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Audio\EnviousWispr.Audio.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Core\EnviousWispr.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Management" Version="10.0.11" />
+  </ItemGroup>
+</Project>

--- a/tools/performance-uat/Program.cs
+++ b/tools/performance-uat/Program.cs
@@ -1,0 +1,629 @@
+using System.Diagnostics;
+using System.Management;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EnviousWispr.Audio;
+using EnviousWispr.Core.Audio;
+using EnviousWispr.Core.Dictation;
+
+var startupIterations = IntegerArgument(args, "--startup-iterations", defaultValue: 5, minimum: 1, maximum: 20);
+var idleSeconds = IntegerArgument(args, "--idle-seconds", defaultValue: 3, minimum: 1, maximum: 20);
+var recordingSeconds = IntegerArgument(args, "--recording-seconds", defaultValue: 5, minimum: 1, maximum: 30);
+var requireLocalRuntime = args.Contains("--require-local-runtime", StringComparer.OrdinalIgnoreCase);
+var outputPath = ArgumentValue(args, "--output");
+var repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+var applicationExecutable = Path.Combine(
+    repositoryRoot,
+    "src",
+    "Production",
+    "EnviousWispr.App",
+    "bin",
+    "x64",
+    "Release",
+    "net10.0-windows10.0.26100.0",
+    "win-x64",
+    "EnviousWispr.App.exe");
+if (!File.Exists(applicationExecutable))
+{
+    throw new FileNotFoundException("Build the Release x64 WinUI application before performance UAT.");
+}
+
+RequireNoExistingApplicationProcess();
+var scratch = Path.Combine(Path.GetTempPath(), $"EnviousWispr-performance-uat-{Guid.NewGuid():N}");
+Directory.CreateDirectory(scratch);
+try
+{
+    var dataDirectory = Path.Combine(scratch, "app-data");
+    var localModelDirectory = Path.Combine(repositoryRoot, "models", "parakeet-tdt-0.6b-v3");
+    if (requireLocalRuntime && !Directory.Exists(localModelDirectory))
+    {
+        throw new DirectoryNotFoundException(
+            "The local Parakeet model pack is required for full-runtime performance UAT.");
+    }
+
+    var startupResults = new List<StartupIteration>();
+    for (var iteration = 0; iteration < startupIterations; iteration++)
+    {
+        startupResults.Add(await MeasureStartupAsync(
+            applicationExecutable,
+            dataDirectory,
+            localModelDirectory,
+            iteration,
+            idleSeconds,
+            requireLocalRuntime));
+    }
+
+    var recording = await MeasureRecordingAsync(TimeSpan.FromSeconds(recordingSeconds));
+    var budgets = PerformanceBudgets.ProvisionalLaptop;
+    var coldStart = startupResults[0];
+    var warmStarts = startupResults.Skip(1).ToArray();
+    var evaluation = new PerformanceEvaluation(
+        ColdStartupPassed: coldStart.ReadyMilliseconds <= budgets.ShellReadyMilliseconds,
+        WarmStartupPassed: warmStarts.Length == 0 ||
+            Percentile(warmStarts.Select(result => result.ReadyMilliseconds), 0.95) <= budgets.ShellReadyMilliseconds,
+        ReadyMemoryPassed: startupResults.All(result =>
+            result.ReadyCombinedWorkingSetBytes <= budgets.ReadyCombinedWorkingSetBytes),
+        IdleCpuPassed: startupResults.All(result => result.IdleCpuPercent <= budgets.IdleCpuPercent),
+        RecordingCpuPassed: recording.CpuPercent <= budgets.RecordingCpuPercent,
+        RecordingMemoryPassed: recording.WorkingSetGrowthBytes <= budgets.RecordingWorkingSetGrowthBytes,
+        LifecyclePassed: startupResults.All(result => result.CleanExit && result.OrphanChildProcessCount == 0),
+        RecordingPassed: recording.CapturePassed,
+        RuntimeReadinessPassed: !requireLocalRuntime || startupResults.All(result =>
+            result.LocalRuntimeReady && result.ChildProcessCount > 0));
+
+    var report = new PerformanceReport(
+        SchemaVersion: 1,
+        CapturedAtUtc: DateTimeOffset.UtcNow,
+        LogicalProcessorCount: Environment.ProcessorCount,
+        requireLocalRuntime,
+        Power: ProbePower(),
+        budgets,
+        coldStart,
+        WarmReadyMedianMilliseconds: warmStarts.Length == 0
+            ? null
+            : Percentile(warmStarts.Select(result => result.ReadyMilliseconds), 0.50),
+        WarmReadyP95Milliseconds: warmStarts.Length == 0
+            ? null
+            : Percentile(warmStarts.Select(result => result.ReadyMilliseconds), 0.95),
+        startupResults,
+        recording,
+        evaluation,
+        Succeeded: evaluation.AllPassed,
+        Privacy: "No audio, transcript, clipboard content, device name or identifier, account, process identifier, event name, or path is recorded.");
+    var json = JsonSerializer.Serialize(report, new JsonSerializerOptions
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    });
+    Console.WriteLine(json);
+    if (!string.IsNullOrWhiteSpace(outputPath))
+    {
+        var resolvedOutput = Path.GetFullPath(outputPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(resolvedOutput)
+                                  ?? throw new InvalidOperationException("Performance output has no directory."));
+        await File.WriteAllTextAsync(resolvedOutput, json + Environment.NewLine);
+    }
+
+    return report.Succeeded ? 0 : 7;
+}
+finally
+{
+    DeleteOwnedScratch(scratch);
+}
+
+static async Task<StartupIteration> MeasureStartupAsync(
+    string executable,
+    string dataDirectory,
+    string localModelDirectory,
+    int iteration,
+    int idleSeconds,
+    bool requireLocalRuntime)
+{
+    var eventName = $@"Local\EnviousLabs.EnviousWispr.PerformanceUat.{Guid.NewGuid():N}";
+    var runtimeEventName = $@"Local\EnviousLabs.EnviousWispr.PerformanceUat.{Guid.NewGuid():N}";
+    using var readyEvent = new EventWaitHandle(false, EventResetMode.ManualReset, eventName);
+    using var runtimeReadyEvent = new EventWaitHandle(false, EventResetMode.ManualReset, runtimeEventName);
+    var startInfo = new ProcessStartInfo(executable)
+    {
+        UseShellExecute = false,
+        WorkingDirectory = Path.GetDirectoryName(executable)
+                           ?? throw new InvalidOperationException("The application has no working directory."),
+    };
+    startInfo.Environment["ENVIOUSWISPR_DATA_DIRECTORY"] = dataDirectory;
+    startInfo.Environment["ENVIOUSWISPR_UAT_CREDENTIAL_SUFFIX"] = $"performance-{Guid.NewGuid():N}";
+    startInfo.Environment["ENVIOUSWISPR_UAT_READY_EVENT"] = eventName;
+    startInfo.Environment["ENVIOUSWISPR_UAT_RUNTIME_READY_EVENT"] = runtimeEventName;
+    if (requireLocalRuntime)
+    {
+        startInfo.Environment["ENVIOUSWISPR_ASR_ENGINE"] = "Parakeet";
+        startInfo.Environment["ENVIOUSWISPR_MODEL_DIRECTORY"] = localModelDirectory;
+    }
+    else
+    {
+        startInfo.Environment["ENVIOUSWISPR_UAT_DISABLE_LOCAL_RUNTIME"] = "1";
+    }
+    startInfo.Environment["ENVIOUSWISPR_UAT_EXIT_AFTER_MILLISECONDS"] =
+        checked((idleSeconds + 1) * 1_000).ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    var timer = Stopwatch.StartNew();
+    using var process = Process.Start(startInfo)
+        ?? throw new InvalidOperationException("The WinUI application process did not start.");
+    var ready = readyEvent.WaitOne(TimeSpan.FromSeconds(30));
+    timer.Stop();
+    if (!ready || process.HasExited)
+    {
+        await StopOwnedProcessAsync(process);
+        return new StartupIteration(
+            iteration + 1,
+            EmptyDataDirectory: iteration == 0,
+            LocalRuntimeReady: false,
+            ReadyMilliseconds: timer.ElapsedMilliseconds,
+            ReadyCombinedWorkingSetBytes: 0,
+            ReadyCombinedPrivateBytes: 0,
+            ReadyHandleCount: 0,
+            ChildProcessCount: 0,
+            IdleCpuPercent: 100,
+            IdleWorkingSetGrowthBytes: 0,
+            CleanExit: false,
+            OrphanChildProcessCount: 0);
+    }
+
+    var localRuntimeReady = runtimeReadyEvent.WaitOne(TimeSpan.Zero);
+    var readyResources = ReadProcessTreeResources(process);
+    await Task.Delay(TimeSpan.FromSeconds(idleSeconds));
+    var idleResources = ReadProcessTreeResources(process);
+    var idleCpuPercent = NormalizeCpu(
+        idleResources.TotalProcessorTime - readyResources.TotalProcessorTime,
+        TimeSpan.FromSeconds(idleSeconds));
+    var observedChildren = readyResources.ChildProcessIds
+        .Concat(idleResources.ChildProcessIds)
+        .Distinct()
+        .ToArray();
+    var cleanExit = await WaitForCleanExitAsync(process, TimeSpan.FromSeconds(10));
+    await Task.Delay(TimeSpan.FromMilliseconds(200));
+    var orphanCount = observedChildren.Count(IsProcessRunning);
+    return new StartupIteration(
+        iteration + 1,
+        EmptyDataDirectory: iteration == 0,
+        localRuntimeReady,
+        ReadyMilliseconds: timer.ElapsedMilliseconds,
+        readyResources.CombinedWorkingSetBytes,
+        readyResources.CombinedPrivateBytes,
+        readyResources.HandleCount,
+        readyResources.ChildProcessIds.Count,
+        idleCpuPercent,
+        Math.Max(0, idleResources.CombinedWorkingSetBytes - readyResources.CombinedWorkingSetBytes),
+        cleanExit,
+        orphanCount);
+}
+
+static async Task<RecordingMeasurement> MeasureRecordingAsync(TimeSpan requestedDuration)
+{
+    using var process = Process.GetCurrentProcess();
+    GC.Collect();
+    GC.WaitForPendingFinalizers();
+    GC.Collect();
+    process.Refresh();
+    var beforeCpu = process.TotalProcessorTime;
+    var beforeWorkingSet = process.WorkingSet64;
+    var beforeHandles = process.HandleCount;
+    var frequencyBefore = ProbeProcessorFrequencyRatio();
+    await using var capture = new WasapiAudioCapture();
+    var started = await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+    if (!started.Succeeded)
+    {
+        return new RecordingMeasurement(
+            RequestedMilliseconds: checked((long)requestedDuration.TotalMilliseconds),
+            CapturedMilliseconds: 0,
+            SampleRate: 0,
+            Channels: 0,
+            CpuPercent: 100,
+            WorkingSetGrowthBytes: 0,
+            HandleGrowth: 0,
+            ProcessorFrequencyRatioBefore: frequencyBefore,
+            ProcessorFrequencyRatioAfter: ProbeProcessorFrequencyRatio(),
+            CapturePassed: false);
+    }
+
+    var wallTimer = Stopwatch.StartNew();
+    await Task.Delay(requestedDuration);
+    var result = await capture.StopAsync();
+    wallTimer.Stop();
+    process.Refresh();
+    var cpuPercent = NormalizeCpu(process.TotalProcessorTime - beforeCpu, wallTimer.Elapsed);
+    var capturedMilliseconds = result.SampleRate > 0
+        ? result.Samples.Length * 1_000L / result.SampleRate
+        : 0;
+    return new RecordingMeasurement(
+        RequestedMilliseconds: checked((long)requestedDuration.TotalMilliseconds),
+        capturedMilliseconds,
+        result.SampleRate,
+        result.Channels,
+        cpuPercent,
+        Math.Max(0, process.WorkingSet64 - beforeWorkingSet),
+        process.HandleCount - beforeHandles,
+        frequencyBefore,
+        ProbeProcessorFrequencyRatio(),
+        CapturePassed: result.Outcome == AudioCaptureOutcome.Completed &&
+            result.SampleRate == AudioSampleConverter.TargetSampleRate &&
+            result.Channels == 1 &&
+            capturedMilliseconds >= requestedDuration.TotalMilliseconds * 0.90);
+}
+
+static ProcessTreeResources ReadProcessTreeResources(Process root)
+{
+    root.Refresh();
+    var children = ChildProcessIds(root.Id);
+    long workingSet = root.WorkingSet64;
+    long privateBytes = root.PrivateMemorySize64;
+    var handles = root.HandleCount;
+    var processorTime = root.TotalProcessorTime;
+    foreach (var childId in children)
+    {
+        try
+        {
+            using var child = Process.GetProcessById(childId);
+            child.Refresh();
+            workingSet = checked(workingSet + child.WorkingSet64);
+            privateBytes = checked(privateBytes + child.PrivateMemorySize64);
+            handles = checked(handles + child.HandleCount);
+            processorTime += child.TotalProcessorTime;
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException)
+        {
+            // A short-lived owned worker can exit between enumeration and sampling.
+        }
+    }
+
+    return new ProcessTreeResources(workingSet, privateBytes, handles, processorTime, children);
+}
+
+static IReadOnlyList<int> ChildProcessIds(int parentProcessId)
+{
+    try
+    {
+        using var searcher = new ManagementObjectSearcher(
+            $"SELECT ProcessId FROM Win32_Process WHERE ParentProcessId = {parentProcessId}");
+        using var results = searcher.Get();
+        return results.Cast<ManagementObject>()
+            .Select(result => Convert.ToInt32(result["ProcessId"], System.Globalization.CultureInfo.InvariantCulture))
+            .ToArray();
+    }
+    catch (Exception exception) when (exception is
+                                      ManagementException or
+                                      COMException or
+                                      UnauthorizedAccessException)
+    {
+        return [];
+    }
+}
+
+static async Task<bool> WaitForCleanExitAsync(Process process, TimeSpan timeout)
+{
+    using var cancellation = new CancellationTokenSource(timeout);
+    try
+    {
+        await process.WaitForExitAsync(cancellation.Token);
+        return process.ExitCode == 0;
+    }
+    catch (OperationCanceledException)
+    {
+        await StopOwnedProcessAsync(process);
+        return false;
+    }
+}
+
+static async Task StopOwnedProcessAsync(Process process)
+{
+    if (process.HasExited)
+    {
+        return;
+    }
+
+    process.Kill(entireProcessTree: true);
+    await process.WaitForExitAsync();
+}
+
+static bool IsProcessRunning(int processId)
+{
+    try
+    {
+        using var process = Process.GetProcessById(processId);
+        return !process.HasExited;
+    }
+    catch (ArgumentException)
+    {
+        return false;
+    }
+}
+
+static void RequireNoExistingApplicationProcess()
+{
+    var existing = Process.GetProcessesByName("EnviousWispr.App");
+    try
+    {
+        if (existing.Length > 0)
+        {
+            throw new InvalidOperationException(
+                "Performance UAT requires no existing EnviousWispr.App process and will not stop one it did not create.");
+        }
+    }
+    finally
+    {
+        foreach (var process in existing)
+        {
+            process.Dispose();
+        }
+    }
+}
+
+static double NormalizeCpu(TimeSpan cpuTime, TimeSpan wallTime)
+{
+    if (wallTime <= TimeSpan.Zero)
+    {
+        return 0;
+    }
+
+    return Math.Round(
+        cpuTime.TotalMilliseconds / wallTime.TotalMilliseconds / Environment.ProcessorCount * 100,
+        3,
+        MidpointRounding.AwayFromZero);
+}
+
+static long Percentile(IEnumerable<long> source, double percentile)
+{
+    var values = source.Order().ToArray();
+    if (values.Length == 0)
+    {
+        throw new ArgumentException("A percentile requires at least one value.", nameof(source));
+    }
+
+    var rank = Math.Clamp((int)Math.Ceiling(percentile * values.Length) - 1, 0, values.Length - 1);
+    return values[rank];
+}
+
+static PowerMeasurement ProbePower()
+{
+    if (!NativeMethods.GetSystemPowerStatus(out var status))
+    {
+        return new PowerMeasurement(PowerSource.Unknown, BatteryChargeTier.Unknown, null);
+    }
+
+    var source = status.AcLineStatus switch
+    {
+        0 => PowerSource.Battery,
+        1 => PowerSource.Ac,
+        _ => PowerSource.Unknown,
+    };
+    var battery = status.BatteryLifePercent switch
+    {
+        byte.MaxValue => BatteryChargeTier.Unknown,
+        < 20 => BatteryChargeTier.Below20Percent,
+        < 50 => BatteryChargeTier.From20To49Percent,
+        < 80 => BatteryChargeTier.From50To79Percent,
+        _ => BatteryChargeTier.AtLeast80Percent,
+    };
+    return new PowerMeasurement(source, battery, ProbeProcessorFrequencyRatio());
+}
+
+static double? ProbeProcessorFrequencyRatio()
+{
+    try
+    {
+        using var searcher = new ManagementObjectSearcher(
+            "SELECT CurrentClockSpeed, MaxClockSpeed FROM Win32_Processor");
+        using var results = searcher.Get();
+        var ratios = results.Cast<ManagementObject>()
+            .Select(result =>
+            {
+                var current = Convert.ToDouble(result["CurrentClockSpeed"], System.Globalization.CultureInfo.InvariantCulture);
+                var maximum = Convert.ToDouble(result["MaxClockSpeed"], System.Globalization.CultureInfo.InvariantCulture);
+                return maximum > 0 ? current / maximum : 0;
+            })
+            .Where(ratio => ratio > 0)
+            .ToArray();
+        return ratios.Length == 0
+            ? null
+            : Math.Round(ratios.Average(), 3, MidpointRounding.AwayFromZero);
+    }
+    catch (Exception exception) when (exception is
+                                      ManagementException or
+                                      COMException or
+                                      UnauthorizedAccessException)
+    {
+        return null;
+    }
+}
+
+static string? ArgumentValue(string[] arguments, string name)
+{
+    for (var index = 0; index < arguments.Length - 1; index++)
+    {
+        if (string.Equals(arguments[index], name, StringComparison.OrdinalIgnoreCase))
+        {
+            return arguments[index + 1];
+        }
+    }
+
+    return null;
+}
+
+static int IntegerArgument(
+    string[] arguments,
+    string name,
+    int defaultValue,
+    int minimum,
+    int maximum)
+{
+    var value = ArgumentValue(arguments, name);
+    if (value is null)
+    {
+        return defaultValue;
+    }
+
+    if (!int.TryParse(value, out var parsed) || parsed < minimum || parsed > maximum)
+    {
+        throw new ArgumentException($"{name} must be from {minimum} through {maximum}.");
+    }
+
+    return parsed;
+}
+
+static string FindRepositoryRoot(string startDirectory)
+{
+    var directory = new DirectoryInfo(startDirectory);
+    while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "CLAUDE.md")))
+    {
+        directory = directory.Parent;
+    }
+
+    return directory?.FullName ?? throw new DirectoryNotFoundException(
+        "The repository root could not be located.");
+}
+
+static void DeleteOwnedScratch(string scratch)
+{
+    if (!Directory.Exists(scratch))
+    {
+        return;
+    }
+
+    var resolved = Path.GetFullPath(scratch);
+    var expectedParent = Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.GetTempPath()));
+    var actualParent = Directory.GetParent(resolved)?.FullName;
+    if (!string.Equals(actualParent, expectedParent, StringComparison.OrdinalIgnoreCase) ||
+        !new DirectoryInfo(resolved).Name.StartsWith("EnviousWispr-performance-uat-", StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException("Refusing to remove an unexpected performance UAT directory.");
+    }
+
+    Directory.Delete(resolved, recursive: true);
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct SystemPowerStatus
+{
+    public byte AcLineStatus;
+    public byte BatteryFlag;
+    public byte BatteryLifePercent;
+    public byte SystemStatusFlag;
+    public uint BatteryLifeTime;
+    public uint BatteryFullLifeTime;
+}
+
+internal static class NativeMethods
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetSystemPowerStatus(out SystemPowerStatus status);
+}
+
+internal enum PowerSource
+{
+    Unknown,
+    Ac,
+    Battery,
+}
+
+internal enum BatteryChargeTier
+{
+    Unknown,
+    Below20Percent,
+    From20To49Percent,
+    From50To79Percent,
+    AtLeast80Percent,
+}
+
+internal sealed record PerformanceBudget(
+    long ShellReadyMilliseconds,
+    long ReadyCombinedWorkingSetBytes,
+    double IdleCpuPercent,
+    double RecordingCpuPercent,
+    long RecordingWorkingSetGrowthBytes);
+
+internal static class PerformanceBudgets
+{
+    public static PerformanceBudget ProvisionalLaptop { get; } = new(
+        ShellReadyMilliseconds: 5_000,
+        ReadyCombinedWorkingSetBytes: 2L * 1024 * 1024 * 1024,
+        IdleCpuPercent: 5,
+        RecordingCpuPercent: 15,
+        RecordingWorkingSetGrowthBytes: 256L * 1024 * 1024);
+}
+
+internal sealed record StartupIteration(
+    int Iteration,
+    bool EmptyDataDirectory,
+    bool LocalRuntimeReady,
+    long ReadyMilliseconds,
+    long ReadyCombinedWorkingSetBytes,
+    long ReadyCombinedPrivateBytes,
+    int ReadyHandleCount,
+    int ChildProcessCount,
+    double IdleCpuPercent,
+    long IdleWorkingSetGrowthBytes,
+    bool CleanExit,
+    int OrphanChildProcessCount);
+
+internal sealed record RecordingMeasurement(
+    long RequestedMilliseconds,
+    long CapturedMilliseconds,
+    int SampleRate,
+    int Channels,
+    double CpuPercent,
+    long WorkingSetGrowthBytes,
+    int HandleGrowth,
+    double? ProcessorFrequencyRatioBefore,
+    double? ProcessorFrequencyRatioAfter,
+    bool CapturePassed);
+
+internal sealed record PowerMeasurement(
+    PowerSource Source,
+    BatteryChargeTier BatteryCharge,
+    double? ProcessorFrequencyRatio);
+
+internal sealed record PerformanceEvaluation(
+    bool ColdStartupPassed,
+    bool WarmStartupPassed,
+    bool ReadyMemoryPassed,
+    bool IdleCpuPassed,
+    bool RecordingCpuPassed,
+    bool RecordingMemoryPassed,
+    bool LifecyclePassed,
+    bool RecordingPassed,
+    bool RuntimeReadinessPassed)
+{
+    public bool AllPassed => ColdStartupPassed &&
+        WarmStartupPassed &&
+        ReadyMemoryPassed &&
+        IdleCpuPassed &&
+        RecordingCpuPassed &&
+        RecordingMemoryPassed &&
+        LifecyclePassed &&
+        RecordingPassed &&
+        RuntimeReadinessPassed;
+}
+
+internal sealed record PerformanceReport(
+    int SchemaVersion,
+    DateTimeOffset CapturedAtUtc,
+    int LogicalProcessorCount,
+    bool RequireLocalRuntime,
+    PowerMeasurement Power,
+    PerformanceBudget ProvisionalLaptopBudget,
+    StartupIteration ColdStart,
+    long? WarmReadyMedianMilliseconds,
+    long? WarmReadyP95Milliseconds,
+    IReadOnlyList<StartupIteration> StartupIterations,
+    RecordingMeasurement Recording,
+    PerformanceEvaluation Evaluation,
+    bool Succeeded,
+    string Privacy);
+
+internal sealed record ProcessTreeResources(
+    long CombinedWorkingSetBytes,
+    long CombinedPrivateBytes,
+    int HandleCount,
+    TimeSpan TotalProcessorTime,
+    IReadOnlyList<int> ChildProcessIds);


### PR DESCRIPTION
## Outcome

Adds a privacy-safe Windows performance and laptop-readiness gate, fixes the app/runtime-worker build and self-contained packaging contract, and records the measured desktop baseline without converting it into unsupported laptop requirements.

## What changed

- measures five isolated WinUI shell or full-runtime launches, direct-child resources, idle overhead, physical WASAPI recording, clean shutdown, and orphan workers
- aggregates 1,000-cycle reliability plus optional Parakeet, Whisper, and preview CPU public-fixture results
- keeps raw reports ignored and excludes content, device identity, process identity, event names, and paths
- validates the bundled development worker and the self-contained published worker can actually launch
- copies the correct framework-dependent worker for development and the complete RID worker set after self-contained publish
- documents provisional budgets, current evidence, and unobserved laptop cells

## Measured evidence

- shell warm p95: 609 ms; full-runtime warm p95: 2,313 ms
- full-runtime working set: 973-975 MB; idle normalized CPU: 0.195-0.439%
- 5 s physical recording: 0.058% normalized CPU and 7.4 MB working-set growth
- Parakeet CPU: 390 / 696 / 3,786 ms on 10 / 20 / 91.5 s fixtures
- Whisper CPU: 11,760 / 11,803 / 32,249 ms and fails the provisional laptop budget
- preview CPU passes cadence through 20 s; known Spanish quality case remains failed
- 1,000 lifecycle cycles passed with handle delta 9

## Validation

- canonical validation: 34 proof tests and 350 production tests passed
- clean Release/x64 WinUI rebuild: zero warnings, zero errors
- bundled worker launch assertion passed with expected no-arguments exit 2
- self-contained unsigned founder 0.21.1 packaging completed after the worker assertion
- focused full-runtime smoke observed one worker, clean exit, zero orphans, and successful physical recording
- staged diff and ignored report privacy scans passed

## Remaining blockers

Phase 21 remains open. Battery and sustained thermal runs, lower-spec integrated-graphics laptops, sleep/resume under load, live model switching, production signing, Whisper CPU latency, and the known Spanish quality case remain unobserved or failed.

Closes #48
Advances #47