### PR TITLE
test: add strict acoustic production journey

### DIFF
--- a/notes/phase-twenty-three-public-release.md
+++ b/notes/phase-twenty-three-public-release.md
@@ -50,8 +50,28 @@ phrase appeared in the controlled native edit field. The app exited normally and
 remaining owned workers, app processes, or target processes. The result contained only typed fields and
 booleans; its isolated profile and temporary target observation were deleted.
 
-This automated result substitutes reviewed fixture capture and named press/release events. Physical WASAPI
-microphone capture and physical global-hotkey registration from a non-EnviousWispr app remain unobserved.
+The strengthened deterministic harness then passed again in 10,394 ms while also requiring the content-free
+recording, capture-finalized, transcription, deterministic-processing, delivery, and clean-shutdown event
+sequence.
+
+A separate strict acoustic mode exercised the installed global hook with synthetic F8 edges and used normal
+production WASAPI capture while the reviewed French fixture played through the default speakers. The harness
+verified the fixture SHA-256, decoded and amplified it only in memory, and deleted its isolated profile and
+temporary target observation. Independent privacy-safe audio measurements confirmed that the active physical
+microphone responded to speaker playback: average RMS rose from approximately 0.0029 at baseline to 0.0065
+during a public test phrase.
+
+The acoustic lexical gate did not pass on this hardware. In the strongest reviewed-fixture attempt, content-free
+diagnostics showed `HotkeyReady`, recording start, capture finalization, Whisper completion, deterministic
+processing completion, text-delivery completion, and clean shutdown; the controlled target grew from 5 to 150
+characters, but the known public word `adresse` was absent. The harness correctly returned non-zero. This is
+evidence that the production global-hook, WASAPI, worker, processing, and delivery stages ran, but it is not
+faithful microphone-dictation proof and is not recorded as a pass.
+
+The default automated result still substitutes reviewed fixture capture and named press/release events. The
+strict acoustic mode adds real WASAPI and the installed global hook, but its key edges and speaker source are
+synthetic and the lexical assertion failed on the tested speaker/webcam path. A person speaking into the
+physical microphone while holding the configured key from a non-EnviousWispr app remains unobserved.
 
 Phase 23 is not complete. The physical journey above, signed install, update, rollback, uninstall, SmartScreen,
 endpoint-security behavior, model and CUDA artifact licensing, accessibility review, representative hardware

