### PR TITLE
Phase 22: founder and private beta release gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/private-beta-bug.yml
+++ b/.github/ISSUE_TEMPLATE/private-beta-bug.yml
@@ -1,0 +1,86 @@
+name: Private beta bug or crash
+description: Report a founder/private-beta failure without sharing private content.
+title: "[Private beta] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Never paste dictated or polished text, audio, clipboard or surrounding text, credentials, account names, private paths, window titles, raw logs, or crash dumps. Attach only the privacy-safe diagnostics export created by EnviousWispr.
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Release channel
+      options:
+        - Founder
+        - Beta
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      placeholder: 0.0.0
+    validations:
+      required: true
+  - type: input
+    id: windows
+    attributes:
+      label: Windows edition and build
+      description: Use Settings > System > About or winver. Do not include the device name or product ID.
+      placeholder: Windows 11 25H2 build 26200.0000
+    validations:
+      required: true
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Coarse hardware class
+      options:
+        - CPU-only or integrated graphics
+        - Intel graphics
+        - AMD graphics
+        - NVIDIA graphics
+        - Unknown or other
+    validations:
+      required: true
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Failed stage
+      options:
+        - Install, repair, update, rollback, or uninstall
+        - Startup, tray, settings, or onboarding
+        - Hotkey or recording
+        - Preview or final transcription
+        - Text processing or polish
+        - Delivery into the target app
+        - Diagnostics or feedback
+        - Shutdown, sleep, or resume
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Sanitized reproduction steps
+      description: Describe actions and visible product states only. Replace private app/file/account names with generic labels.
+    validations:
+      required: true
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Frequency
+      options:
+        - Once
+        - Intermittent
+        - Every time
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy confirmation
+      options:
+        - label: I removed private content and will attach only an EnviousWispr privacy-safe diagnostics export, if available.
+          required: true

--- a/.github/ISSUE_TEMPLATE/private-beta-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/private-beta-feedback.yml
@@ -1,0 +1,68 @@
+name: Private beta product feedback
+description: Share a content-free founder/private-beta observation or request.
+title: "[Private beta feedback] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the workflow, not what you dictated. Never include transcript, audio, clipboard or surrounding text, credentials, accounts, private paths, device identity, target-window titles, raw logs, or crash dumps.
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Release channel
+      options:
+        - Founder
+        - Beta
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      placeholder: 0.0.0
+    validations:
+      required: true
+  - type: dropdown
+    id: workflow
+    attributes:
+      label: Workflow area
+      options:
+        - Install and updates
+        - Onboarding and settings
+        - Hold, speak, release
+        - Live preview
+        - Final transcription
+        - Polishing
+        - Delivery into another app
+        - History, portability, or diagnostics
+        - Accessibility or international use
+        - Performance, battery, or thermal behavior
+    validations:
+      required: true
+  - type: textarea
+    id: observation
+    attributes:
+      label: Sanitized observation
+      description: State what you expected and what the product did using generic, content-free examples.
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - Prevents daily use
+        - Repeatedly interrupts daily use
+        - Noticeable but recoverable
+        - Minor improvement
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy confirmation
+      options:
+        - label: I removed private content and stable device or account identifiers from this report.
+          required: true

--- a/docs/distribution/private-beta-evidence.example.json
+++ b/docs/distribution/private-beta-evidence.example.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "channel": "win-x64-founder",
+  "version": "0.0.0",
+  "machineClass": "replace-with-coarse-class",
+  "checks": {
+    "cleanInstall": "unobserved",
+    "admittedUpdate": "unobserved",
+    "atomicRestart": "unobserved",
+    "forcedFailureRollback": "unobserved",
+    "repair": "unobserved",
+    "uninstall": "unobserved",
+    "dataPreservation": "unobserved",
+    "diagnosticsConsent": "unobserved",
+    "feedbackTriage": "unobserved",
+    "crashTriage": "unobserved",
+    "smartScreen": "unobserved",
+    "endpointSecurity": "unobserved"
+  },
+  "approvals": {
+    "founderRelease": false,
+    "updateEndpoint": false,
+    "telemetryServerPolicy": false
+  },
+  "blockerIssueNumbers": [42, 44, 45, 47, 50]
+}

