### PR TITLE
the knowledge files stop carrying things that can only rot

### DIFF
--- a/.claude/knowledge/architecture.md
+++ b/.claude/knowledge/architecture.md
@@ -20,9 +20,19 @@ build so customers do not need to install developer tooling.
 - `Pipeline`: recording-to-delivery orchestration and cancellation.
 - `Services`: storage, credentials, updates, telemetry boundaries, and Windows integration.
 - `ModelDelivery`: manifests, downloads, hashes, versions, storage, and cleanup.
+- `RuntimeWorker`: a **separate executable** that hosts the native speech runtimes, including the CUDA
+  build. `Services` drives it through `RuntimeWorkerSupervisor` over a versioned protocol with a bounded
+  restart budget and an explicit process priority.
 
 Dependencies point inward toward contracts. UI, storage, network, and model runtimes do not leak into the
 deterministic core.
+
+**Speech models run OUT OF PROCESS.** Wire a new engine through the worker and its supervisor, never
+in-process in the app. The supervisor's process priority is also what keeps the worker off the efficiency
+cores — see `../rules/validation-discipline.md` RULE: work-started-over-ssh-lands-on-the-slow-cores.
+
+The RATIONALE for the split is not recorded anywhere in the source. Treat crash isolation as the likely
+reason but ask rather than assert it, and write the answer here when you get it.
 
 ## Speech engines
 

--- a/.claude/knowledge/mac-parity-audit.md
+++ b/.claude/knowledge/mac-parity-audit.md
@@ -6,9 +6,16 @@ already exist on one side. Taken 2026-08-27 against the Mac repo's own
 `.claude/knowledge/capability-map.md`, which is the authoritative list of what macOS ships.
 
 ## RULE: query-the-catalog-first
