### PR TITLE
Phase 23: gate model and native artifact licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Start with [CLAUDE.md](CLAUDE.md), the [product contract](.claude/knowledge/prod
 - Use the bounded support and private-beta forms described in [SUPPORT.md](SUPPORT.md).
 - EnviousWispr source is licensed under GNU GPL version 3 only; see [LICENSE](LICENSE). Production NuGet
   notices are generated in [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md). Separate model and native
-  redistributable licenses remain mandatory release inputs.
+  redistributable source evidence and pending decisions are tracked in the
+  [artifact license inventory](docs/distribution/artifact-license-inventory.md).
 
 Copyright © 2026 Envious Labs LLC.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -40,4 +40,5 @@ the result. Canonical validation rejects missing license metadata or notice drif
 Model packs, CUDA redistributables, and EG-1 are separately delivered artifacts. Their signed model
 manifests must carry the exact upstream license notice and acceptance requirements; this NuGet
 inventory does not approve or replace those notices. A public release remains blocked until every
-shipped artifact has a reviewed license record.
+shipped artifact has a reviewed license record. Source evidence and open decisions are tracked in
+`docs/distribution/artifact-license-inventory.md`.

--- a/docs/distribution/artifact-license-inventory.json
+++ b/docs/distribution/artifact-license-inventory.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": 1,
+  "evidenceObservedAt": "2026-08-26",
+  "artifacts": [
+    {
+      "id": "parakeet-final-model",
+      "artifactClass": "model",
+      "plannedPayload": "Parakeet TDT 0.6B v3 ONNX model pack",
+      "upstreamIdentity": "nvidia/parakeet-tdt-0.6b-v3",
+      "observedLicense": "CC-BY-4.0",
+      "sourceUrl": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
+      "sourceRevision": "PENDING",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Pin the exact ONNX conversion source and revision.",
+        "Record the exact file names, sizes, and hashes in the signed manifest.",
+        "Approve and preserve the required attribution notice."
+      ]
+    },
+    {
+      "id": "whisper-final-model",
+      "artifactClass": "model",
+      "plannedPayload": "Whisper large-v3-turbo GGML model pack",
+      "upstreamIdentity": "openai/whisper large-v3-turbo",
+      "observedLicense": "MIT",
+      "sourceUrl": "https://github.com/openai/whisper/blob/main/LICENSE",
+      "sourceRevision": "PENDING",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Pin the exact GGML conversion source and revision.",
+        "Record the exact quantized and full-precision files, sizes, and hashes.",
+        "Approve and preserve the OpenAI MIT notice with the model pack."
+      ]
+    },
+    {
+      "id": "whisper-preview-model",
+      "artifactClass": "model",
+      "plannedPayload": "Whisper small GGML preview model pack",
+      "upstreamIdentity": "openai/whisper small",
+      "observedLicense": "MIT",
+      "sourceUrl": "https://github.com/openai/whisper/blob/main/LICENSE",
+      "sourceRevision": "PENDING",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Pin the exact GGML conversion source and revision.",
+        "Record the exact preview file, size, and hash.",
+        "Approve and preserve the OpenAI MIT notice with the model pack."
+      ]
+    },
+    {
+      "id": "eg1-model",
+      "artifactClass": "model",
+      "plannedPayload": "Envious Labs EG-1 Qwen3-4B derivative GGUF model pack",
+      "upstreamIdentity": "Qwen/Qwen3-4B-Instruct-2507 plus Envious Labs fine-tune",
+      "observedLicense": "UPSTREAM-APACHE-2.0-DERIVATIVE-TERMS-PENDING",
+      "sourceUrl": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
+      "sourceRevision": "PENDING",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Confirm the exact base revision, training inputs, and Envious Labs ownership chain.",
+        "Choose and approve the EG-1 derivative license and attribution notice.",
+        "Record every GGUF shard name, size, and hash in the signed manifest."
+      ]
+    },
+    {
+      "id": "llama-server-windows",
+      "artifactClass": "native-runtime",
+      "plannedPayload": "Pinned Windows llama.cpp server used only for local EG-1",
+      "upstreamIdentity": "ggml-org/llama.cpp",
+      "observedLicense": "MIT",
+      "sourceUrl": "https://github.com/ggml-org/llama.cpp/blob/master/LICENSE",
+      "sourceRevision": "PENDING",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Pin the exact source commit and reproducible Windows build recipe.",
+        "Inventory licenses for every compiled or vendored component in that build.",
+        "Record binary hashes and approve the complete native notice bundle."
+      ]
+    },
+    {
+      "id": "nvidia-cuda-runtime",
+      "artifactClass": "native-runtime",
+      "plannedPayload": "Private app-local CUDA 13 runtime subset",
+      "upstreamIdentity": "NVIDIA CUDA Toolkit",
+      "observedLicense": "LicenseRef-NVIDIA-CUDA-EULA",
+      "sourceUrl": "https://docs.nvidia.com/cuda/eula/",
+      "sourceRevision": "PENDING",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Select the exact CUDA release and only Attachment A redistributable files.",
+        "Record NVIDIA source manifests, file names, sizes, and hashes.",
+        "Approve required downstream terms, notices, and private-directory packaging."
+      ]
+    },
+    {
+      "id": "nvidia-cudnn-runtime",
+      "artifactClass": "native-runtime",
+      "plannedPayload": "Private app-local cuDNN 9 runtime DLL subset",
+      "upstreamIdentity": "NVIDIA cuDNN",
+      "observedLicense": "LicenseRef-NVIDIA-cuDNN-SLA",
+      "sourceUrl": "https://docs.nvidia.com/deeplearning/cudnn/backend/latest/reference/eula.html",
+      "sourceRevision": "PENDING",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Select the exact cuDNN release and official redistributable archive.",
+        "Record NVIDIA source manifests, runtime DLL names, sizes, and hashes.",
+        "Approve required downstream terms and notices for app-only access."
+      ]
+    },
+    {
+      "id": "minds14-public-uat-fixtures",
+      "artifactClass": "test-data",
+      "plannedPayload": "Three reviewed PolyAI MINDS-14 WAV fixtures and attribution manifest",
+      "upstreamIdentity": "PolyAI/minds14 revision 40ce77cb32a384e4d50a568e1ec39ac804019d33",
+      "observedLicense": "CC-BY-4.0",
+      "sourceUrl": "https://huggingface.co/datasets/PolyAI/minds14/tree/40ce77cb32a384e4d50a568e1ec39ac804019d33",
+      "sourceRevision": "40ce77cb32a384e4d50a568e1ec39ac804019d33",
+      "shipDisposition": "pending-review",
+      "approvedBy": null,
+      "approvedAt": null,
+      "openRequirements": [
+        "Approve the checked-in attribution and public-repository distribution decision."
+      ]
+    }
+  ]
+}