--- a/docs/distribution/private-beta-release.md
+++ b/docs/distribution/private-beta-release.md
@@ -1,0 +1,36 @@
+# Founder and private-beta release gate
+
+The founder and beta channels are release candidates only after the signed artifact set and one
+content-free lifecycle evidence record pass `scripts/validate-release-candidate.ps1`. This gate is
+independent of packaging: it rehashes the immutable artifact set, rechecks the isolated channel identity,
+requires a valid Envious Labs signature on Setup and every packaged executable, and refuses unsigned
+development output.
+
+Lifecycle evidence is a bounded record, not a free-text report. Copy
+`docs/distribution/private-beta-evidence.example.json` outside the repository for each coarse machine class,
+replace only the typed values, and keep every check `unobserved` or `failed` until the exact native path has
+been witnessed. Do not include paths, machine names, accounts, device identifiers, crash text, transcript,
+audio, clipboard data, credentials, endpoint secrets, or user feedback in this record. Link detailed
+privacy-safe evidence from the corresponding GitHub issue.
+
+Run the admission gate after packaging and native lifecycle UAT:
+
+```powershell
+pwsh -NoProfile -File .\scripts\validate-release-candidate.ps1 `
+  -DistributionDirectory <immutable-founder-or-beta-output> `
+  -Channel founder `
+  -Version <version> `
+  -EvidenceFile <content-free-evidence.json>
+```
+
+All twelve native checks must be `passed`, all three approvals must be `true`, and
+`blockerIssueNumbers` must be empty. Approval values mean the founder approved this exact release, the
+channel-specific immutable HTTPS update endpoint is operational, and the telemetry server minimization,
+access, retention, deletion, incident-response, sampling, and regional-processing policy is approved.
+They are not substitutes for those decisions.
+
+The gate does not publish, upload, sign, install, update, roll back, merge, or close issues. A passing
+record for one machine class does not cover another. Store the signed artifacts immutably, publish the new
+channel index last, retain the last-known-good signed release, and record daily-use, feedback, and crash
+triage in issue #50. Founder and beta remain unavailable while the checked-in example stays red and the
+current signing, endpoint, compatibility, performance, and daily-use blockers remain open.

--- a/docs/distribution/windows-release.md
+++ b/docs/distribution/windows-release.md
@@ -86,6 +86,9 @@ running this command.
 
 ## Release gate
 
+Founder and beta candidates must also pass the independent artifact and lifecycle admission described in
+`docs/distribution/private-beta-release.md`. Packaging success alone is never a release approval.
+
 The following remain mandatory before public direct distribution:
 
 - Founder approval and configuration of Azure Artifact Signing.

--- a/docs/privacy/private-beta-telemetry-server.md
+++ b/docs/privacy/private-beta-telemetry-server.md
@@ -1,0 +1,29 @@
+# Private-beta telemetry server approval contract
+
+The client upload control remains unavailable until the founder approves a production endpoint and this
+server-side contract has a named operator and concrete retention values. Client allowlisting is necessary
+but insufficient because the network service can observe connection metadata outside the JSON body.
+
+The service must accept only the sealed diagnostic schema documented in `docs/privacy/observability.md`,
+reject unknown fields, enforce request and rate limits, and avoid recording request bodies in proxy,
+application, error, analytics, or support logs. It must never join events to installation, advertising,
+account, fingerprint, or stable device identifiers. Source IP and TLS metadata visible to network
+infrastructure must use the shortest supported retention, with access restricted to operational security
+needs.
+
+Approval for one endpoint records the legal entity and operator, hosting region, subprocessors, exact
+event retention, connection-log retention, backup retention, access roles, MFA and audit controls, deletion
+procedure, incident-response owner and notification path, sampling policy, data-processing terms, and the
+public user disclosure. None of those values may remain unknown at approval time. A material schema,
+provider, region, retention, correlation, sampling, or access change requires a new privacy review before
+deployment.
+
+The client defaults sharing off and sends nothing until saved consent is true. Revoking consent stops new
+queue admission; the server approval must also define how a user requests deletion of already accepted
+events when applicable. Transport failure cannot block dictation or shutdown. Private-beta operators use
+the bounded GitHub issue forms for feedback and attach only the product-generated privacy-safe diagnostic
+export—never raw logs or crash dumps.
+
+Endpoint credentials and infrastructure configuration stay outside the repository. The release evidence
+boolean `telemetryServerPolicy` can become true only after the founder reviews the concrete operating
+record against this contract. Until then, no production telemetry endpoint is embedded or enabled.

