### PR TITLE
the knowledge base stops disagreeing with itself

### DIFF
--- a/.claude/knowledge/INDEX.md
+++ b/.claude/knowledge/INDEX.md
@@ -10,14 +10,15 @@ Read only the files relevant to the task, but read each selected file completely
 | Anything the user SEES — a screen, a control, a colour, a size, copy on a surface | `design-system.md` |
 | Installer, signing, updates, or release channels | `distribution.md`, `product-contract.md` |
 | A crash, hang, silent exit, or any "why did it do that" | `diagnostics.md` FIRST, then the matching contract |
-| Any shipped implementation | `../rules/workflow.md`, `../rules/validation.md`, plus matching contracts above |
+| Any shipped implementation | the always-on rules are already in context; add the matching contracts above |
 | Parity with the macOS app, or "does Windows have X yet" | the catalog first (below), then `mac-parity-audit.md` |
 | Historical measurements or experiments | Matching file under `../../notes/` |
 
 ## The cross-platform catalog answers parity questions first
 
-`~/.claude/knowledge/enviouswispr/catalog.db` holds 92 features across macOS and Windows, each row citing
-the file that decided it. Query it before reading a table or grepping the tree:
+`~/.claude/knowledge/enviouswispr/catalog.db` holds every feature across macOS, Windows and Android, each
+row citing the file that decided it. Query it before reading a table or grepping the tree. **Never publish
+a feature count here; ask the catalog.**
 
 ```bash
 C=~/.claude/knowledge/enviouswispr/catalog.db
@@ -40,8 +41,8 @@ surfaces the row without the whole index. One row per line, every row carries a 
 
 - [diagnostics.md](diagnostics.md) — **when:** crash, hang, silent exit, app quit, vanished, app.jsonl, run-state, heartbeat, diagnostic log, why did it do that
 - [design-system.md](design-system.md) — **when:** screen, control, colour, color, size, spacing, copy, icon, theme, anything the user sees
-- [pipeline.md](pipeline.md) — **when:** dictation behaviour, deterministic cleanup, emoji, punctuation, fallback, transcript
-- [distribution.md](distribution.md) — **when:** installer, signing, updates, release channel, Velopack, feed
-- [architecture.md](architecture.md) — **when:** architecture, dependency, platform choice, project layout
-- [product-contract.md](product-contract.md) — **when:** product decision, scope, invariant, privacy boundary
-- [mac-parity-audit.md](mac-parity-audit.md) — **when:** macOS parity, does Windows have, missing feature
+- [pipeline.md](pipeline.md) — **when:** dictation behaviour, deterministic cleanup, emoji, punctuation, fallback, transcript, wrong words, made up, making up, makes up, invented, hallucinat, extra words, trailing garbage, cut off, empty result, garbage at the end
+- [distribution.md](distribution.md) — **when:** installer, signing, updates, release channel, Velopack, feed, SmartScreen, publisher warning, cannot install, update failed
+- [architecture.md](architecture.md) — **when:** architecture, dependency, platform choice, project layout, new module, where does this live, out of process, worker
+- [product-contract.md](product-contract.md) — **when:** product decision, scope, invariant, privacy boundary, are we allowed to, should we ship, release gate, is this a defect
+- [mac-parity-audit.md](mac-parity-audit.md) — **when:** macOS parity, does Windows have, missing feature, the Mac does, on macOS, how does the Mac, deliberately different

--- a/.claude/knowledge/architecture.md
+++ b/.claude/knowledge/architecture.md
@@ -56,7 +56,8 @@ reason but ask rather than assert it, and write the answer here when you get it.
 - Audio: WASAPI through a maintained .NET wrapper or a narrow native bridge.
 - Hotkey: `RegisterHotKey` where possible, with a low-level hook only for combinations it cannot express.
 - Focus and context: Windows UI Automation with explicit fallbacks and privacy limits.
-- Delivery: UI Automation when reliable, otherwise clipboard plus narrowly scoped `SendInput`.
+- Delivery: clipboard-backed paste through narrowly scoped `SendInput`, with clipboard-only fallback when
+  synthetic paste is refused. Two routes, not the macOS cascade of five, and that is deliberate.
 - Secrets: Windows Credential Manager.
 - Storage: versioned user data outside the install directory with atomic writes and migrations.
 

--- a/.claude/knowledge/design-system.md
+++ b/.claude/knowledge/design-system.md
@@ -75,14 +75,13 @@ one before.
   **Padding on a frame is padding the frame's own background does not share.** Put it on the content
   layer whenever anything is meant to fill the frame.
 
-**The tell is always the same and it is free: the measurement does not move.** Not "improves a little" -
-IDENTICAL. Ask for the number before and the number after, and treat an unchanged number as evidence the
-change never reached the thing, not as evidence the change was too small.
+**The law, the measurement tell and the loud-failure preference are owned by
+`../rules/validation-discipline.md` RULE: a-change-that-does-nothing-looks-exactly-like-one-that-never-shipped,
+which is always in context. This file keeps the WinUI mechanics behind each instance.**
 
-**And the inverse failure is cheaper, so prefer it.** Replacing `MinHeight` with `Height` fixed the
-density and CLIPPED the group headings - the bottom row of pixels sliced off every glyph. That cost one
-round, because it was visible the moment anyone looked. The three inert changes cost three rounds and
-would all have shipped believed-working. **A fix that fails loudly beats three that fail silently.**
+Worked instance of preferring the loud failure: replacing `MinHeight` with `Height` fixed the density and
+CLIPPED the group headings, slicing the bottom row of pixels off every glyph. Visible the moment anyone
+looked.
 
 Corollary for sizing a text-bearing container: shorten the BLOCK with margin, never the text box with a
 height. `MinHeight` cannot shrink it and `Height` cannot let it grow, so a fixed height is a clip waiting
@@ -454,9 +453,9 @@ cheap check; that exchange is the expensive one, and neither replaces the other.
 Companion to RULE: a-gate-that-pins-the-MECHANISM. That one is about what a check ASSERTS; this is
 about what it asserts it WITH.
 
-## RULE: the-instrument-that-found-a-problem-may-not-verify-its-fix
-A measurement built to DETECT an inconsistency is frequently the wrong one to CONFIRM the fix, and
-re-running it produces a scattered result that reads as failure.
+## FACT: the spacing detector could not verify the spacing fix
+General law: `../rules/validation-discipline.md`
+RULE: the-instrument-that-found-a-problem-may-not-verify-its-fix. This is its worked instance.
 
 Measured on the spacing scale. The geometry table that found the problem measures gaps between
 consecutive WIDE CONTROLS and skips every label and paragraph in between, so a "370" is not a gap -
@@ -467,8 +466,7 @@ it is two controls with unmeasured content between them. Re-run after the fix it
 elements, histogrammed. Three real values landing exactly on 4, 8 and 12 DIP, against 2, 2.67, 10,
 10.67, 14 and 32.7 before - not one of which was on a grid.
 
-**Ask what the detecting instrument SKIPS before re-running it as a verifier.** A detector can
-afford to skip things; a verifier cannot.
+The detector skipped labels and paragraphs, so it could not verify adjacent-element spacing.
 
 ## FACT: one-environmental-test-was-truncating-the-suite-and-the-summary-hid-it
 Measured on the rig 2026-08-29, and the CAUSE was found only because the symptom recurred.

--- a/.claude/knowledge/product-contract.md
+++ b/.claude/knowledge/product-contract.md
@@ -1,13 +1,18 @@
 # Product contract
 
 **How to read this file.** A PROMISE is stated here with its values, because if the code drops one this
-file is what catches it. An IMPLEMENTATION DETAIL — a member list, a display order, an initial value —
-names its owning type instead, because prose restating code can only decay.
+file is what catches it. An IMPLEMENTATION DETAIL — an internal member list or display order with no
+independent product requirement — names its owning type instead, because prose restating code can only
+decay.
 
 The line matters: a contract that points at code for everything can never disagree with code, so it can
-never catch a regression. Providers, engines, the navigation groups and the licensing direction are
-promises and stay written out. Enum members, catalog order and defaults are details and point at their
-owner.
+never catch a regression. Providers, engines, navigation groups, licensing direction, and user-visible
+fresh-install defaults are promises and stay written out. Internal enum membership and catalog order are
+details and point at their owner.
+
+**The test, when a line is ambiguous:** would changing or removing this value reduce supported
+user-visible behaviour, violate a release promise, or weaken acceptance criteria? If yes, write it as a
+promise. If it only describes internal representation, ordering or ownership, point at the code.
 
 ## Audience and promise
 
@@ -80,8 +85,9 @@ explains the degraded stage without exposing private content.
 Invariant 8 says public release waits for full agreed Windows parity. What "agreed" means, stated so it is
 not re-litigated:
 
-- **The catalog decides parity, not this file.** A feature is release-blocking when its Windows row is
-  `absent` or `partial` AND it is not recorded as `deliberately-different`.
+- **The catalog decides parity, not this file.** A feature is release-blocking while its Windows status is
+  `absent` or `partial`. A `deliberately-different` row stops being a blocker only once
+  `difference_reason` records the settled reason.
 - **A deliberate difference needs its reason recorded before it counts as settled**, in the catalog's
   `difference_reason`. An undocumented divergence is a gap, not a decision.
 - **Parity is claimed from observed behaviour, never from a green suite.** The evidence is the real
@@ -93,8 +99,8 @@ sqlite3 ~/.claude/knowledge/enviouswispr/catalog.db \
    WHERE platform_key='windows' AND status IN ('absent','partial') ORDER BY status, feature_slug;"
 ```
 