--- a/docs/distribution/artifact-license-inventory.md
+++ b/docs/distribution/artifact-license-inventory.md
@@ -1,0 +1,33 @@
+# Model and native-runtime license inventory
+
+This is a source-evidence inventory, not legal approval. It records the upstream license statements observed
+for the model, native-runtime, and public-test artifacts that are outside the production NuGet graph. The
+machine-readable source is `artifact-license-inventory.json`.
+
+| Artifact | Upstream evidence | Current decision |
+| --- | --- | --- |
+| Parakeet final model | NVIDIA identifies Parakeet TDT 0.6B v3 as CC-BY-4.0 | Conversion provenance, exact payload, attribution, and approval pending |
+| Whisper final and preview models | OpenAI's repository licenses Whisper code and model weights under MIT | Conversion provenance, exact payloads, notices, and approval pending |
+| EG-1 | The recorded base, Qwen3-4B-Instruct-2507, is Apache-2.0 | Base revision, training/ownership chain, derivative license, payload, and approval pending |
+| Windows llama.cpp server | Upstream project is MIT | Exact commit/build, vendored-component notices, binary hashes, and approval pending |
+| CUDA runtime subset | NVIDIA's CUDA EULA limits redistribution to identified distributable portions | Exact release/Attachment A files, downstream terms, private packaging, and approval pending |
+| cuDNN runtime subset | NVIDIA's cuDNN agreement identifies runtime `.dll` files as distributable subject to its requirements | Exact release/archive/files, downstream terms, app-only access, and approval pending |
+| MINDS-14 public UAT fixtures | PolyAI dataset is CC-BY-4.0 at the pinned fixture revision | Checked-in attribution and public distribution approval pending |
+
+Run the structural gate at any time:
+
+```powershell
+pwsh -NoProfile -File .\scripts\validate-artifact-license-inventory.ps1
+```
+
+The release owner runs the strict form only after every exact source revision, payload, notice, and decision is
+approved:
+
+```powershell
+pwsh -NoProfile -File .\scripts\validate-artifact-license-inventory.ps1 -RequireApproved
+```
+
+The strict form currently fails by design. An approval applies only to exact signed-manifest payloads; it does
+not authorize a different model conversion, llama.cpp build, CUDA/cuDNN release, or file set. If an artifact is
+excluded from a release, the release candidate needs a separate manifest-to-inventory check proving that its
+files and feature claims are absent. Do not turn a pending record into an approval based only on this page.