--- a/scripts/generate-third-party-notices.ps1
+++ b/scripts/generate-third-party-notices.ps1
@@ -162,7 +162,13 @@ try {
         if (-not (Test-Path -LiteralPath $noticePath -PathType Leaf)) {
             throw 'THIRD-PARTY-NOTICES.md is missing.'
         }
-        $existing = Get-Content -LiteralPath $noticePath -Raw
+        # Git may materialize the tracked Markdown with CRLF on Windows even though
+        # the generated contract is intentionally LF-only. Normalize checkout line
+        # endings before the exact content comparison so CI still verifies every
+        # package, version, license value, and hash rather than the Git worktree mode.
+        $existing = (Get-Content -LiteralPath $noticePath -Raw) `
+            -replace "`r`n", "`n" `
+            -replace "`r", "`n"
         if ($existing -ne $content) {
             throw 'THIRD-PARTY-NOTICES.md does not match the resolved production dependency graph.'
         }

--- a/tools/app-journey-uat/EnviousWispr.AppJourney.Uat.csproj
+++ b/tools/app-journey-uat/EnviousWispr.AppJourney.Uat.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Audio\EnviousWispr.Audio.csproj" />
     <ProjectReference Include="..\..\src\Production\EnviousWispr.ASR\EnviousWispr.ASR.csproj" />
     <ProjectReference Include="..\..\src\Production\EnviousWispr.Core\EnviousWispr.Core.csproj" />
     <ProjectReference Include="..\..\src\Production\EnviousWispr.ModelDelivery\EnviousWispr.ModelDelivery.csproj" />

--- a/tools/app-journey-uat/Program.cs
+++ b/tools/app-journey-uat/Program.cs
@@ -2,11 +2,24 @@ using EnviousWispr.ASR;
 using EnviousWispr.Core.Runtime;
 using EnviousWispr.ModelDelivery;
 using EnviousWispr.Services.Runtime;
+using NAudio.Codecs;
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
 using System.Diagnostics;
 using System.Management;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text.Json;
 
+const byte F8 = 0x77;
+const int AcousticPlaybackGain = 2;
+const int AcousticPlaybackRepetitions = 2;
+const string ReviewedFrenchFixtureHash =
+    "84DEFDC828EF59CEC10364354FBC284BC2CC683FDD4A5EDD5863B7BB2C6123A8";
+var liveMicrophone = args.Any(argument => string.Equals(
+    argument,
+    "--live-microphone",
+    StringComparison.OrdinalIgnoreCase));
 var repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
 var appExecutable = Path.Combine(
     repositoryRoot,
@@ -38,6 +51,7 @@ var fixturePath = Path.Combine(
 RequireFile(appExecutable, "Build the Release/x64 production WinUI app before journey UAT.");
 RequireFile(targetExecutable, "Build the controlled delivery target before journey UAT.");
 RequireFile(fixturePath, "The reviewed public French fixture is missing.");
+RequireReviewedFixture(fixturePath, ReviewedFrenchFixtureHash);
 if (!new LocalWhisperModelProbe().Probe(modelDirectory).QuantizedComplete)
 {
     throw new DirectoryNotFoundException(
@@ -50,6 +64,7 @@ var runId = Guid.NewGuid().ToString("N");
 var uatDirectory = Path.Combine(Path.GetTempPath(), $"EnviousWispr-AppJourney-Uat-{runId}");
 Directory.CreateDirectory(uatDirectory);
 Directory.CreateDirectory(Path.Combine(uatDirectory, "no-preview-model"));
+var diagnosticPath = Path.Combine(uatDirectory, "profile", "diagnostics", "app.jsonl");
 var targetResultPath = Path.Combine(uatDirectory, "target-result.json");
 var readyEventName = $@"Local\EnviousLabs.EnviousWispr.PerformanceUat.{runId}.ready";
 var runtimeEventName = $@"Local\EnviousLabs.EnviousWispr.PerformanceUat.{runId}.runtime";
@@ -103,11 +118,18 @@ try
     appStart.Environment["ENVIOUSWISPR_PREVIEW_MODEL_DIRECTORY"] =
         Path.Combine(uatDirectory, "no-preview-model");
     appStart.Environment["ENVIOUSWISPR_POLISH_PROVIDER"] = "None";
-    appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY"] = "public-fixture-v1";
-    appStart.Environment["ENVIOUSWISPR_UAT_AUDIO_FIXTURE"] = fixturePath;
-    appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_START_EVENT"] = startEventName;
-    appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_COMPLETE_EVENT"] = completeEventName;
-    appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_EXIT_AFTER_COMPLETION"] = "1";
+    if (liveMicrophone)
+    {
+        appStart.Environment["ENVIOUSWISPR_UAT_EXIT_AFTER_MILLISECONDS"] = "30000";
+    }
+    else
+    {
+        appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY"] = "public-fixture-v1";
+        appStart.Environment["ENVIOUSWISPR_UAT_AUDIO_FIXTURE"] = fixturePath;
+        appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_START_EVENT"] = startEventName;
+        appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_COMPLETE_EVENT"] = completeEventName;
+        appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_EXIT_AFTER_COMPLETION"] = "1";
+    }
     app = Process.Start(appStart) ?? throw new InvalidOperationException(
         "The production WinUI app did not start.");
 
@@ -128,23 +150,58 @@ try
 
     BringToForeground(target.MainWindowHandle);
     Thread.Sleep(250);
-    startEvent.Set();
-    journeyCompleted = completeEvent.WaitOne(TimeSpan.FromSeconds(60));
-    if (!journeyCompleted)
+    if (liveMicrophone)
     {
-        throw new TimeoutException("The production journey did not complete within 60 seconds.");
+        SendKey(F8, keyDown: true);
+        try
+        {
+            Thread.Sleep(500);
+            await PlayPublicFixtureAsync(fixturePath);
+            Thread.Sleep(500);
+        }
+        finally
+        {
+            SendKey(F8, keyDown: false);
+        }
+
+        targetObserved = WaitForExpectedTargetResult(
+            targetResultPath,
+            TimeSpan.FromSeconds(20));
+        journeyCompleted = targetObserved;
+    }
+    else
+    {
+        startEvent.Set();
+        journeyCompleted = completeEvent.WaitOne(TimeSpan.FromSeconds(60));
+        if (!journeyCompleted)
+        {
+            throw new TimeoutException("The production journey did not complete within 60 seconds.");
+        }
+
+        targetObserved = WaitForExpectedTargetResult(
+            targetResultPath,
+            TimeSpan.FromSeconds(5));
     }
 
-    targetObserved = WaitForExpectedTargetResult(
-        targetResultPath,
-        TimeSpan.FromSeconds(5));
     if (!targetObserved)
     {
+        if (liveMicrophone)
+        {
+            _ = app.WaitForExit(35_000);
+            Console.Error.WriteLine(JsonSerializer.Serialize(new
+            {
+                liveMicrophoneDiagnosticEvents = ReadDiagnosticEvents(diagnosticPath),
+                targetCharacterCount = ReadTargetCharacterCount(targetResultPath),
+            }));
+        }
+
         throw new InvalidOperationException(
-            "The controlled target did not observe the expected public-fixture text.");
+            liveMicrophone
+                ? "The controlled target did not observe the expected public microphone phrase."
+                : "The controlled target did not observe the expected public-fixture text.");
     }
 
-    appExitedCleanly = app.WaitForExit(15_000);
+    appExitedCleanly = app.WaitForExit(liveMicrophone ? 35_000 : 15_000);
     if (!appExitedCleanly)
     {
         throw new TimeoutException("The production app did not exit cleanly after journey completion.");
@@ -154,6 +211,10 @@ try
     {
         throw new InvalidOperationException("The production app returned a non-zero exit code.");
     }
+
+    var diagnosticEvents = ReadDiagnosticEvents(diagnosticPath);
+    RequireProductionJourneyEvents(diagnosticEvents);
+    var productionStagesObserved = true;
 
     ownedWorkerCount = ownedWorkerIds.Count(IsProcessRunning);
     if (ownedWorkerCount != 0)
@@ -173,6 +234,7 @@ try
         runtimeReady,
         journeyCompleted,
         targetObserved,
+        productionStagesObserved,
         appExitedCleanly,
         ownedWorkerStartedCount = ownedWorkerIds.Length,
         ownedWorkerCount,
@@ -184,7 +246,13 @@ try
         provider = selection.Provider?.ToString() ?? "Unavailable",
         modelPack = selection.ModelPack?.ToString() ?? "Unavailable",
         polish = "None",
-        fixture = "PolyAI-minds14-fr-FR-row0",
+        inputKind = liveMicrophone
+            ? "SyntheticF8-ReviewedFixturePlayback-ProductionWasapi"
+            : "NamedEvents-ReviewedFixtureAudioCapture",
+        audioCapture = liveMicrophone ? "ProductionWasapi" : "ReviewedFixture",
+        fixture = liveMicrophone
+            ? "PolyAI-minds14-fr-FR-row0-acoustic-playback"
+            : "PolyAI-minds14-fr-FR-row0",
         deliveryTarget = "ControlledWinFormsEdit",
     }));
     return 0;
@@ -217,6 +285,22 @@ static void RequireFile(string path, string message)
     if (!File.Exists(path))
     {
         throw new FileNotFoundException(message, path);
+    }
+}
+
+static void RequireReviewedFixture(string path, string expectedHash)
+{
+    var file = new FileInfo(path);
+    if (file.Length is <= 0 or > 1_000_000)
+    {
+        throw new InvalidDataException("The reviewed public fixture has an unexpected size.");
+    }
+
+    using var stream = file.OpenRead();
+    var actualHash = Convert.ToHexString(SHA256.HashData(stream));
+    if (!string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+    {
+        throw new InvalidDataException("The reviewed public fixture hash does not match.");
     }
 }
 
@@ -290,6 +374,94 @@ static bool WaitForExpectedTargetResult(string path, TimeSpan timeout)
     return false;
 }
 
+static IReadOnlyList<string> ReadDiagnosticEvents(string path)
+{
+    if (!File.Exists(path))
+    {
+        return ["DiagnosticsUnavailable"];
+    }
+
+    var events = new List<string>();
+    foreach (var line in File.ReadLines(path))
+    {
+        using var document = JsonDocument.Parse(line);
+        var root = document.RootElement;
+        var eventName = root.TryGetProperty("event", out var eventElement)
+            ? eventElement.GetString()
+            : "UnknownEvent";
+        var failure = root.TryGetProperty("failure", out var failureElement)
+            ? failureElement.GetString()
+            : null;
+        var error = root.TryGetProperty("errorCode", out var errorElement)
+            ? errorElement.GetString()
+            : null;
+        events.Add(string.Join(
+            '/',
+            new[] { eventName, failure, error }.Where(value => !string.IsNullOrWhiteSpace(value))));
+    }
+
+    return events;
+}
+
+static int? ReadTargetCharacterCount(string path)
+{
+    try
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        return document.RootElement.GetProperty("characterCount").GetInt32();
+    }
+    catch (Exception exception) when (
+        exception is IOException or JsonException or InvalidOperationException)
+    {
+        return null;
+    }
+}
+
+static void RequireProductionJourneyEvents(IReadOnlyList<string> events)
+{
+    var requiredEvents = new[]
+    {
+        "HotkeyReady",
+        "DictationRecordingStarted",
+        "DictationCaptureFinalized",
+        "DictationTranscriptionStarted",
+        "DeterministicProcessingStarted",
+        "TextDeliveryStarted",
+        "TextDeliveryCompleted",
+        "ApplicationCleanShutdown",
+    };
+    var missing = requiredEvents
+        .Where(required => !events.Any(value => value.StartsWith(
+            required + '/',
+            StringComparison.Ordinal)))
+        .ToList();
+    if (!events.Any(value => value.StartsWith(
+            "DictationTranscriptionCompleted/",
+            StringComparison.Ordinal)) &&
+        !events.Any(value => value.StartsWith(
+            "DictationTranscriptionDegraded/",
+            StringComparison.Ordinal)))
+    {
+        missing.Add("DictationTranscriptionCompletedOrDegraded");
+    }
+
+    if (!events.Any(value => value.StartsWith(
+            "DeterministicProcessingCompleted/",
+            StringComparison.Ordinal)) &&
+        !events.Any(value => value.StartsWith(
+            "DeterministicProcessingDegraded/",
+            StringComparison.Ordinal)))
+    {
+        missing.Add("DeterministicProcessingCompletedOrDegraded");
+    }
+
+    if (missing.Count > 0)
+    {
+        throw new InvalidOperationException(
+            $"The production journey omitted required content-free stages: {string.Join(", ", missing)}.");
+    }
+}
+
 static IReadOnlyList<int> ChildProcessIds(int parentProcessId, string processName)
 {
     using var searcher = new ManagementObjectSearcher(
@@ -317,6 +489,130 @@ static bool IsProcessRunning(int processId)
     catch (ArgumentException)
     {
         return false;
+    }
+}
+
+static async Task PlayPublicFixtureAsync(string fixturePath)
+{
+    var (pcmBytes, sampleRate) = ReadReviewedMuLawFixture(
+        fixturePath,
+        AcousticPlaybackGain);
+    pcmBytes = RepeatPcm(pcmBytes, sampleRate, AcousticPlaybackRepetitions);
+    using var stream = new MemoryStream(pcmBytes, writable: false);
+    using var source = new RawSourceWaveStream(stream, new WaveFormat(sampleRate, 16, 1));
+    await using var output = await new WasapiPlayerBuilder()
+        .WithDefaultDeviceStreamRouting()
+        .BuildAsync();
+    var completed = new TaskCompletionSource<Exception?>(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    output.PlaybackStopped += (_, args) => completed.TrySetResult(args.Exception);
+    output.Init(source);
+    output.Volume = 1f;
+    output.Play();
+    var failure = await completed.Task.WaitAsync(TimeSpan.FromSeconds(15));
+    if (failure is not null)
+    {
+        throw new InvalidOperationException("The reviewed public fixture could not be played.", failure);
+    }
+}
+
+static (byte[] PcmBytes, int SampleRate) ReadReviewedMuLawFixture(string path, int gain)
+{
+    ArgumentOutOfRangeException.ThrowIfLessThan(gain, 1);
+    ArgumentOutOfRangeException.ThrowIfGreaterThan(gain, 8);
+    var bytes = File.ReadAllBytes(path);
+    if (bytes.Length < 12 ||
+        !bytes.AsSpan(0, 4).SequenceEqual("RIFF"u8) ||
+        !bytes.AsSpan(8, 4).SequenceEqual("WAVE"u8))
+    {
+        throw new InvalidDataException("The reviewed fixture is not a RIFF WAVE file.");
+    }
+
+    byte[]? format = null;
+    var position = 12;
+    while (position + 8 <= bytes.Length)
+    {
+        var chunkId = bytes.AsSpan(position, 4);
+        var chunkSize = BitConverter.ToInt32(bytes, position + 4);
+        position += 8;
+        if (chunkSize < 0 || position + chunkSize > bytes.Length)
+        {
+            throw new InvalidDataException("The reviewed fixture has an invalid chunk.");
+        }
+
+        if (chunkId.SequenceEqual("fmt "u8))
+        {
+            format = bytes.AsSpan(position, chunkSize).ToArray();
+        }
+        else if (chunkId.SequenceEqual("data"u8) && format is { Length: >= 16 })
+        {
+            var audioFormat = BitConverter.ToInt16(format, 0);
+            var channels = BitConverter.ToInt16(format, 2);
+            var sampleRate = BitConverter.ToInt32(format, 4);
+            var bitsPerSample = BitConverter.ToInt16(format, 14);
+            if (audioFormat != 7 || channels != 1 || sampleRate <= 0 || bitsPerSample != 8)
+            {
+                throw new InvalidDataException("The reviewed fixture is not mono 8-bit mu-law audio.");
+            }
+
+            var pcmBytes = new byte[checked(chunkSize * sizeof(short))];
+            for (var index = 0; index < chunkSize; index++)
+            {
+                var decoded = MuLawDecoder.MuLawToLinearSample(bytes[position + index]);
+                var sample = checked((short)Math.Clamp(
+                    decoded * gain,
+                    short.MinValue,
+                    short.MaxValue));
+                BitConverter.TryWriteBytes(pcmBytes.AsSpan(index * sizeof(short)), sample);
+            }
+
+            return (pcmBytes, sampleRate);
+        }
+
+        position += chunkSize + (chunkSize % 2);
+    }
+
+    throw new InvalidDataException("The reviewed fixture has no supported audio data.");
+}
+
+static byte[] RepeatPcm(byte[] pcmBytes, int sampleRate, int repetitions)
+{
+    ArgumentOutOfRangeException.ThrowIfLessThan(repetitions, 1);
+    ArgumentOutOfRangeException.ThrowIfGreaterThan(repetitions, 3);
+    var silenceBytes = checked(sampleRate / 4 * sizeof(short));
+    var repeated = new byte[checked(
+        (pcmBytes.Length * repetitions) + (silenceBytes * (repetitions - 1)))];
+    for (var repetition = 0; repetition < repetitions; repetition++)
+    {
+        var offset = checked(repetition * (pcmBytes.Length + silenceBytes));
+        pcmBytes.CopyTo(repeated, offset);
+    }
+
+    return repeated;
+}
+
+static void SendKey(byte virtualKey, bool keyDown)
+{
+    if (Marshal.SizeOf<Input>() != 40)
+    {
+        throw new InvalidOperationException("The synthetic keyboard input does not match the Win64 ABI.");
+    }
+
+    var input = new Input
+    {
+        Type = 1,
+        Data = new InputUnion
+        {
+            Keyboard = new KeyboardInput
+            {
+                VirtualKey = virtualKey,
+                Flags = keyDown ? 0u : 0x0002u,
+            },
+        },
+    };
+    if (NativeMethods.SendInput(1, [input], Marshal.SizeOf<Input>()) != 1)
+    {
+        throw new InvalidOperationException("Synthetic keyboard input was rejected.");
     }
 }
 
@@ -380,8 +676,35 @@ static void BringToForeground(nint window)
     }
 }
 
