### PR TITLE
the app records its own life, so read that before the event log

### DIFF
--- a/.claude/knowledge/INDEX.md
+++ b/.claude/knowledge/INDEX.md
@@ -9,6 +9,7 @@ Read only the files relevant to the task, but read each selected file completely
 | Dictation behavior, deterministic cleanup, emoji, or fallback | `pipeline.md`, `product-contract.md` |
 | Anything the user SEES — a screen, a control, a colour, a size, copy on a surface | `design-system.md` |
 | Installer, signing, updates, or release channels | `distribution.md`, `product-contract.md` |
+| A crash, hang, silent exit, or any "why did it do that" | `diagnostics.md` FIRST, then the matching contract |
 | Any shipped implementation | `../rules/workflow.md`, `../rules/validation.md`, plus matching contracts above |
 | Parity with the macOS app, or "does Windows have X yet" | the catalog first (below), then `mac-parity-audit.md` |
 | Historical measurements or experiments | Matching file under `../../notes/` |
@@ -31,3 +32,16 @@ app, and its `absent` rows rest on a grep that a differently-named feature would
 The forward-looking source of truth is this knowledge folder. `notes/` contains dated evidence. Code and
 tests establish current implementation. When they disagree, stop, identify the drift, and resolve it in
 the same change or a linked GitHub issue.
+
+## Pathway Triggers
+
+The session hook greps this section and arms each row's `**when:**` words as triggers, so a matching prompt
+surfaces the row without the whole index. One row per line, every row carries a `**when:**`.
+
+- [diagnostics.md](diagnostics.md) — **when:** crash, hang, silent exit, app quit, vanished, app.jsonl, run-state, heartbeat, diagnostic log, why did it do that
+- [design-system.md](design-system.md) — **when:** screen, control, colour, color, size, spacing, copy, icon, theme, anything the user sees
+- [pipeline.md](pipeline.md) — **when:** dictation behaviour, deterministic cleanup, emoji, punctuation, fallback, transcript
+- [distribution.md](distribution.md) — **when:** installer, signing, updates, release channel, Velopack, feed
+- [architecture.md](architecture.md) — **when:** architecture, dependency, platform choice, project layout
+- [product-contract.md](product-contract.md) — **when:** product decision, scope, invariant, privacy boundary
+- [mac-parity-audit.md](mac-parity-audit.md) — **when:** macOS parity, does Windows have, missing feature

--- a/.claude/knowledge/diagnostics.md
+++ b/.claude/knowledge/diagnostics.md
@@ -1,0 +1,74 @@
+# The app's own diagnostic log
+
+**Read this before investigating any crash, hang, silent exit or "it did something and I do not know
+why". The app records its own life, and that record is the first evidence, not the last.**
+
+The Windows event log and `%LOCALAPPDATA%\CrashDumps` answer one narrow question: did the process fault?
+They say nothing about a process that ended without faulting, which is the harder and more common case.
+
+## Where it is
+
+`%LOCALAPPDATA%\Envious Labs\<data directory>\diagnostics\app.jsonl`, one JSON object per line, oldest
+first. The data directory is per release channel and is named in `docs/distribution/windows-release.md`;
+a run started with `ENVIOUSWISPR_DATA_DIRECTORY` set writes under that path instead, which is why a UAT
+harness leaves its own log beside its own scratch profile.
+
+`run-state.json` sits one level up in the same data directory and carries `startedAt`, `lastHeartbeatAt`,
+`cleanShutdown`, `consecutiveInterruptedRuns` and `dictationActive`. **A heartbeat lands once a minute**
+(`App.RunHeartbeatAsync`), so on a process that vanished, the last heartbeat bounds the time of death to
+the minute even though the log itself stops earlier.
+
+## It is on by default
+
+`UserPreferences` ships `LocalDiagnosticsEnabled: true` with `DiagnosticRetentionDays: 14`, applied
+through `JsonLineFileLogger.Configure`. Assume the log exists and go and read it. Settings can turn it
+off, so an empty file is a fact worth checking rather than proof that nothing happened.
+
+The file is privacy-safe by construction: event codes, failure categories, engine and hardware class,
+elapsed milliseconds. No audio, no transcript, no polished text, no clipboard, no surrounding document.
+The `dictationId` correlates lines within one dictation and is local-only, never sent.
+
+## The three events that decide what kind of ending you are looking at
+
+`AppEventCode` is the vocabulary. Three of its members answer the question "how did this run end", and
+they are the reason the log beats every other source:
+
+| Last seen | What it proves |
+| --- | --- |
+| `ApplicationCleanShutdown` | The whole teardown succeeded and the run was completed in `run-state.json`. |
+| `ShellClosed` but no `ApplicationCleanShutdown` | The app chose to exit and something in teardown failed. |
+| Neither | **The app never chose to exit.** Something outside it ended the process. |
+
+`App.PrepareForExitCoreAsync` writes `ShellClosed`, and it sits on the far side of every exit the app can
+choose: tray Exit, both `ENVIOUSWISPR_UAT_*` exit variables, a window close with `_exitRequested`, and
+update-apply. So the absence of `ShellClosed` eliminates all of them at once rather than leaving them as
+suspicions to test one at a time. Measured 2026-08-30: zero `ShellClosed` across 22 launches on the test
+machine, which is what moved issue #88 off "why does the app quit" and onto "what is killing it".
+
+## How to read it
+
+Split the file on `ApplicationStarting`. Each slice is one launch, and the last line of a slice is the
+last thing that run managed to say. Compare that timestamp against `run-state.json`'s `lastHeartbeatAt`
+to see how long the process lived after it went quiet.
+
+```python
+import json
+runs, cur = [], None
+for line in open('app.jsonl'):
+    if not line.strip(): continue
+    r = json.loads(line)
+    if r['event'] == 'ApplicationStarting': cur = []; runs.append(cur)
+    if cur is not None: cur.append(r)
+for i, run in enumerate(runs, 1):
+    print(i, run[0]['timestamp'], '->', run[-1]['timestamp'], 'last =', run[-1]['event'])
+```
+
+`failure` is `"None"` on a healthy line, so filtering for anything else gives every degraded moment in the
+file in one pass.
+
+## A frozen reading is a death, not a datum
+
+An automated watcher that samples the app must treat an identical value N times running as a liveness
+alarm. Three spontaneous exits on 2026-08-30 went unnoticed while a measurement loop kept returning
+plausible constant numbers; it was sampling the wallpaper. Assert liveness on a schedule, and never let a
+measurement outlive proof that the thing being measured is still there.