--- a/docs/distribution/public-release.md
+++ b/docs/distribution/public-release.md
@@ -7,7 +7,7 @@ and then verifies every Phase 23 evidence class below.
 | Evidence class | Required proof | Current state |
 | --- | --- | --- |
 | Product parity | Agreed feature matrix and native end-to-end UAT across the final pipeline | Incomplete |
-| Legal | GPL source notice plus reviewed notices for every NuGet, native runtime, model, and CUDA artifact | NuGet inventory automated; model/CUDA review open |
+| Legal | GPL source notice plus reviewed notices for every NuGet, native runtime, model, and CUDA artifact | NuGet inventory automated; model/native source inventory recorded; approval open |
 | Privacy | Approved user notice, telemetry server record, schema/redaction review, and deletion procedure | Engineering boundary implemented; approval open |
 | Security | Private reporting, secret scanning, dependency review, threat review, and signed artifact scan | Repository protections enabled; candidate review open |
 | Accessibility | Keyboard, screen reader, contrast, DPI, multi-monitor, locale, RTL, and IME evidence | Partial matrix only |
@@ -21,6 +21,13 @@ Run repository compliance first:
 
 ```powershell
 pwsh -NoProfile -File .\scripts\audit-public-release.ps1 -VerifyGitHubSecurity
+```
+
+The audit validates the pending model/native source inventory without converting it into approval. Before
+admitting a public candidate, the exact artifact records must pass the separate strict gate:
+
+```powershell
+pwsh -NoProfile -File .\scripts\validate-artifact-license-inventory.ps1 -RequireApproved
 ```
 
 Then run the Phase 22 admission against the exact immutable signed founder/beta artifact and content-free

--- a/notes/phase-twenty-three-public-release.md
+++ b/notes/phase-twenty-three-public-release.md
@@ -11,6 +11,9 @@ Date: 2026-08-26
 - `scripts/generate-third-party-notices.ps1` resolves the exact production WinUI app and runtime-worker NuGet
   graphs. It rejects missing or unsafe license metadata and generated an inventory of 30 packages. Separately
   delivered models, CUDA components, and EG-1 still require reviewed license records in their signed manifests.