--- a/notes/phase-twenty-two-private-beta-release.md
+++ b/notes/phase-twenty-two-private-beta-release.md
@@ -1,0 +1,36 @@
+# Phase 22 private-beta release evidence
+
+Date: 2026-08-26
+
+## Implemented release controls
+
+- `scripts/validate-release-candidate.ps1` independently verifies founder/beta identity, immutable manifest
+  membership, size and SHA-256, required Setup/full-package/index artifacts, the Envious Labs Authenticode
+  publisher on Setup and every packaged executable, and a bounded lifecycle evidence schema.
+- A candidate cannot pass unless twelve native lifecycle/support checks are `passed`, the exact release,
+  update endpoint, and telemetry server policy have explicit approvals, and the evidence lists no open P0
+  or P1 blockers.
+- The checked-in evidence example is intentionally unobserved, unapproved, and blocked. Canonical validation
+  parses the gate and enforces that this example stays red.
+- Privacy-safe GitHub forms bound founder/private-beta bug, crash, and product feedback intake. They warn
+  against transcript, audio, clipboard, context, credentials, accounts, private paths, window titles, raw
+  logs, crash dumps, and device identity.
+- The server approval contract defines schema rejection, body-log exclusion, connection-metadata
+  minimization, access, retention, deletion, incident response, sampling, regional processing, and renewed
+  review requirements. Client upload remains disabled until a concrete operating record is approved.
+
+## Validation
+
+- The current unsigned founder 0.21.1 package was rejected before lifecycle evidence with exit code 1
+  because `signedForProduction` was false.
+- The canonical validation gate passed: 34 preserved-proof tests, 350 production tests, all Release builds,
+  the bundled worker launch assertion, the Phase 22 script parse, and the deliberately red evidence check.
+- Phase 21 draft PR #49 completed both CI workflows successfully before this branch was created.
+
+## Unobserved and blocked
+
+No production signing identity, signed artifact, immutable HTTPS feed, telemetry endpoint approval, signed
+install/update/apply/rollback, clean target machine, SmartScreen result, representative endpoint-security
+result, private-beta daily use, or production feedback/crash triage has been observed. Open Phase 19–22
+signing, CUDA delivery, compatibility, performance, and release issues remain release blockers. Phase 22 is
+therefore infrastructure-ready but not release-ready.