-**Still undecided and owned by the founder:** whether every `partial` row must reach `shipped`, or whether
-some may ship as a stated limitation. Do not assume either.
+**Until the founder records a changed contract, every `partial` row blocks public release.** A stated
+limitation is not an exception.
 
 ## Licensing and release
 

--- a/.claude/rules/validation-discipline.md
+++ b/.claude/rules/validation-discipline.md
@@ -134,6 +134,33 @@ called, a list present but capped.
 - **Every save-and-restore harness must test an EMPTY original state and verify the restored world.** A
   successful wrapper call is not proof that restoration happened.
 
+## RULE: a-change-that-does-nothing-looks-exactly-like-one-that-never-shipped
+Six changes in this repo built clean, passed every gate, and had ZERO effect on the running app. Each was
+found only by measuring afterwards and getting the number from before.
+
+**The tell is free and always the same: the measurement does not MOVE.** Not "improved a little" —
+identical. Take the number before and after. Read an unchanged number as evidence the change never reached
+the thing, never as evidence it was too small to see.
+
+- **Prefer the failure mode that is loud.** A blunt mechanism that clips visibly is caught immediately; a
+  silent no-op ships believed-working.
+- **A minimum is a floor and a maximum is a ceiling.** Setting either on the wrong side of a natural value
+  is inert by construction and reads in the diff as a real change.
+- **Two mechanisms setting one property have no defined order.** Whichever you did not write wins.
+- **Padding on a frame is padding the frame's own background does not share.** Anything meant to fill a
+  frame goes on the content layer.
+
+**SIBLING FAILURE, DIFFERENT CAUSE.** This catches code that RUNS and does nothing. Code that is correct
+and that nothing can REACH ships green too, and the measurement tell cannot find it, because an
+unreachable feature never runs. Check that every set agrees: the declaration, the registration, the
+routing, and the surface that exposes it.
+
+Platform instances and the WinUI mechanics behind each: `../knowledge/design-system.md`.
+
+## RULE: the-instrument-that-found-a-problem-may-not-verify-its-fix
+A tool sensitive enough to detect a defect is frequently blind to whether the repair worked. Name the
+verification instrument separately from the detection instrument, and state why it can see the fix.
+
 ## RULE: an-expectation-built-with-the-thing-under-test-cannot-fail
 When asserting that a transformation PRESERVES something, build the expected value from a literal. If your
 expected value passes through any of the machinery the subject passes through, the test can only prove the