-`~/.claude/knowledge/enviouswispr/catalog.db` now carries both columns, 92 features on macOS and 92 on
-Windows, each row citing the file that decided it. It is the answer to "does Windows have X yet?" and it
-is machine-queryable, which this table is not:
+`~/.claude/knowledge/enviouswispr/catalog.db` carries both columns, each row citing the file that decided
+it. It is the answer to "does Windows have X yet?" and it is machine-queryable, which this table is not.
+
+**A count published here cannot stay correct**, because nothing links this file to a catalog edit. Ask the
+catalog instead:
+
+```bash
+sqlite3 ~/.claude/knowledge/enviouswispr/catalog.db \
+  "SELECT status, count(*) FROM feature_platform WHERE platform_key='windows' GROUP BY 1;"
+```
 
 ```bash
 sqlite3 -header -column ~/.claude/knowledge/enviouswispr/catalog.db \

--- a/.claude/knowledge/product-contract.md
+++ b/.claude/knowledge/product-contract.md
@@ -1,5 +1,14 @@
 # Product contract
 
+**How to read this file.** A PROMISE is stated here with its values, because if the code drops one this
+file is what catches it. An IMPLEMENTATION DETAIL — a member list, a display order, an initial value —
+names its owning type instead, because prose restating code can only decay.
+
+The line matters: a contract that points at code for everything can never disagree with code, so it can
+never catch a regression. Providers, engines, the navigation groups and the licensing direction are
+promises and stay written out. Enum members, catalog order and defaults are details and point at their
+owner.
+
 ## Audience and promise
 
 EnviousWispr is commercial-grade Windows dictation for ordinary laptops and powerful gaming PCs. The
@@ -27,13 +36,14 @@ without a dedicated GPU.
   OUTPUT (Clipboard), and SYSTEM (Permissions, Check for Updates, Open Source Licenses).
 - Appearance follows the Windows setting by default and also offers explicit Light and Dark modes.
 - The recording pill can appear at the top or bottom of the active monitor.
-- The three recording-pill designs are Capsule, Reading Well, and Level Rail. Capsule and Level Rail are
-  wordless choices. Reading Well is the Live Preview choice and grows to show up to five lines of the
-  display-only preview. The app remembers the wordless and with-words selections separately.
-- Recording sounds are optional and off by default. Whisper Tick is the fresh-install selection. The
-  ordered catalog is Dust Mote, Velvet Hush, Muted Confirm, Whisper Tick, Round Pebble, Paper Tap, Soft
-  Hush, Low Nod, Cloud Pop, Velvet Tap, Satin Shift, and Air Glint. Settings can preview the selected
-  start/stop pair even while the master switch is off, but never during an active recording.
+- Three recording-pill designs. Capsule and Level Rail are the wordless choices; Reading Well is the Live
+  Preview choice and grows to show up to five lines of display-only preview. The app remembers the wordless
+  and with-words selections separately. **The user-facing name "Capsule" is `Classic` in code** — the enum
+  `RecordingPillDesign` is the authority and does not use the display name.
+- Recording sounds are optional and off by default. Whisper Tick is the fresh-install selection. Settings
+  can preview the selected start/stop pair while the master switch is off, but never during an active
+  recording. **`RecordingSoundCatalog.Choices` owns the sounds, their display names and their order, and
+  feeds the picker directly; `RecordingSoundPairing` owns the identities. Never restate either list here.**
 - Keybinds offer Push to Talk and Toggle recording modes. The recording, cancel, and Add-a-word
   shortcuts are independently configurable and must not overlap. Windows defaults are F8, Escape, and
   Ctrl+Alt+W respectively.
@@ -64,6 +74,27 @@ without a dedicated GPU.
 The deterministic result is always usable on its own. Optional AI polish may improve it but cannot be
 required to complete a dictation. If any later stage fails, the pipeline returns the last valid result and
 explains the degraded stage without exposing private content.
+
+## Release gate
+
+Invariant 8 says public release waits for full agreed Windows parity. What "agreed" means, stated so it is
+not re-litigated:
+
+- **The catalog decides parity, not this file.** A feature is release-blocking when its Windows row is
+  `absent` or `partial` AND it is not recorded as `deliberately-different`.
+- **A deliberate difference needs its reason recorded before it counts as settled**, in the catalog's
+  `difference_reason`. An undocumented divergence is a gap, not a decision.
+- **Parity is claimed from observed behaviour, never from a green suite.** The evidence is the real
+  application driven in a logged-on interactive desktop session, with the recording attached.
+
+```bash
+sqlite3 ~/.claude/knowledge/enviouswispr/catalog.db \
+  "SELECT feature_slug, status FROM feature_platform \
+   WHERE platform_key='windows' AND status IN ('absent','partial') ORDER BY status, feature_slug;"
+```
+
+**Still undecided and owned by the founder:** whether every `partial` row must reach `shipped`, or whether
+some may ship as a stated limitation. Do not assume either.
 
 ## Licensing and release
 

--- a/.claude/rules/validation-discipline.md
+++ b/.claude/rules/validation-discipline.md
@@ -88,6 +88,20 @@ a two-valued caller, and the third value collapses into "no".
 | a capability reached by a DEFAULTED argument | absence has no call-site token, so no search finds it | make the default fail closed and read the callers off the first run |
 | a pipeline | returns its LAST command's status | assign first, then branch |
 | a cross-process visibility check | measures a pair; a probe process is not the signed app | make the SUBJECT log the outcome on every path |
+| **a CPU percentage counter** | three counters read 56%, 71% and 51% on a machine consuming 14.2 of 32 cores | gate on CPU-seconds per wall-second, summed over the worker processes, re-checked at EVERY heartbeat |
+
+## RULE: work-started-over-ssh-lands-on-the-slow-cores
+Windows puts a process started by a background service into EcoQoS and schedules it onto the efficiency
+cores. Measured 2026-08-28: under a load designed to saturate every thread, processors 16-31 sat at
+91-100% and processors 0-15 at 0-26%. **Every build this project ran over SSH used the slow cores.**
+
+Set `PriorityClass = 'High'` on the started process to opt back out; the same load then reached 28 of 32
+threads at 4.1 GHz. `scripts/verify-here.ps1` already does this and says why at the line that does it.
+Open: issue #68.
+
+Consequence for any load or performance run: three attempts reported a busy-looking machine that was not
+busy, and one printed `alive=0` for six consecutive minutes then claimed it had survived twelve minutes of
+load. Never use blank frames as an encoder load; they finish almost instantly.
 
 Before believing any sweep's silence, run the pattern against a case you KNOW is present.
 
@@ -108,6 +122,17 @@ wrong thing, and no guard shape catches them:
 Two free tells. An answer IDENTICAL across targets with no reason to agree is a property of the
 instrument. And existence is not function: an attribute present but constant, a name present but never
 called, a list present but capped.
+
+## RULE: four-things-that-pass-while-proving-nothing
+- **A new gate is unproven until a deliberate violation makes it fail AND a clean artifact makes it pass.**
+  One direction is not a control.
+- **For every setting, compare the values the UI can produce against the values storage accepts, runtime
+  listens for, and routing handles.** Three matching sets do not prove the fourth.
+- **A pattern over a delimited list must be proven against a MIDDLE element and the FINAL one.** The final
+  element carries a closing delimiter instead of a trailing separator, so a pattern that works everywhere
+  else fails there alone.
+- **Every save-and-restore harness must test an EMPTY original state and verify the restored world.** A
+  successful wrapper call is not proof that restoration happened.
 
 ## RULE: an-expectation-built-with-the-thing-under-test-cannot-fail
 When asserting that a transformation PRESERVES something, build the expected value from a literal. If your


### PR DESCRIPTION
the knowledge files stop carrying things that can only rot

First four files of a pass over the knowledge base, Codex-reviewed one file at a
time. The standard applied to every sentence: would deleting this change what a
future session does, after it has read the current code, scripts, issues and the
canonical owner?

Deleted: the untracked session-state snapshot from 2026-08-28. It was never
committed and most of it was a handoff with owners elsewhere. Codex found four
lessons in it that were not owned anywhere, and those are now in
validation-discipline:

- a new gate is unproven until a deliberate violation fails and a clean artifact
  passes; one direction is not a control
- for any setting, the values the screen can produce, storage accepts, runtime
  listens for and routing handles are four sets, and three agreeing does not prove
  the fourth
- a pattern over a delimited list must be proven against a middle element and the
  final one, which is punctuated differently
- a save-and-restore harness must be tested from an empty original state and must
  verify the restored world; a successful call is not proof

Also promoted from it, before deleting: work started over SSH lands on the
efficiency cores, with the priority fix and the reason percentage counters lied
about it. The machine-specific crash forensics went to private notes rather than
this public repository.

architecture.md: RuntimeWorker was missing from the module list. Speech models run
out of process, supervised over a versioned protocol with a restart budget. A
session reading this file would have wired a new engine in-process. The rationale
for the split is not recorded in the source and is now flagged as a question rather
than guessed at.

product-contract.md: every claim re-verified against C sharp; all of it held. The
decaying part was rosters that must track code, so the sound catalogue now points at
RecordingSoundCatalog.Choices, which owns the order and feeds the picker. Added a
statement of which lists stay written out and why: a contract that points at code
for everything can never disagree with code, so it can never catch a regression.
Added the release gate, which invariant 8 implied and nothing defined.

Recorded: the pill design a user sees as Capsule is Classic in code.

mac-parity-audit.md: it published a feature count that is now wrong. Replaced with
the query, because nothing links a count here to a catalog edit.