--- a/.claude/rules/validation.md
+++ b/.claude/rules/validation.md
@@ -28,3 +28,21 @@ powershell -ExecutionPolicy Bypass -File scripts/validate.ps1 -IncludeLocalRunti
 Model-dependent checks may be skipped only when assets are absent, and the handoff must call that out. A
 filtered green test is never described as full runtime proof. Final handoff lists the branch, pull request,
 commands run, native user paths observed, and remaining risks.
+
+## Observe it, do not assert it
+
+User-facing behavior is proven by driving the real application in a logged-on interactive desktop session,
+never from a background service session. A WinUI app launched from a service session exits before it draws,
+so a green headless run is evidence about the code and no evidence at all about what the user sees.
+
+Founder standing instruction, 2026-08-30:
+
+- Every session has eyes and hands on the Windows development machine. Use them rather than describing what
+  the change should look like.
+- Behavior that unfolds over time is captured as a screen recording and attached to the pull request or
+  issue. Prose about what happened is not the evidence; the recording is.
+- Prefer a synthetic end-to-end run over a human checklist. Reserve the human only for what a synthetic
+  sender cannot produce, such as a global gesture the operating system refuses to accept from software.
+
+The `tools/*-uat` harnesses are the shipped vehicles for this, and `tools/app-journey-uat` covers the whole
+dictation journey. Extend an existing harness before adding another.


### PR DESCRIPTION
Routes future sessions to `app.jsonl`, the app's own diagnostic log, and records the founder's standing UAT instruction.

## Why

Issue #88's investigation checked the Windows event log and `%LOCALAPPDATA%\CrashDumps` for a process that kept vanishing, found both empty, and had nothing left. `app.jsonl` held 316 records across 22 launches at the time, unread. Local diagnostics ship on (`UserPreferences.LocalDiagnosticsEnabled: true`), so that evidence exists on every machine by default.

## What lands

- **`.claude/knowledge/diagnostics.md`** — where the log lives per channel, the privacy shape, how to split it per launch, and the three-way test for how a run ended:

  | Last seen | What it proves |
  | --- | --- |
  | `ApplicationCleanShutdown` | teardown finished and the run completed |
  | `ShellClosed` alone | the app chose to exit, teardown failed |
  | neither | the app never chose to exit |

  `PrepareForExitCoreAsync` writes `ShellClosed` on the far side of every exit the app can choose, including both `ENVIOUSWISPR_UAT_*` exit variables, so its absence eliminates all of them in one read instead of one experiment each. That is what moved #88 off "why does the app quit".

- **`INDEX.md`** — a router row plus a `## Pathway Triggers` section, so a prompt about a crash or a silent exit surfaces the file rather than depending on somebody thinking to look.

- **`.claude/rules/validation.md`** — the founder's standing instruction of 2026-08-30: drive the real app in a logged-on desktop session, prove behaviour with a recording, prefer a synthetic end-to-end run over a human checklist.

## Validation

Documentation only, no code paths touched. Every symbol, default and file name cited was verified against the tree: `AppEventCode`, `App.PrepareForExitCoreAsync`, `App.RunHeartbeatAsync` (one-minute period), `JsonLineFileLogger.Configure`, `UserPreferences` defaults, and the `RunStateFile` field names checked against a live `run-state.json`. Scanned clean for machine paths and personal data.