--- a/scripts/validate-release-candidate.ps1
+++ b/scripts/validate-release-candidate.ps1
@@ -1,0 +1,189 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DistributionDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('founder', 'beta')]
+    [string]$Channel,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$')]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [string]$EvidenceFile
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Require-Equal {
+    param([string]$Name, $Actual, $Expected)
+    if ($Actual -ne $Expected) {
+        throw "$Name must be '$Expected' but was '$Actual'."
+    }
+}
+
+function Require-ExactProperties {
+    param([string]$Name, $Object, [string[]]$Expected)
+    $actual = @($Object.PSObject.Properties.Name | Sort-Object)
+    $wanted = @($Expected | Sort-Object)
+    if (Compare-Object -ReferenceObject $wanted -DifferenceObject $actual) {
+        throw "$Name has missing or unexpected properties."
+    }
+}
+
+$identity = switch ($Channel) {
+    'founder' {
+        @{
+            PackageId = 'EnviousLabs.EnviousWispr.Founder'
+            ChannelName = 'win-x64-founder'
+        }
+    }
+    'beta' {
+        @{
+            PackageId = 'EnviousLabs.EnviousWispr.Beta'
+            ChannelName = 'win-x64-beta'
+        }
+    }
+}
+
+$distributionRoot = [IO.Path]::GetFullPath($DistributionDirectory)
+if (-not (Test-Path -LiteralPath $distributionRoot -PathType Container)) {
+    throw 'The distribution directory does not exist.'
+}
+
+$manifestPath = Join-Path $distributionRoot 'distribution-manifest.json'
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw 'The distribution manifest is missing.'
+}
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -ErrorAction Stop
+Require-ExactProperties 'Distribution manifest' $manifest @(
+    'schemaVersion', 'packageId', 'version', 'channel', 'runtime', 'signedForProduction', 'files')
+Require-Equal 'Manifest schema' $manifest.schemaVersion 1
+Require-Equal 'Package identity' $manifest.packageId $identity.PackageId
+Require-Equal 'Version' $manifest.version $Version
+Require-Equal 'Channel' $manifest.channel $identity.ChannelName
+Require-Equal 'Runtime' $manifest.runtime 'win-x64'
+Require-Equal 'Production signing flag' $manifest.signedForProduction $true
+
+if (Test-Path -LiteralPath (Join-Path $distributionRoot 'UNSIGNED-DEVELOPMENT-ONLY.txt')) {
+    throw 'Unsigned development output cannot become a release candidate.'
+}
+
+$manifestNames = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+foreach ($file in @($manifest.files)) {
+    Require-ExactProperties 'Manifest file entry' $file @('name', 'size', 'sha256')
+    if ([string]::IsNullOrWhiteSpace($file.name) -or
+        $file.name -ne [IO.Path]::GetFileName($file.name) -or
+        $file.name.Length -gt 160) {
+        throw 'A manifest file name is unsafe.'
+    }
+    if (-not $manifestNames.Add($file.name)) {
+        throw "Duplicate manifest file: $($file.name)"
+    }
+
+    $artifactPath = Join-Path $distributionRoot $file.name
+    if (-not (Test-Path -LiteralPath $artifactPath -PathType Leaf)) {
+        throw "Manifest artifact is missing: $($file.name)"
+    }
+    $artifact = Get-Item -LiteralPath $artifactPath
+    Require-Equal "Size for $($file.name)" $artifact.Length ([int64]$file.size)
+    $actualHash = (Get-FileHash -LiteralPath $artifactPath -Algorithm SHA256).Hash
+    Require-Equal "SHA-256 for $($file.name)" $actualHash $file.sha256
+}
+
+$actualNames = @(Get-ChildItem -LiteralPath $distributionRoot -File |
+    Where-Object Name -ne 'distribution-manifest.json' |
+    ForEach-Object Name)
+if (Compare-Object -ReferenceObject @($manifestNames) -DifferenceObject $actualNames) {
+    throw 'The distribution directory and manifest do not contain the same immutable artifact set.'
+}
+
+$setupName = "$($identity.PackageId)-$($identity.ChannelName)-Setup.exe"
+$packageName = "$($identity.PackageId)-$Version-$($identity.ChannelName)-full.nupkg"
+$indexName = "releases.$($identity.ChannelName).json"
+foreach ($required in @($setupName, $packageName, $indexName)) {
+    if (-not $manifestNames.Contains($required)) {
+        throw "Required release artifact is missing: $required"
+    }
+}
+
+$setupSignature = Get-AuthenticodeSignature -LiteralPath (Join-Path $distributionRoot $setupName)
+if ($setupSignature.Status -ne 'Valid' -or
+    $setupSignature.SignerCertificate.Subject -notmatch 'Envious Labs') {
+    throw 'Setup is not validly signed by Envious Labs.'
+}
+
+$scratch = Join-Path ([IO.Path]::GetTempPath()) "EnviousWisprReleaseGate-$([Guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Force -Path $scratch | Out-Null
+try {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [IO.Compression.ZipFile]::ExtractToDirectory((Join-Path $distributionRoot $packageName), $scratch)
+    $portableRoot = Join-Path $scratch 'lib\app'
+    $portableFiles = @(Get-ChildItem -LiteralPath $portableRoot -Recurse -File |
+        Where-Object Extension -in @('.exe', '.dll'))
+    if ($portableFiles.Count -eq 0) {
+        throw 'The full package contains no portable binaries.'
+    }
+    foreach ($portable in $portableFiles) {
+        $signature = Get-AuthenticodeSignature -LiteralPath $portable.FullName
+        if ($signature.Status -ne 'Valid' -or
+            $signature.SignerCertificate.Subject -notmatch 'Envious Labs') {
+            throw "A packaged binary is not validly signed by Envious Labs: $($portable.Name)"
+        }
+    }
+}
+finally {
+    $resolvedScratch = [IO.Path]::GetFullPath($scratch)
+    $expectedParent = [IO.Path]::TrimEndingDirectorySeparator([IO.Path]::GetFullPath([IO.Path]::GetTempPath()))
+    if ((Split-Path -Parent $resolvedScratch) -eq $expectedParent -and
+        (Split-Path -Leaf $resolvedScratch).StartsWith('EnviousWisprReleaseGate-', [StringComparison]::Ordinal)) {
+        Remove-Item -LiteralPath $resolvedScratch -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$evidencePath = [IO.Path]::GetFullPath($EvidenceFile)
+if (-not (Test-Path -LiteralPath $evidencePath -PathType Leaf)) {
+    throw 'The lifecycle evidence file is missing.'
+}
+$evidence = Get-Content -LiteralPath $evidencePath -Raw | ConvertFrom-Json -ErrorAction Stop
+Require-ExactProperties 'Lifecycle evidence' $evidence @(
+    'schemaVersion', 'channel', 'version', 'machineClass', 'checks', 'approvals', 'blockerIssueNumbers')
+Require-Equal 'Evidence schema' $evidence.schemaVersion 1
+Require-Equal 'Evidence channel' $evidence.channel $identity.ChannelName
+Require-Equal 'Evidence version' $evidence.version $Version
+if ($evidence.machineClass -notmatch '^[a-z0-9][a-z0-9-]{0,39}$') {
+    throw 'Evidence machineClass must be a coarse, non-identifying label.'
+}
+
+$requiredChecks = @(
+    'cleanInstall', 'admittedUpdate', 'atomicRestart', 'forcedFailureRollback', 'repair', 'uninstall',
+    'dataPreservation', 'diagnosticsConsent', 'feedbackTriage', 'crashTriage', 'smartScreen',
+    'endpointSecurity')
+Require-ExactProperties 'Lifecycle checks' $evidence.checks $requiredChecks
+foreach ($check in $requiredChecks) {
+    Require-Equal "Lifecycle check $check" $evidence.checks.$check 'passed'
+}
+
+$requiredApprovals = @('founderRelease', 'updateEndpoint', 'telemetryServerPolicy')
+Require-ExactProperties 'Release approvals' $evidence.approvals $requiredApprovals
+foreach ($approval in $requiredApprovals) {
+    Require-Equal "Approval $approval" $evidence.approvals.$approval $true
+}
+if (@($evidence.blockerIssueNumbers).Count -ne 0) {
+    throw 'Release evidence still lists unresolved P0/P1 blocker issues.'
+}
+
+[ordered]@{
+    schemaVersion = 1
+    channel = $identity.ChannelName
+    version = $Version
+    machineClass = $evidence.machineClass
+    artifactsVerified = $manifestNames.Count
+    packagedBinariesVerified = $portableFiles.Count
+    lifecycleChecksPassed = $requiredChecks.Count
+    approvalsPassed = $requiredApprovals.Count
+    ready = $true
+    privacy = 'Content-free release evidence only; no paths, accounts, device identifiers, user content, or secrets.'
+} | ConvertTo-Json

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -5,6 +5,25 @@ param(
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
+Write-Host "Validating the private-beta release gate and deliberately red evidence example..."
+$releaseGatePath = Join-Path $repoRoot "scripts\validate-release-candidate.ps1"
+$parseErrors = $null
+[void][System.Management.Automation.Language.Parser]::ParseFile(
+    $releaseGatePath,
+    [ref]$null,
+    [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) {
+    throw "The private-beta release gate has PowerShell parse errors."
+}
+$redEvidence = Get-Content `
+    -LiteralPath (Join-Path $repoRoot "docs\distribution\private-beta-evidence.example.json") `
+    -Raw | ConvertFrom-Json -ErrorAction Stop
+if (@($redEvidence.checks.PSObject.Properties.Value | Where-Object { $_ -ne 'unobserved' }).Count -gt 0 -or
+    @($redEvidence.approvals.PSObject.Properties.Value | Where-Object { $_ -ne $false }).Count -gt 0 -or
+    @($redEvidence.blockerIssueNumbers).Count -eq 0) {
+    throw "The checked-in private-beta evidence example must remain explicitly unobserved and blocked."
+}
+
 function Resolve-DotNetSdk {
     param([Parameter(Mandatory = $true)][int]$MajorVersion)
 


### PR DESCRIPTION
## Outcome

Adds a fail-closed founder/private-beta release admission gate and privacy-bounded feedback/telemetry operating contracts. It deliberately does not claim a release candidate exists.

## What changed

- independently rechecks founder/beta identity, immutable manifest membership, sizes, SHA-256, required artifacts, Setup signature, and every packaged PE signature
- requires twelve typed native lifecycle/support checks, three explicit approvals, and zero listed P0/P1 blockers
- keeps the checked-in evidence example unobserved, unapproved, and blocked; canonical validation enforces that state
- adds privacy-safe private-beta bug/crash and feedback issue forms
- defines the production telemetry server approval contract while client upload remains disabled
- documents the operator runbook and exact unobserved release cells

## Validation

- canonical validation passed: 34 proof tests, 350 production tests, all Release builds, and bundled worker launch
- release gate parsed in canonical validation
- current unsigned founder 0.21.1 package failed closed with exit 1 at the production-signing flag
- staged changes passed whitespace, secret, and private-path scans
- parent Phase 21 PR #49 passed both CI workflows

## Not release-ready

No production signing identity, signed package, immutable HTTPS feed, approved telemetry endpoint, signed apply/restart/rollback, clean target machine, SmartScreen/endpoint-security result, or real private-beta daily-use evidence was available. The gate does not publish, upload, sign, install, merge, or close issues.

Advances #50