### PR DESCRIPTION
the knowledge base stops disagreeing with itself

Second half of the knowledge pass. Codex returned NOT-CLEAR on the first attempt
with four blockers, three of which were contradictions introduced earlier the same
day. All four are fixed and the confirming round is ALL-CLEAR.

Contradictions removed:

- architecture.md described delivery as UI Automation first, falling back to the
  clipboard. The catalog records the opposite and is right: clipboard-backed paste
  through narrowly scoped SendInput, with clipboard-only when that is refused. Two
  routes, deliberately, not the macOS cascade of five.
- The release gate said a partial feature blocks release, then said whether it
  blocks was undecided. It now says one thing: every partial row blocks until the
  founder records otherwise, and a stated limitation is not an exception.
- product-contract.md called defaults an implementation detail while keeping several
  user-visible defaults as promises. The rule now carries the test that decides:
  would changing this value reduce user-visible behaviour, violate a release promise,
  or weaken acceptance criteria.
- design-system.md still carried a rule that had been lifted into the always-on
  validation rules. It is now a worked instance pointing at the owner.

INDEX.md: a pointer to two rule files that no longer exist, broken when they were
absorbed into workflow-process and validation-discipline. A published feature count
that covered two platforms when there are three. Both fixed.

Pathway triggers widened with the words a person types when something is wrong
rather than the names of the parts. Verified by replay: four natural phrasings of the
trailing-hallucination problem all reach pipeline.md, where before this pass the
component name was the only way in. One phrasing missed on the first attempt because
the trigger read "made up" and the sentence said "making up".

The routing contract suite passes from this checkout: 96 checks, 0 failures, 13 index
rows and 58 project rows parse.

Deferred with Codex agreement, an improvement rather than a blocker: moving four more
validation entries out of the 40 KB design file. validation-discipline is already
12.5 KB in every session, so that split needs its own pass.
