### PR TITLE
finished work ships instead of waiting to be asked

### DIFF
--- a/.claude/rules/github.md
+++ b/.claude/rules/github.md
@@ -49,9 +49,11 @@ diagnosis alone.
 
 ## RULE: the-pull-request-workflow
 Branch from `main` in its own worktree, implement, commit, push, open the pull request, clear review, then
-leave it merge-ready. Merge and delete the branch only on Saurabh's exact request. **Never arm auto-merge.**
+merge and delete the branch. Always pass `--auto` so the merge waits for CI rather than no-opping while
+checks run.
 
-Never merge unless Saurabh asks for that exact merge.
+**The gate IS the approval.** Merge your own work once it clears; never ask, and never leave finished work
+open waiting to be asked (founder standing instruction, 2026-08-30).
 
 ## RULE: write-to-a-live-surface-alone-in-its-own-call
 Any command that posts to an issue or a pull request runs alone, never chained, and never with its output

--- a/.claude/rules/session-behavior.md
+++ b/.claude/rules/session-behavior.md
@@ -1,11 +1,16 @@
 # Session behaviour
 
 ## RULE: main-stays-clean
-`main` is never edited in place. Every change uses its own branch and worktree. After an authorized
-merge, remove the worktree. Restore the checkout to `main` at session start and leave it there.
+`main` is never edited in place. Every change uses its own branch and worktree. After the merge, remove
+the worktree. Restore the checkout to `main` at session start and leave it there.
 
-## RULE: never-ask-if-done
-Keep working. Saurabh decides when to stop. Never ask whether the work or the session is finished.
+## RULE: never-ask-permission
+Keep working. Saurabh decides when to stop, and he does not need to be asked for anything else (founder
+standing instruction, 2026-08-30). Never ask whether the work is finished, whether to merge, whether to
+rebuild, or whether to run a check you could run yourself. Act, then report in the past tense.
+
+Escalate only a genuine product, spend, or strategy decision. A question the rules already answer is a
+lookup you did not do, not caution.
 
 ## RULE: plain-english-to-saurabh
 Saurabh is the founder, not an engineer. No class names, file paths, protocol jargon, or acronyms in chat.
@@ -31,8 +36,7 @@ On "wrap up" or "wind down", complete all four. Never stop after one.
 2. Close finished GitHub issues; status-comment the open ones.
 3. Add a `LOG.md` entry if the session produced a decision, a defect found by something other than its
    author, or a fact that would cost somebody a day to rediscover.
-4. Ship the branch and reviewed pull request. Merge and verify `main` only when Saurabh requested that
-   exact merge.
+4. Ship: branch, pull request, gates clear, merge, verify `main` green.
 
 ## RULE: one-release-per-session
 At most one release per session. Batch post-release bugs into the next planned release unless the bug

--- a/.claude/rules/workflow-process.md
+++ b/.claude/rules/workflow-process.md
@@ -16,7 +16,7 @@ How a change moves from idea to merged.
    fallback, and public-repository safety first.
 6. **Build.** Larger work is built in chunks, each reviewed against its own diff before the next starts.
 7. **Validate.** The portable gate, plus the observed Windows user path.
-8. **Ship.** Branch, pull request, review gate. Merge only on Saurabh's exact request.
+8. **Ship.** Branch, pull request, review gate, merge, verify `main`.
 
 ## RULE: port-the-proof-before-simplifying-it
 When replacing proven WPF behaviour, first port its outcome and its causal comments unchanged. Simplify
@@ -73,6 +73,7 @@ Merge-ready means the release build, the portable gate, the observed Windows pat
 CI are all green. After an authorized merge, verify `main` and close the issue. Any code edit after
 validation invalidates validation.
 
-## RULE: never-merge-unasked
-Codex and Claude may open and update pull requests. Neither merges unless Saurabh asks for that exact
-merge.
+## RULE: the-gate-is-the-approval
+Once a change clears its gates, merge it yourself, including your own work. Never ask for permission to
+merge and never park finished work awaiting a founder merge (founder standing instruction, 2026-08-30).
+If something blocks the merge, surface the exact command for Saurabh to run once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,8 @@ the portable build and contract gate used by CI.
 ## Delivery workflow
 
 GitHub Issues are the durable task system. Every implementation ends with relevant validation, a pushed
-branch, and an updated pull request. Codex may submit work but must not merge unless Saurabh explicitly
-requests that exact merge.
+branch, and an updated pull request. Once a change clears its gates, merge it. Do not park finished work
+waiting to be asked (founder standing instruction, 2026-08-30).
 
 Work happens in a git worktree on its own branch, merges to `main`, and the worktree is removed. `main`
 stays buildable and is never edited in place.


### PR DESCRIPTION
Founder standing instruction, 2026-08-30: "you never need to ask me."

Four places told a session to hold a cleared pull request until Saurabh asked for that exact merge. That parks finished work behind a question he does not want, and it contradicts how the other projects already operate.

- **The gate is the approval.** Merge your own work once it clears.
- Always pass `--auto`, so the merge waits for CI rather than no-opping while checks run.
- `never-ask-if-done` widens to `never-ask-permission`: do not ask whether to merge, whether to rebuild, or whether to run a check you could run yourself. Act, then report in the past tense. Escalate only a real product, spend, or strategy call.

Follows #105. Verified separately that a fresh session here now loads all six rule files and both brain files, so these are in context rather than sitting on disk.