+- The separate model/native inventory records authoritative upstream source evidence for Parakeet, Whisper,
+  EG-1's Qwen base, llama.cpp, CUDA, cuDNN, and MINDS-14. Its structural gate passes with eight explicit pending
+  decisions, while `-RequireApproved` fails until exact provenance, payloads, notices, and legal approvals exist.
 - `scripts/audit-public-release.ps1` fails closed on missing public documents, notice drift, private machine
   paths, secret-shaped content, or tracked model, private audio, and key material. The only audio exception is
   the exact reviewed public Whisper UAT fixture directory.
@@ -22,7 +25,9 @@ Date: 2026-08-26
 
 ## Validation
 
-- The public audit passed over 356 tracked files and verified all 30 production NuGet packages.
+- The public audit passed over 364 tracked files and verified all 30 production NuGet packages.
+- The expanded public audit validates the eight-record model/native inventory without treating source evidence
+  as legal approval.
 - `git diff --cached --check`, PowerShell parsing for changed scripts, and Python AST parsing for changed spike
   helpers passed.
 - Canonical validation passed with zero build warnings or errors: 34 preserved-proof contract tests and 350

--- a/scripts/audit-public-release.ps1
+++ b/scripts/audit-public-release.ps1
@@ -12,6 +12,8 @@ $requiredFiles = @(
     'SECURITY.md',
     'SUPPORT.md',
     'THIRD-PARTY-NOTICES.md',
+    'docs/distribution/artifact-license-inventory.json',
+    'docs/distribution/artifact-license-inventory.md',
     'docs/distribution/public-release.md'
 )
 foreach ($relative in $requiredFiles) {
@@ -34,6 +36,11 @@ try {
     & pwsh -NoProfile -File '.\scripts\generate-third-party-notices.ps1' -Verify
     if ($LASTEXITCODE -ne 0) {
         throw 'Production third-party notice verification failed.'
+    }
+
+    & pwsh -NoProfile -File '.\scripts\validate-artifact-license-inventory.ps1'
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Model/native artifact license inventory verification failed.'
     }
 
     $tracked = @(git ls-files)

--- a/scripts/generate-third-party-notices.ps1
+++ b/scripts/generate-third-party-notices.ps1
@@ -153,7 +153,8 @@ try {
     $lines.Add('Model packs, CUDA redistributables, and EG-1 are separately delivered artifacts. Their signed model')
     $lines.Add('manifests must carry the exact upstream license notice and acceptance requirements; this NuGet')
     $lines.Add('inventory does not approve or replace those notices. A public release remains blocked until every')
-    $lines.Add('shipped artifact has a reviewed license record.')
+    $lines.Add('shipped artifact has a reviewed license record. Source evidence and open decisions are tracked in')
+    $lines.Add('`docs/distribution/artifact-license-inventory.md`.')
     # Keep generated Markdown stable across Windows and Linux validation hosts.
     $content = ($lines -join "`n") + "`n"
 

--- a/scripts/validate-artifact-license-inventory.ps1
+++ b/scripts/validate-artifact-license-inventory.ps1
@@ -1,0 +1,179 @@
+param(
+    [switch]$RequireApproved
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$inventoryPath = Join-Path $repoRoot 'docs\distribution\artifact-license-inventory.json'
+
+function Require-ExactProperties(
+    [string]$label,
+    [object]$value,
+    [string[]]$expected)
+{
+    $actual = @($value.PSObject.Properties.Name | Sort-Object)
+    $wanted = @($expected | Sort-Object)
+    if (Compare-Object -ReferenceObject $wanted -DifferenceObject $actual)
+    {
+        throw "$label has unexpected or missing properties."
+    }
+}
+
+if (-not (Test-Path -LiteralPath $inventoryPath -PathType Leaf))
+{
+    throw 'The model/native artifact license inventory is missing.'
+}
+
+$inventory = Get-Content -LiteralPath $inventoryPath -Raw |
+    ConvertFrom-Json -ErrorAction Stop
+Require-ExactProperties 'Artifact inventory' $inventory @(
+    'schemaVersion',
+    'evidenceObservedAt',
+    'artifacts')
+$evidenceObservedAt = [DateTimeOffset]::MinValue
+if ($inventory.schemaVersion -ne 1 -or
+    -not [DateTimeOffset]::TryParse(
+        [string]$inventory.evidenceObservedAt,
+        [ref]$evidenceObservedAt))
+{
+    throw 'The artifact inventory schema or evidence date is invalid.'
+}
+
+$requiredIds = @(
+    'parakeet-final-model',
+    'whisper-final-model',
+    'whisper-preview-model',
+    'eg1-model',
+    'llama-server-windows',
+    'nvidia-cuda-runtime',
+    'nvidia-cudnn-runtime',
+    'minds14-public-uat-fixtures')
+$expectedEvidence = @{
+    'parakeet-final-model' = @(
+        'CC-BY-4.0',
+        'https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3')
+    'whisper-final-model' = @(
+        'MIT',
+        'https://github.com/openai/whisper/blob/main/LICENSE')
+    'whisper-preview-model' = @(
+        'MIT',
+        'https://github.com/openai/whisper/blob/main/LICENSE')
+    'eg1-model' = @(
+        'UPSTREAM-APACHE-2.0-DERIVATIVE-TERMS-PENDING',
+        'https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507')
+    'llama-server-windows' = @(
+        'MIT',
+        'https://github.com/ggml-org/llama.cpp/blob/master/LICENSE')
+    'nvidia-cuda-runtime' = @(
+        'LicenseRef-NVIDIA-CUDA-EULA',
+        'https://docs.nvidia.com/cuda/eula/')
+    'nvidia-cudnn-runtime' = @(
+        'LicenseRef-NVIDIA-cuDNN-SLA',
+        'https://docs.nvidia.com/deeplearning/cudnn/backend/latest/reference/eula.html')
+    'minds14-public-uat-fixtures' = @(
+        'CC-BY-4.0',
+        'https://huggingface.co/datasets/PolyAI/minds14/tree/40ce77cb32a384e4d50a568e1ec39ac804019d33')
+}
+$artifacts = @($inventory.artifacts)
+$artifactIdDifference = @(Compare-Object `
+    -ReferenceObject @($requiredIds | Sort-Object) `
+    -DifferenceObject @($artifacts.id | Sort-Object))
+if ($artifacts.Count -ne $requiredIds.Count -or
+    $artifactIdDifference.Count -ne 0)
+{
+    throw 'The artifact inventory does not contain the exact required artifact set.'
+}
+
+$pending = [System.Collections.Generic.List[string]]::new()
+foreach ($artifact in $artifacts)
+{
+    Require-ExactProperties "Artifact $($artifact.id)" $artifact @(
+        'id',
+        'artifactClass',
+        'plannedPayload',
+        'upstreamIdentity',
+        'observedLicense',
+        'sourceUrl',
+        'sourceRevision',
+        'shipDisposition',
+        'approvedBy',
+        'approvedAt',
+        'openRequirements')
+
+    foreach ($field in @(
+        'id',
+        'artifactClass',
+        'plannedPayload',
+        'upstreamIdentity',
+        'observedLicense',
+        'sourceRevision'))
+    {
+        if ([string]::IsNullOrWhiteSpace([string]$artifact.$field))
+        {
+            throw "Artifact $($artifact.id) has an empty $field."
+        }
+    }
+
+    $source = $null
+    if (-not [Uri]::TryCreate([string]$artifact.sourceUrl, [UriKind]::Absolute, [ref]$source) -or
+        $source.Scheme -ne [Uri]::UriSchemeHttps)
+    {
+        throw "Artifact $($artifact.id) has an invalid source URL."
+    }
+
+    $expected = $expectedEvidence[[string]$artifact.id]
+    if ($artifact.observedLicense -cne $expected[0] -or
+        $artifact.sourceUrl -cne $expected[1])
+    {
+        throw "Artifact $($artifact.id) does not match its reviewed upstream evidence."
+    }
+
+    if ($artifact.artifactClass -notin @('model', 'native-runtime', 'test-data'))
+    {
+        throw "Artifact $($artifact.id) has an unsupported artifact class."
+    }
+
+    if ($artifact.shipDisposition -notin @('pending-review', 'approved-to-ship'))
+    {
+        throw "Artifact $($artifact.id) has an unsupported ship disposition."
+    }
+
+    $requirements = @($artifact.openRequirements)
+    if (@($requirements | Where-Object {
+                [string]::IsNullOrWhiteSpace([string]$_) -or
+                ([string]$_).Length -gt 300
+            }).Count -gt 0)
+    {
+        throw "Artifact $($artifact.id) has an invalid open requirement."
+    }
+    $approved = $artifact.shipDisposition -eq 'approved-to-ship'
+    if ($approved)
+    {
+        $approvedAt = [DateTimeOffset]::MinValue
+        if ($requirements.Count -ne 0 -or
+            [string]::IsNullOrWhiteSpace([string]$artifact.approvedBy) -or
+            -not [DateTimeOffset]::TryParse([string]$artifact.approvedAt, [ref]$approvedAt) -or
+            $artifact.sourceRevision -eq 'PENDING' -or
+            $artifact.observedLicense -match 'PENDING|UNKNOWN')
+        {
+            throw "Artifact $($artifact.id) has an incomplete approval record."
+        }
+    }
+    else
+    {
+        if ($requirements.Count -eq 0 -or
+            $null -ne $artifact.approvedBy -or
+            $null -ne $artifact.approvedAt)
+        {
+            throw "Artifact $($artifact.id) has an inconsistent pending record."
+        }
+        $pending.Add([string]$artifact.id)
+    }
+}
+
+if ($RequireApproved -and $pending.Count -gt 0)
+{
+    throw "Artifact license approval is incomplete: $($pending -join ', ')"
+}
+
+Write-Host "Artifact license inventory validated: $($artifacts.Count) records, $($pending.Count) pending approval."


### PR DESCRIPTION
## Outcome

Adds the Phase 23 non-NuGet artifact license inventory as source evidence with an explicitly red approval gate.

- records eight exact artifact classes: Parakeet final, Whisper final, Whisper preview, EG-1, Windows llama.cpp server, CUDA runtime, cuDNN runtime, and public MINDS-14 fixtures;
- locks each record to the reviewed authoritative upstream URL and observed license label;
- keeps source evidence separate from Envious Labs legal/ship approval;
- requires exact source revisions, payloads/hashes, notices, and named approval before `-RequireApproved` can pass;
- validates the pending inventory during every public audit and canonical validation;
- links the model/native inventory from README, public-release admission, and generated NuGet notices.

## Current result

- structural gate: **pass**, 8 records
- pending decisions: **8**
- strict release gate: **fails by design** and lists all 8 records

Observed upstream evidence on 2026-08-26:

- NVIDIA Parakeet: CC-BY-4.0
- OpenAI Whisper code and weights: MIT
- Qwen3-4B-Instruct-2507 base: Apache-2.0; EG-1 derivative terms still pending
- llama.cpp: MIT; exact build/vendored notices pending
- CUDA/cuDNN: NVIDIA redistribution agreements; exact release/file set and downstream terms pending
- PolyAI MINDS-14: CC-BY-4.0 at the pinned fixture revision

## Validation

- canonical validation passed: 34 proof + 350 production tests; every build zero-warning/error
- public audit passed across 364 tracked files
- 30-package production NuGet inventory verified
- 8-record model/native inventory verified
- strict approval gate confirmed red

## Honest boundary

This PR is not legal advice and approves nothing. The release owner/legal reviewer must resolve every open requirement against the exact signed-manifest payloads. CUDA/cuDNN selection in particular must be limited to the exact distributable files and downstream terms of the selected NVIDIA releases.

Advances #52. Stacked on draft PR #55.