+[StructLayout(LayoutKind.Sequential)]
+internal struct Input
+{
+    public uint Type;
+    public InputUnion Data;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 32)]
+internal struct InputUnion
+{
+    [FieldOffset(0)]
+    public KeyboardInput Keyboard;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct KeyboardInput
+{
+    public ushort VirtualKey;
+    public ushort ScanCode;
+    public uint Flags;
+    public uint Time;
+    public nuint ExtraInfo;
+}
+
 internal static class NativeMethods
 {
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern uint SendInput(uint inputCount, Input[] inputs, int inputSize);
+
     [DllImport("user32.dll")]
     internal static extern nint GetForegroundWindow();
 

--- a/tools/app-journey-uat/README.md
+++ b/tools/app-journey-uat/README.md
@@ -18,11 +18,31 @@ pwsh -NoProfile -File .\scripts\validate.ps1
 dotnet run --no-build --project .\tools\app-journey-uat\EnviousWispr.AppJourney.Uat.csproj -c Release
 ```
 
+The separate live-audio mode keeps the production WASAPI capture and global hook. It synthesizes F8 edges,
+plays the reviewed public French MINDS-14 fixture through the default speakers, and requires the known word
+`adresse` to travel back through the default capture device and appear in the controlled target. The harness
+verifies the fixture's reviewed SHA-256 before playback:
+
+Playback applies a bounded 2x in-memory gain with clipping protection and plays the fixture twice with a short
+silence gap so a webcam microphone can hear the quiet mu-law source; no converted or amplified audio is written
+to disk.
+
+```powershell
+dotnet run --no-build --project .\tools\app-journey-uat\EnviousWispr.AppJourney.Uat.csproj `
+  -c Release -- --live-microphone
+```
+
+This mode is audible. It records only while F8 is held, never persists audio, uses an isolated profile, and
+stores only a temporary phrase-match boolean and character count before cleanup. It refuses to run while an
+unowned EnviousWispr or controlled-target process exists.
+
 The gitignored `models/whisper-large-v3-turbo` pack is required. The result is one content-free JSON object with
 shell/worker/journey/target/cleanup booleans and typed Windows, architecture, engine, provider, model-pack,
 fixture, and delivery-target fields. The temporary target observation records only whether the known public
 phrase appeared and the character count, then the harness deletes it with the isolated profile.
 
-This is real production pipeline proof, but not microphone or global-registration proof. Before Phase 23 can
-close, a person must hold the configured global key from a non-EnviousWispr target, speak through a physical
-microphone, release, observe insertion, and record only content-free pass/fail evidence for that exact build.
+The default mode is real production pipeline proof, but not microphone or global-registration proof. The live
+mode adds production WASAPI, the installed global hook, and an acoustic speaker-to-microphone path, but its key
+edges and reviewed-fixture playback source are still synthetic. Before Phase 23 can close, a person must hold
+the configured global key from a non-EnviousWispr target, speak through a physical microphone, release, observe
+insertion, and record only content-free pass/fail evidence for that exact build.


### PR DESCRIPTION
## Outcome

Adds a strict, privacy-safe acoustic journey for the production Windows app. It exercises the installed low-level global F8 hook, normal production WASAPI capture, the real Whisper runtime worker, deterministic processing, recovery handling, and native text delivery.

## Safety and proof contract

- refuses to run beside an unowned app or controlled target
- uses an isolated profile and credential suffix
- verifies the reviewed MINDS-14 fixture SHA-256 before playback
- decodes/amplifies/repeats the public fixture only in memory; writes no audio
- stores only content-free stage events plus a temporary expected-word boolean and character count
- requires the known public word `adresse`; arbitrary non-empty output cannot pass
- checks the Win64 `SendInput` ABI and requires exactly one owned worker with clean teardown

## Measured result on 2026-08-26

- deterministic production fixture journey: PASS in 10,394 ms
- strict acoustic speaker-to-webcam journey: FAIL as designed
- acoustic failure still observed HotkeyReady, recording, capture finalization, Whisper completion, deterministic processing, text delivery, and clean shutdown
- controlled target grew from 5 to 150 characters, but `adresse` was absent, so the harness returned non-zero
- this does not replace the required physical human key-and-speech release-candidate pass

## Validation

- canonical `scripts/validate.ps1`: PASS
- public audit: 364 tracked files, 30 NuGet packages, 8 artifact records
- preserved proof tests: 34 passed
- production tests: 350 passed
- all Release and UAT builds: zero warnings, zero errors

Stacked on #56. Draft only; do not merge.