### PR TITLE
the app says why it is running on the slow path

### DIFF
--- a/docs/privacy/observability.md
+++ b/docs/privacy/observability.md
@@ -36,6 +36,7 @@ JSONL writer, exporter, or HTTP transport.
 | `stage` | optional `DeterministicTextStage` enum | Which deterministic cleanup step a record is about: custom words, filler and false starts, spoken emoji, inverse text normalization, or emoji restoration. |
 | `stageStatus` | optional `DeterministicStageStatus` enum | Completed, Skipped, TimedOut, or Failed. A skipped step is the answer to most questions asked of this pipeline, so it is reported rather than omitted. |
 | `changed` | optional boolean | Whether that step altered the text. One bit, never what changed. |
+| `runtimeSelection` | optional `DiagnosticRuntimeSelectionReason` enum | Which processing path a run ended up on and what put it there: the graphics card, the processor because no card was available, the processor because the user asked for it, or the processor because the card was chosen and would not start. Also the three ways selection can fail. No device name, no driver version, and never the exception text behind a failed start. |
 
 There is no account ID, install ID, session ID, advertising ID, IP field, device name, username, path,
 model ID, locale, transcript length, audio length, target-app name, or free-form string field.

--- a/scripts/prepare-founder-local-runtime.ps1
+++ b/scripts/prepare-founder-local-runtime.ps1
@@ -13,11 +13,56 @@ param(
 
     [string[]]$CudaSourceDirectories,
 
-    [switch]$IncludeCuda
+    [switch]$IncludeCuda,
+
+    # THE ONLY WAY PAST THE GUARD BELOW, AND IT COSTS A STATED INTENT. Provisioning a machine that
+    # has an NVIDIA card without its runtime libraries is legitimate - a deliberate processor-only
+    # setup, or a card whose libraries are supplied some other way - but it is never what somebody
+    # wanted by ACCIDENT, which is what the bare default used to produce.
+    [switch]$SkipCuda
 )
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = [IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot))
+
+# ---- refuse to half-provision a machine that has a card ---------------------------------------
+# THIS SCRIPT'S DEFAULT SILENTLY BUILT THE EXACT STATE ISSUE #102 SPENT DAYS ON. Without
+# -IncludeCuda it provisions models and no graphics runtime, so the app correctly finds no
+# dependencies, correctly falls back, and dictation runs about a hundred times slower on a machine
+# with an idle RTX 4090. Nothing failed, nothing was red, and the only symptom was a slow app.
+#
+# A DEFAULT THAT PRODUCES A BROKEN-LOOKING MACHINE IS NOT A SAFE DEFAULT. The check runs BEFORE any
+# file is copied so a refusal leaves the machine exactly as it was found.
+#
+# THE DRIVER'S OWN TOOL IS THE AUTHORITY, and the display adapter list is the fallback for a machine
+# whose driver tools are not on PATH. Neither is asked whether the RUNTIME libraries are present -
+# that is what -IncludeCuda provisions; this asks only whether a card is here to be wasted.
+function Test-NvidiaDevicePresent {
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $smi = Get-Command 'nvidia-smi' -ErrorAction SilentlyContinue
+        if ($null -ne $smi) {
+            $listed = & $smi.Source '-L' 2>&1 | Out-String
+            if ($LASTEXITCODE -eq 0 -and $listed -match 'GPU 0:') { return $true }
+        }
+
+        $adapters = @(Get-CimInstance -ClassName Win32_VideoController -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match 'NVIDIA' })
+        return $adapters.Count -gt 0
+    }
+    finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
+if (-not $IncludeCuda -and -not $SkipCuda -and (Test-NvidiaDevicePresent)) {
+    throw ('This machine has an NVIDIA graphics card and -IncludeCuda was not passed, so the run ' +
+        'would install the models and none of the graphics runtime libraries they need. That is ' +
+        'the state where transcription silently falls back to the processor and runs about a ' +
+        'hundred times slower (#102). Re-run with -IncludeCuda, or with -SkipCuda if a ' +
+        'processor-only machine is what you meant. Nothing has been copied.')
+}
 
 if ([string]::IsNullOrWhiteSpace($DataDirectory)) {
     $DataDirectory = Join-Path `

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -1481,7 +1481,9 @@ public partial class App : Application, IAsyncDisposable
                 "1",
                 StringComparison.Ordinal))
         {
-            _window?.SetSessionStatus(DictationStatus.Quiet("Local transcription disabled for performance UAT"));
+            _window?.SetSessionStatus(DictationStatus
+                .Quiet("Local transcription disabled for performance UAT")
+                .AboutTheTranscriptionEngine());
             return;
         }
 
@@ -1510,7 +1512,8 @@ public partial class App : Application, IAsyncDisposable
         {
             _window?.SetSessionStatus(
                 DictationStatus.Advisory(
-                    "Local transcription model is not installed", OpenTranscription));
+                        "Local transcription model is not installed", OpenTranscription)
+                    .AboutTheTranscriptionEngine());
             _logger.Write(new AppLogEntry(
                 DateTimeOffset.UtcNow,
                 AppEventCode.DictationTranscriptionFailed,
@@ -1521,22 +1524,30 @@ public partial class App : Application, IAsyncDisposable
         var hardware = await new WindowsHardwareDiscovery(_cudaRuntimeDirectory)
             .ProbeAsync()
             .ConfigureAwait(true);
+        var workerExecutable = Path.Combine(AppContext.BaseDirectory, "EnviousWispr.RuntimeWorker.exe");
+        // THE SELECTION IS MADE BEFORE IT IS OBSERVED. This line used to be written above the two
+        // Create calls, so it could only ever report the hardware and never what the hardware was
+        // used FOR - which is why a machine transcribing on the processor beside an idle graphics
+        // card had nothing anywhere saying whether the card was absent, refused, or chosen and
+        // broken. Ref: #102.
+        _transcriptionEngine = engine == FinalAsrEngine.Whisper
+            ? CreateWhisperEngine(
+                workerExecutable, modelDirectory, hardware, whisperLanguage, out var selectionReason)
+            : CreateParakeetEngine(workerExecutable, modelDirectory, hardware, out selectionReason);
         _logger.Write(new AppLogEntry(
             DateTimeOffset.UtcNow,
             AppEventCode.RuntimeSelectionObserved,
             Engine: engine == FinalAsrEngine.Whisper
                 ? DiagnosticEngineChoice.Whisper
                 : DiagnosticEngineChoice.Parakeet,
-            HardwareClass: DiagnosticHardwareClassFor(hardware)));
-        var workerExecutable = Path.Combine(AppContext.BaseDirectory, "EnviousWispr.RuntimeWorker.exe");
-        _transcriptionEngine = engine == FinalAsrEngine.Whisper
-            ? CreateWhisperEngine(workerExecutable, modelDirectory, hardware, whisperLanguage)
-            : CreateParakeetEngine(workerExecutable, modelDirectory, hardware);
+            HardwareClass: DiagnosticHardwareClassFor(hardware),
+            RuntimeSelection: selectionReason));
         if (_transcriptionEngine is null)
         {
             _window?.SetSessionStatus(
                 DictationStatus.Advisory(
-                    "Local transcription is unavailable on this machine", OpenTranscription));
+                        "Local transcription is unavailable on this machine", OpenTranscription)
+                    .AboutTheTranscriptionEngine());
             _logger.Write(new AppLogEntry(
                 DateTimeOffset.UtcNow,
                 AppEventCode.DictationTranscriptionFailed,
@@ -1564,7 +1575,8 @@ public partial class App : Application, IAsyncDisposable
                 _transcriptionEngine = null;
                 _window?.SetSessionStatus(
                     DictationStatus.Advisory(
-                    "Local transcription could not start", OpenTranscription));
+                            "Local transcription could not start", OpenTranscription)
+                        .AboutTheTranscriptionEngine());
                 _logger.Write(new AppLogEntry(
                     DateTimeOffset.UtcNow,
                     AppEventCode.DictationTranscriptionFailed,
@@ -1573,17 +1585,39 @@ public partial class App : Application, IAsyncDisposable
             }
 
             ConfigureLivePreview(workerExecutable, hardware, whisperLanguage, forceCpu: true);
-            _window?.SetSessionStatus(DictationStatus.Quiet("Local transcription ready on the processor"));
+            // THE MEMBER NO SELECTOR CAN PRODUCE. Getting here means the selection SUCCEEDED and the
+            // runtime then refused to start, which the selector cannot see and therefore cannot
+            // report. Measured on the development machine: the graphics libraries were missing, the
+            // card was chosen, the start failed, the processor took over, and dictation ran about a
+            // hundred times slower for days with nothing saying so. Ref: #102.
+            var degradedReason =
+                selectionReason == DiagnosticRuntimeSelectionReason.GpuSelected
+                    ? DiagnosticRuntimeSelectionReason.ProcessorSelectedAfterGpuFailedToStart
+                    : selectionReason;
+            // ADVISORY, NOT QUIET, AND ONLY WHERE THE CARD IS ACTUALLY THE STORY. This is the user's
+            // setup needing attention rather than the app breaking, so it takes the advisory pill and
+            // carries the consequence rather than the mechanism - a person who reads "ready on the
+            // processor" has been told a fact about our plumbing and nothing they can act on. Where
+            // the run was never going to be on a card, there is no consequence to report and the
+            // quiet line stands.
+            _window?.SetSessionStatus(
+                (degradedReason == DiagnosticRuntimeSelectionReason.ProcessorSelectedAfterGpuFailedToStart
+                    ? DictationStatus.Advisory(
+                        "Your graphics card did not start, so dictation is slower", OpenTranscription)
+                    : DictationStatus.Quiet("Local transcription ready on the processor"))
+                    .AboutTheTranscriptionEngine());
             _logger.Write(new AppLogEntry(
                 DateTimeOffset.UtcNow,
                 AppEventCode.DictationTranscriptionDegraded,
                 AppFailureCategory.RuntimeProvider,
-                ErrorCode: AppErrorCode.RuntimeProviderUnavailable));
+                ErrorCode: AppErrorCode.RuntimeProviderUnavailable,
+                RuntimeSelection: degradedReason));
             return;
         }
 
         ConfigureLivePreview(workerExecutable, hardware, whisperLanguage);
-        _window?.SetSessionStatus(DictationStatus.Quiet("Local transcription ready"));
+        _window?.SetSessionStatus(
+            DictationStatus.Quiet("Local transcription ready").AboutTheTranscriptionEngine());
     }
 
     private void ConfigureLivePreview(
@@ -1635,7 +1669,8 @@ public partial class App : Application, IAsyncDisposable
     private RuntimeWorkerTranscriptionEngine? CreateParakeetEngine(
         string workerExecutable,
         string modelDirectory,
-        HardwareSnapshot hardware)
+        HardwareSnapshot hardware,
+        out DiagnosticRuntimeSelectionReason reason)
     {
         var models = new LocalParakeetModelProbe().Probe(modelDirectory);
         var selection = ParakeetRuntimeSelector.Select(hardware, models);
@@ -1643,6 +1678,9 @@ public partial class App : Application, IAsyncDisposable
             hardware,
             models,
             RuntimeProviderPreference.Cpu);
+        // REPORTED ON BOTH EXITS, WHICH IS THE POINT OF THE OUT PARAMETER. The failing path is the
+        // one nobody could read: returning null told the caller only that there was no engine.
+        reason = DiagnosticRuntimeSelectionReasons.From(selection);
         if (!selection.Succeeded ||
             selection.Provider is null ||
             selection.ModelPack is null ||
@@ -1695,7 +1733,8 @@ public partial class App : Application, IAsyncDisposable
         string workerExecutable,
         string modelDirectory,
         HardwareSnapshot hardware,
-        string language)
+        string language,
+        out DiagnosticRuntimeSelectionReason reason)
     {
         var models = new LocalWhisperModelProbe().Probe(modelDirectory);
         var selection = WhisperRuntimeSelector.Select(hardware, models);
@@ -1703,6 +1742,7 @@ public partial class App : Application, IAsyncDisposable
             hardware,
             models,
             RuntimeProviderPreference.Cpu);
+        reason = DiagnosticRuntimeSelectionReasons.From(selection);
         if (!selection.Succeeded ||
             selection.Provider is null ||
             selection.ModelPack is null ||
@@ -3050,7 +3090,8 @@ public partial class App : Application, IAsyncDisposable
             await controller.ResetAsync(CancellationToken.None).ConfigureAwait(false);
             _window?.DispatcherQueue.TryEnqueue(() =>
                 _window?.SetSessionStatus(DictationStatus.Advisory(
-                    "Audio captured, but local transcription is unavailable", OpenTranscription)));
+                        "Audio captured, but local transcription is unavailable", OpenTranscription)
+                    .AboutTheTranscriptionEngine()));
             return;
         }
 

--- a/src/Production/EnviousWispr.App/MainWindow.xaml.cs
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml.cs
@@ -604,14 +604,14 @@ public sealed partial class MainWindow : Window, IDisposable
         PreviewRecordingSoundButton.IsEnabled = overlayState != DictationOverlayState.Recording;
         SetSpeedCheckAvailability(overlayState != DictationOverlayState.Recording);
         _overlayWindow.ShowState(status);
-        if (sentence.Contains("ready", StringComparison.OrdinalIgnoreCase))
-        {
-            EngineReadinessText.Text = sentence;
-            OnboardingModelText.Text = sentence;
-        }
-        else if (sentence.Contains("model is not installed", StringComparison.OrdinalIgnoreCase) ||
-                 sentence.Contains("transcription is unavailable", StringComparison.OrdinalIgnoreCase) ||
-                 sentence.Contains("worker could not start", StringComparison.OrdinalIgnoreCase))
+        // THE STATUS SAYS WHETHER IT BELONGS HERE; THIS NO LONGER GUESSES FROM THE WORDS. What stood
+        // here tested the sentence for "ready", "model is not installed", "transcription is
+        // unavailable" and "worker could not start", which is the same mistake `OverlayStateFor` was
+        // deleted for one surface over. It let four unrelated messages overwrite the Transcription
+        // card - a Windows resume, a finished Escape Recovery, and both Ollama health lines - and it
+        // would have dropped any new engine sentence that did not happen to contain one of the four
+        // phrases. `AboutTheTranscriptionEngine` carries the answer from the call site instead.
+        if (status.DescribesTranscriptionEngine)
         {
             EngineReadinessText.Text = sentence;
             OnboardingModelText.Text = sentence;

--- a/src/Production/EnviousWispr.Architecture.Tests/DiagnosticRuntimeSelectionReasonTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/DiagnosticRuntimeSelectionReasonTests.cs
@@ -1,0 +1,241 @@
+using EnviousWispr.Core.Diagnostics;
+using EnviousWispr.Core.Presentation;
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+/// <summary>The log can say why a run is on the path it is on, for every reason a selector has.</summary>
+/// <remarks>
+/// THE ENUMERATION IS THE TEST, NOT THE EXAMPLES. Both selectors own a private reason vocabulary and
+/// the app now writes a mapped one to the log, so the failure this guards is a member added to a
+/// selector and never mapped - which would throw on a real user's startup path. Reflecting over the
+/// source enums means the guard covers members that do not exist yet, which a list of cases cannot.
+/// </remarks>
+public sealed class DiagnosticRuntimeSelectionReasonTests
+{
+    public static TheoryData<RuntimeSelectionReason, RuntimeProviderKind> ParakeetReasons()
+    {
+        var data = new TheoryData<RuntimeSelectionReason, RuntimeProviderKind>();
+        foreach (var reason in Enum.GetValues<RuntimeSelectionReason>())
+        {
+            foreach (var provider in Enum.GetValues<RuntimeProviderKind>())
+            {
+                data.Add(reason, provider);
+            }
+        }
+
+        return data;
+    }
+
+    public static TheoryData<WhisperRuntimeSelectionReason, RuntimeProviderKind> WhisperReasons()
+    {
+        var data = new TheoryData<WhisperRuntimeSelectionReason, RuntimeProviderKind>();
+        foreach (var reason in Enum.GetValues<WhisperRuntimeSelectionReason>())
+        {
+            foreach (var provider in Enum.GetValues<RuntimeProviderKind>())
+            {
+                data.Add(reason, provider);
+            }
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(ParakeetReasons))]
+    public void EveryParakeetSelectionReasonHasADiagnosticReason(
+        RuntimeSelectionReason reason,
+        RuntimeProviderKind provider)
+    {
+        var mapped = DiagnosticRuntimeSelectionReasons.From(new RuntimeSelection(
+            true,
+            provider,
+            ParakeetModelPack.Quantized,
+            IntraOpThreads: 4,
+            InterOpThreads: 1,
+            reason));
+
+        Assert.True(Enum.IsDefined(mapped));
+    }
+
+    [Theory]
+    [MemberData(nameof(WhisperReasons))]
+    public void EveryWhisperSelectionReasonHasADiagnosticReason(
+        WhisperRuntimeSelectionReason reason,
+        RuntimeProviderKind provider)
+    {
+        var mapped = DiagnosticRuntimeSelectionReasons.From(new WhisperRuntimeSelection(
+            true,
+            provider,
+            WhisperModelPack.Quantized,
+            ThreadCount: 4,
+            reason));
+
+        Assert.True(Enum.IsDefined(mapped));
+    }
+
+    /// <summary>A user who asked for the processor is not reported as a machine that had no card.</summary>
+    /// <remarks>
+    /// THE ONE ARM WHERE THE REASON ALONE IS NOT ENOUGH. Both selectors report an explicit choice as
+    /// `ManualProviderAccepted` whichever provider was asked for, so a mapping that read only the
+    /// reason would answer "why is this slow" with the same word for a deliberate choice and for a
+    /// broken card. Those are opposite investigations.
+    /// </remarks>
+    [Theory]
+    [InlineData(RuntimeProviderKind.Cpu, DiagnosticRuntimeSelectionReason.ProcessorSelectedByUserChoice)]
+    [InlineData(RuntimeProviderKind.Cuda, DiagnosticRuntimeSelectionReason.GpuSelected)]
+    [InlineData(RuntimeProviderKind.DirectMl, DiagnosticRuntimeSelectionReason.GpuSelected)]
+    public void ManualAcceptanceIsReportedAgainstTheProviderTheUserChose(
+        RuntimeProviderKind provider,
+        DiagnosticRuntimeSelectionReason expected)
+    {
+        Assert.Equal(
+            expected,
+            DiagnosticRuntimeSelectionReasons.From(new WhisperRuntimeSelection(
+                true,
+                provider,
+                WhisperModelPack.Quantized,
+                ThreadCount: 4,
+                WhisperRuntimeSelectionReason.ManualProviderAccepted)));
+        Assert.Equal(
+            expected,
+            DiagnosticRuntimeSelectionReasons.From(new RuntimeSelection(
+                true,
+                provider,
+                ParakeetModelPack.Quantized,
+                IntraOpThreads: 4,
+                InterOpThreads: 1,
+                RuntimeSelectionReason.ManualProviderAccepted)));
+    }
+
+    [Fact]
+    public void TheAutomaticProcessorFallbackSaysNoCardWasAvailable()
+    {
+        Assert.Equal(
+            DiagnosticRuntimeSelectionReason.ProcessorSelectedNoGpuAvailable,
+            DiagnosticRuntimeSelectionReasons.From(new WhisperRuntimeSelection(
+                true,
+                RuntimeProviderKind.Cpu,
+                WhisperModelPack.Quantized,
+                ThreadCount: 4,
+                WhisperRuntimeSelectionReason.TunedCpuWithQuantizedModel)));
+        Assert.Equal(
+            DiagnosticRuntimeSelectionReason.ProcessorSelectedNoGpuAvailable,
+            DiagnosticRuntimeSelectionReasons.From(new RuntimeSelection(
+                true,
+                RuntimeProviderKind.Cpu,
+                ParakeetModelPack.Quantized,
+                IntraOpThreads: 4,
+                InterOpThreads: 1,
+                RuntimeSelectionReason.TunedCpuUniversalFallback)));
+    }
+
+    /// <summary>An unmapped member is loud, because a silent one is the defect being fixed.</summary>
+    [Fact]
+    public void AnUnmappedReasonRefusesRatherThanReportingNothing()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            DiagnosticRuntimeSelectionReasons.From(new WhisperRuntimeSelection(
+                true,
+                RuntimeProviderKind.Cpu,
+                WhisperModelPack.Quantized,
+                ThreadCount: 4,
+                (WhisperRuntimeSelectionReason)int.MaxValue)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            DiagnosticRuntimeSelectionReasons.From(new RuntimeSelection(
+                true,
+                RuntimeProviderKind.Cpu,
+                ParakeetModelPack.Quantized,
+                IntraOpThreads: 4,
+                InterOpThreads: 1,
+                (RuntimeSelectionReason)int.MaxValue)));
+    }
+
+    [Fact]
+    public void AnUndefinedRuntimeSelectionCannotReachThePrivacySafeRecord()
+    {
+        var record = PrivacySafeDiagnosticRecord.From(new AppLogEntry(
+            DateTimeOffset.UtcNow,
+            AppEventCode.RuntimeSelectionObserved,
+            RuntimeSelection: (DiagnosticRuntimeSelectionReason)int.MaxValue));
+
+        Assert.Null(record.RuntimeSelection);
+    }
+
+    [Fact]
+    public void TheRuntimeSelectionSurvivesTheTripToTheLocalLine()
+    {
+        var record = PrivacySafeDiagnosticRecord.From(new AppLogEntry(
+            DateTimeOffset.UtcNow,
+            AppEventCode.RuntimeSelectionObserved,
+            RuntimeSelection: DiagnosticRuntimeSelectionReason.ProcessorSelectedAfterGpuFailedToStart));
+
+        Assert.Equal(
+            DiagnosticRuntimeSelectionReason.ProcessorSelectedAfterGpuFailedToStart,
+            LocalDiagnosticLine.From(record, dictationId: null).RuntimeSelection);
+    }
+}
+
+/// <summary>A status says for itself whether the Transcription card should show it.</summary>
+/// <remarks>
+/// THE WINDOW USED TO DECIDE THIS BY SEARCHING THE SENTENCE FOR FOUR PHRASES, which is only testable
+/// through a window that no test here can build. Moving the answer onto the status is what makes it
+/// checkable at all, and these are the checks that were impossible before.
+/// </remarks>
+public sealed class TranscriptionEngineStatusTests
+{
+    [Fact]
+    public void AStatusIsNotAboutTheEngineUnlessItSaysSo()
+    {
+        Assert.False(DictationStatus.Quiet("Windows resumed. EnviousWispr is ready")
+            .DescribesTranscriptionEngine);
+        Assert.False(DictationStatus.Quiet("Escape Recovery finished. Text is ready to copy")
+            .DescribesTranscriptionEngine);
+        Assert.False(DictationStatus.Quiet("Ollama is ready").DescribesTranscriptionEngine);
+        Assert.False(DictationStatus.Quiet("Cleaned locally; the selected Ollama model is not installed")
+            .DescribesTranscriptionEngine);
+    }
+
+    /// <summary>Marking a status changes nothing else about it.</summary>
+    [Fact]
+    public void MarkingAStatusKeepsItsSentencePillAndButton()
+    {
+        var action = new PillAction("Open settings", PillActionKind.OpenTranscriptionSettings);
+        var marked = DictationStatus
+            .Advisory("Your graphics card did not start, so dictation is slower", action)
+            .AboutTheTranscriptionEngine();
+
+        Assert.True(marked.DescribesTranscriptionEngine);
+        Assert.Equal("Your graphics card did not start, so dictation is slower", marked.Text);
+        Assert.Equal(DictationOverlayState.Advisory, marked.State);
+        Assert.Equal(action, marked.Action);
+    }
+
+    /// <summary>
+    /// A sentence carrying none of the four old phrases still reaches the card once it is marked.
+    /// </summary>
+    /// <remarks>
+    /// THIS IS THE HALF THE OLD MECHANISM COULD NOT DO. The new degraded sentence contains no
+    /// "ready", no "unavailable" and no "not installed", so under the previous rule the Transcription
+    /// card would have kept showing whatever it last said while the app told the user on the pill
+    /// that their graphics card had failed.
+    /// </remarks>
+    [Fact]
+    public void AnEngineSentenceReachesTheCardWithoutContainingAnyOldTriggerWord()
+    {
+        var status = DictationStatus
+            .Advisory("Your graphics card did not start, so dictation is slower")
+            .AboutTheTranscriptionEngine();
+
+        foreach (var phrase in new[]
+                 {
+                     "ready", "model is not installed", "transcription is unavailable",
+                     "worker could not start",
+                 })
+        {
+            Assert.DoesNotContain(phrase, status.Text, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.True(status.DescribesTranscriptionEngine);
+    }
+}

--- a/src/Production/EnviousWispr.Architecture.Tests/PrivacySafeObservabilityTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/PrivacySafeObservabilityTests.cs
@@ -315,13 +315,14 @@ public sealed class PrivacySafeObservabilityTests
             HardwareClass: DiagnosticHardwareClass.NvidiaCuda,
             Stage: DeterministicTextStage.CustomWords,
             StageStatus: DeterministicStageStatus.Completed,
-            Changed: true);
+            Changed: true,
+            RuntimeSelection: DiagnosticRuntimeSelectionReason.ProcessorSelectedAfterGpuFailedToStart);
 
         var populated = typeof(PrivacySafeDiagnosticRecord)
             .GetProperties(BindingFlags.Public | BindingFlags.Instance)
             .Where(property => property.Name != "EqualityContract")
             .ToArray();
-        Assert.Equal(11, populated.Length);
+        Assert.Equal(12, populated.Length);
 
         var line = LocalDiagnosticLine.From(record, Guid.NewGuid());
         foreach (var property in populated)

--- a/src/Production/EnviousWispr.Architecture.Tests/TranscriptionEngineNameTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/TranscriptionEngineNameTests.cs
@@ -1530,8 +1530,15 @@ public sealed partial class DesignSystemTokenTests
             .Select(match => match.Groups[1].Value)
             .ToHashSet(StringComparer.Ordinal);
 
+        // WHITESPACE-TOLERANT ON PURPOSE, AND THIS WAS A CORRECTION. The check was a substring test
+        // for "DictationStatus." exactly, so a call site that wrapped the line between the type and
+        // its factory - which the line length forces once a status is also marked for the
+        // Transcription card - was reported as deciding its appearance somewhere unseen. It was not:
+        // it named the type on the line above. The gate was pinning the LINE BREAK rather than the
+        // property it exists to hold, and the app was right. It now asserts what it actually means,
+        // which is that the call site names the type.
         var unnamed = arguments
-            .Where(argument => !argument.Contains("DictationStatus.", StringComparison.Ordinal))
+            .Where(argument => !DictationStatusFactoryCall().IsMatch(argument))
             .Where(argument => !carriers.Any(carrier =>
                 IdentifierRegexFor(carrier).IsMatch(argument)))
             .ToArray();
@@ -1540,6 +1547,28 @@ public sealed partial class DesignSystemTokenTests
             unnamed.Length == 0,
             "These statuses reach the window without naming the pill they want, so the appearance "
                 + "is decided somewhere this suite cannot see: " + string.Join(" | ", unnamed));
+    }
+
+    /// <summary>The relaxed match still refuses an argument that names no status at all.</summary>
+    /// <remarks>
+    /// PROVING THE RELAXATION DID NOT OPEN THE GATE. Allowing whitespace between the type and its
+    /// factory is a one-character change to a pattern, and the failure it could introduce is silent:
+    /// a gate that matches everything passes forever. Both directions are asserted here because one
+    /// of them alone is not a control.
+    /// </remarks>
+    [Fact]
+    public void TheStatusFactoryMatchAcceptsAWrappedCallAndStillRefusesANamelessOne()
+    {
+        var pattern = DictationStatusFactoryCall();
+        Assert.Matches(pattern, "DictationStatus.Quiet(\"Ready\")");
+        Assert.Matches(
+            pattern,
+            "DictationStatus" + Environment.NewLine +
+            "                .Quiet(\"Ready\")" + Environment.NewLine +
+            "                .AboutTheTranscriptionEngine()");
+        Assert.DoesNotMatch(pattern, "helper.BuildTheStatus(sentence)");
+        Assert.DoesNotMatch(pattern, "statusFromSentence(sentence)");
+        Assert.DoesNotMatch(pattern, "DictationStatusHelper(sentence)");
     }
 
     private static IEnumerable<string> ProductionSourceFiles(string directory) =>
@@ -1586,6 +1615,10 @@ public sealed partial class DesignSystemTokenTests
     /// <summary>A name the compiler agrees is a DictationStatus: member, parameter, or local.</summary>
     [GeneratedRegex(@"\bDictationStatus\??\s+(\w+)\s*(?:\(|=|\)|,|;)")]
     private static partial Regex DictationStatusCarrier();
+
+    /// <summary>The type naming one of its own factories, across a line break if need be.</summary>
+    [GeneratedRegex(@"\bDictationStatus\s*\.")]
+    private static partial Regex DictationStatusFactoryCall();
 
     /// <summary>
     /// No page arrives with a heading and nothing under it.

--- a/src/Production/EnviousWispr.Core/Diagnostics/AppLogEntry.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/AppLogEntry.cs
@@ -14,4 +14,5 @@ public sealed record AppLogEntry(
     DiagnosticHardwareClass? HardwareClass = null,
     DeterministicTextStage? Stage = null,
     DeterministicStageStatus? StageStatus = null,
-    bool? Changed = null);
+    bool? Changed = null,
+    DiagnosticRuntimeSelectionReason? RuntimeSelection = null);

--- a/src/Production/EnviousWispr.Core/Diagnostics/DiagnosticRuntimeSelectionReasons.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/DiagnosticRuntimeSelectionReasons.cs
@@ -1,0 +1,102 @@
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Core.Diagnostics;
+
+/// <summary>Turns an engine selector's own reason into the one the log records.</summary>
+/// <remarks>
+/// TWO SELECTORS, TWO PRIVATE VOCABULARIES, ONE QUESTION A READER ASKS. Parakeet answers in
+/// <see cref="RuntimeSelectionReason"/> and Whisper in <see cref="WhisperRuntimeSelectionReason"/>,
+/// and both spell the same three outcomes differently because each names the MODEL PACK it settled
+/// on as well as the provider. A reader of the log is asking something narrower - which path is this
+/// run on, and what put it there - so the mapping deliberately collapses the pack half away.
+///
+/// IT THROWS ON AN UNMAPPED MEMBER RATHER THAN RETURNING NULL. Declining to classify is an action: a
+/// null here would be written as a line with no reason on it, which is indistinguishable from the
+/// silence this whole change exists to remove. The throw cannot reach a user because
+/// `EveryRuntimeSelectionReasonHasADiagnosticReason` enumerates both source enums by reflection, so
+/// a member added without a mapping is a red test rather than a startup crash.
+///
+/// MANUAL ACCEPTANCE IS THE ONE ARM THAT NEEDS THE PROVIDER. Both selectors report a user's explicit
+/// choice as one member whichever provider was asked for, so the reason alone cannot tell "the user
+/// chose the processor" from "the user chose the card" - and those are opposite answers to why a run
+/// is slow.
+/// </remarks>
+public static class DiagnosticRuntimeSelectionReasons
+{
+    public static DiagnosticRuntimeSelectionReason From(RuntimeSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        return selection.Reason switch
+        {
+            RuntimeSelectionReason.NvidiaCudaWithQdqFreeModel =>
+                DiagnosticRuntimeSelectionReason.GpuSelected,
+
+            // THE ONLY AUTOMATIC ROUTE TO THE PROCESSOR. The selector reaches it when no usable
+            // graphics path was found, so the pack it names is not the question a reader has.
+            RuntimeSelectionReason.TunedCpuUniversalFallback =>
+                DiagnosticRuntimeSelectionReason.ProcessorSelectedNoGpuAvailable,
+
+            RuntimeSelectionReason.ManualProviderAccepted => ForManualChoice(selection.Provider),
+
+            // A DECODER INCOMPATIBILITY IS A PROVIDER THAT IS NOT AVAILABLE HERE, from the point of
+            // view of somebody reading why their run went the way it did.
+            RuntimeSelectionReason.DirectMlIncompatibleWithParakeetDecoder or
+                RuntimeSelectionReason.RequestedProviderUnavailable =>
+                DiagnosticRuntimeSelectionReason.SelectionFailedProviderUnavailable,
+
+            RuntimeSelectionReason.RequiredModelPackMissing =>
+                DiagnosticRuntimeSelectionReason.SelectionFailedModelPackMissing,
+
+            RuntimeSelectionReason.UnsupportedProcessorArchitecture =>
+                DiagnosticRuntimeSelectionReason.SelectionFailedUnsupportedProcessorArchitecture,
+
+            _ => throw new ArgumentOutOfRangeException(nameof(selection)),
+        };
+    }
+
+    public static DiagnosticRuntimeSelectionReason From(WhisperRuntimeSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        return selection.Reason switch
+        {
+            WhisperRuntimeSelectionReason.NvidiaCudaWithFullPrecisionModel or
+                WhisperRuntimeSelectionReason.NvidiaCudaWithQuantizedModel =>
+                DiagnosticRuntimeSelectionReason.GpuSelected,
+
+            // BOTH TUNED-CPU MEMBERS MEAN THE SAME THING TO A READER. The selector tries the card
+            // first under Automatic and only names a processor pack once that returned nothing, and
+            // the pack it settled on is a different question from why the card is not in use.
+            WhisperRuntimeSelectionReason.TunedCpuWithQuantizedModel or
+                WhisperRuntimeSelectionReason.TunedCpuWithFullPrecisionModel =>
+                DiagnosticRuntimeSelectionReason.ProcessorSelectedNoGpuAvailable,
+
+            WhisperRuntimeSelectionReason.ManualProviderAccepted => ForManualChoice(selection.Provider),
+
+            WhisperRuntimeSelectionReason.RequestedProviderUnavailable =>
+                DiagnosticRuntimeSelectionReason.SelectionFailedProviderUnavailable,
+
+            WhisperRuntimeSelectionReason.RequiredModelPackMissing =>
+                DiagnosticRuntimeSelectionReason.SelectionFailedModelPackMissing,
+
+            WhisperRuntimeSelectionReason.UnsupportedProcessorArchitecture =>
+                DiagnosticRuntimeSelectionReason.SelectionFailedUnsupportedProcessorArchitecture,
+
+            _ => throw new ArgumentOutOfRangeException(nameof(selection)),
+        };
+    }
+
+    private static DiagnosticRuntimeSelectionReason ForManualChoice(RuntimeProviderKind? provider) =>
+        provider switch
+        {
+            RuntimeProviderKind.Cpu => DiagnosticRuntimeSelectionReason.ProcessorSelectedByUserChoice,
+
+            // BOTH ACCELERATED PROVIDERS READ AS "ON THE CARD". The reader's question is whether the
+            // slow path is in use, and neither of these is it.
+            RuntimeProviderKind.Cuda or RuntimeProviderKind.DirectMl =>
+                DiagnosticRuntimeSelectionReason.GpuSelected,
+
+            // A SUCCEEDING SELECTION ALWAYS CARRIES A PROVIDER, so null here is a contract break
+            // rather than a state to describe, and inventing a category for it would hide that.
+            _ => throw new ArgumentOutOfRangeException(nameof(provider)),
+        };
+}

--- a/src/Production/EnviousWispr.Core/Diagnostics/LocalDiagnosticLine.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/LocalDiagnosticLine.cs
@@ -40,6 +40,7 @@ public sealed record LocalDiagnosticLine(
     DeterministicTextStage? Stage = null,
     DeterministicStageStatus? StageStatus = null,
     bool? Changed = null,
+    DiagnosticRuntimeSelectionReason? RuntimeSelection = null,
     Guid? DictationId = null)
 {
     /// <summary>Takes a line that is safe to send and adds what only this machine may know.</summary>
@@ -58,6 +59,7 @@ public sealed record LocalDiagnosticLine(
             record.Stage,
             record.StageStatus,
             record.Changed,
+            record.RuntimeSelection,
             dictationId);
     }
 }

--- a/src/Production/EnviousWispr.Core/Diagnostics/PrivacySafeDiagnosticRecord.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/PrivacySafeDiagnosticRecord.cs
@@ -40,6 +40,45 @@ public enum DiagnosticHardwareClass
     NvidiaCuda,
 }
 
+/// <summary>Which processing path a run ended up on, and what put it there.</summary>
+/// <remarks>
+/// THE ANSWER TO "WHY IS THIS SLOW", WRITTEN AT THE MOMENT IT IS DECIDED. The engine selectors have
+/// always computed a reason and returned it; nothing carried it as far as the log, so a machine that
+/// spent days transcribing on the processor beside an idle graphics card had nothing anywhere saying
+/// which of "no card", "you asked for this" and "the card was chosen and would not start" was true.
+/// Those three are one sentence apart for a reader and a different investigation each. Ref: #102.
+///
+/// A CATEGORY, NEVER A MESSAGE. Members are fixed and few, so this may cross the network beside
+/// Engine and HardwareClass; an exception string never could, and deliberately is not carried here.
+///
+/// PROCESSOR-AFTER-GPU-FAILED IS THE MEMBER NO SELECTOR CAN PRODUCE. The selection succeeds and the
+/// runtime then refuses to start, which is one layer below anything a selector can see, so the app
+/// writes that member itself at the point it swaps the engine out.
+/// </remarks>
+public enum DiagnosticRuntimeSelectionReason
+{
+    /// <summary>The graphics card was chosen and the run is on it.</summary>
+    GpuSelected,
+
+    /// <summary>No usable graphics path was available, so the processor was chosen.</summary>
+    ProcessorSelectedNoGpuAvailable,
+
+    /// <summary>The user asked for the processor explicitly.</summary>
+    ProcessorSelectedByUserChoice,
+
+    /// <summary>The graphics card was chosen, failed to start, and the processor took over.</summary>
+    ProcessorSelectedAfterGpuFailedToStart,
+
+    /// <summary>Nothing was selected: the model pack is missing.</summary>
+    SelectionFailedModelPackMissing,
+
+    /// <summary>Nothing was selected: the requested provider is not available here.</summary>
+    SelectionFailedProviderUnavailable,
+
+    /// <summary>Nothing was selected: this processor architecture is not supported.</summary>
+    SelectionFailedUnsupportedProcessorArchitecture,
+}
+
 public sealed record PrivacySafeDiagnosticRecord(
     DateTimeOffset Timestamp,
     AppEventCode Event,
@@ -51,7 +90,8 @@ public sealed record PrivacySafeDiagnosticRecord(
     DiagnosticHardwareClass? HardwareClass = null,
     DeterministicTextStage? Stage = null,
     DeterministicStageStatus? StageStatus = null,
-    bool? Changed = null)
+    bool? Changed = null,
+    DiagnosticRuntimeSelectionReason? RuntimeSelection = null)
 {
     public const long MaximumElapsedMilliseconds = 86_400_000;
 
@@ -76,6 +116,9 @@ public sealed record PrivacySafeDiagnosticRecord(
             // somebody said.
             entry.Stage is { } stage && Enum.IsDefined(stage) ? stage : null,
             entry.StageStatus is { } stageStatus && Enum.IsDefined(stageStatus) ? stageStatus : null,
-            entry.Changed);
+            entry.Changed,
+            entry.RuntimeSelection is { } runtimeSelection && Enum.IsDefined(runtimeSelection)
+                ? runtimeSelection
+                : null);
     }
 }

--- a/src/Production/EnviousWispr.Core/Presentation/DictationStatus.cs
+++ b/src/Production/EnviousWispr.Core/Presentation/DictationStatus.cs
@@ -124,11 +124,38 @@ public sealed record PillAction(string Label, PillActionKind Kind, string? Acces
 /// <param name="Text">The sentence shown to the user.</param>
 /// <param name="State">The pill that carries it.</param>
 /// <param name="Action">The one thing the user can do about it, or null.</param>
+/// <param name="DescribesTranscriptionEngine">
+/// Whether this sentence is about the speech engine's own readiness, and therefore belongs on the
+/// Transcription card and the onboarding line as well as the status line.
+/// </param>
 public readonly record struct DictationStatus(
     string Text,
     DictationOverlayState State,
-    PillAction? Action = null)
+    PillAction? Action = null,
+    bool DescribesTranscriptionEngine = false)
 {
+    /// <summary>Marks a status as one the Transcription card should show.</summary>
+    /// <remarks>
+    /// THE SECOND HALF OF THE SAME LESSON AS THE STATE ABOVE, AND IT WAS STILL BEING READ OUT OF THE
+    /// WORDS. The window decided whether to update the Transcription card by testing the sentence
+    /// for "ready", "model is not installed", "transcription is unavailable" and "worker could not
+    /// start" - so the card was reached by whatever happened to contain those words rather than by
+    /// what the sentence was about.
+    ///
+    /// FOUR UNRELATED MESSAGES REACHED IT, counted rather than assumed: "Windows resumed.
+    /// EnviousWispr is ready" after a lid opens, "Escape Recovery finished. Text is ready to copy"
+    /// after a dictation, and both cleanup-provider health lines - "Ollama is ready" and "Cleaned
+    /// locally; the selected Ollama model is not installed". Each one overwrote the card that is
+    /// supposed to say which speech engine is loaded, with a sentence about something else.
+    ///
+    /// AND IT FAILS IN BOTH DIRECTIONS. A new engine sentence that happens not to contain one of the
+    /// four phrases never reaches the card at all, silently, which is how a copy edit removes a
+    /// surface. Saying it here at the call site is the only version of this that a reword cannot
+    /// break.
+    /// </remarks>
+    public DictationStatus AboutTheTranscriptionEngine() =>
+        this with { DescribesTranscriptionEngine = true };
+
     /// <summary>Shown on the settings status line only. No pill.</summary>
     public static DictationStatus Quiet(string text) => new(text, DictationOverlayState.Hidden);
 

--- a/src/Production/EnviousWispr.Services/Diagnostics/JsonLineFileLogger.cs
+++ b/src/Production/EnviousWispr.Services/Diagnostics/JsonLineFileLogger.cs
@@ -141,6 +141,7 @@ public sealed class JsonLineFileLogger : IAppLogger
                 // remembered.
                 (record.Stage is null || Enum.IsDefined(record.Stage.Value)) &&
                 (record.StageStatus is null || Enum.IsDefined(record.StageStatus.Value)) &&
+                (record.RuntimeSelection is null || Enum.IsDefined(record.RuntimeSelection.Value)) &&
                 record.ElapsedMilliseconds is null or
                     (>= 0 and <= PrivacySafeDiagnosticRecord.MaximumElapsedMilliseconds);
         }


### PR DESCRIPTION
## What a person gets

Dictation can run on the graphics card or on the processor, and the processor is
about a hundred times slower on this engine. Nothing said which one you were on.

Now the app records it, and where the slow path was not what you asked for it
tells you, with the consequence rather than the mechanism and a button to the
page where you would fix it:

> Your graphics card did not start, so dictation is slower

## What changed

1. **The log carries the reason.** `RuntimeSelectionObserved` already named the
   engine and the hardware; it now also names which path the run is on and what
   put it there. The selectors always computed this and it was discarded at the
   log boundary.
2. **The case that hid has its own member.** `ProcessorSelectedAfterGpuFailedToStart`
   is written by the app at the fallback, because the selection *succeeded* and the
   runtime then refused to start — one layer below anything a selector can see.
3. **The Transcription card stopped guessing from the words.** See below; this was
   not in the issue and had to be fixed to reach the user at all.
4. **The provisioning script refuses to half-provision a machine with a card.**
   `-SkipCuda` states the intent and gets past it. The check runs before any file
   is copied, so a refusal leaves the machine untouched.

## The finding that was not in the issue

`SetSessionStatus` decided whether to update the Transcription card by searching
the status sentence for `"ready"`, `"model is not installed"`,
`"transcription is unavailable"` and `"worker could not start"` — the same shape
as `OverlayStateFor`, deleted in #65 for the recording pill one surface over.

**Four unrelated messages reach that card today**, counted rather than assumed:

| Sentence | Where it comes from |
| --- | --- |
| `Windows resumed. EnviousWispr is ready` | a lid opening |
| `Escape Recovery finished. Text is ready to copy` | a finished dictation |
| `Ollama is ready` | cleanup-provider health |
| `Cleaned locally; the selected Ollama model is not installed` | cleanup-provider health |

Each overwrote the line that says which speech engine is loaded.

**And it fails silently in the other direction**, which is what forced the fix:
the new sentence contains none of the four phrases, so the card would have kept
showing stale text while the pill said the graphics card had failed. A status now
carries `DescribesTranscriptionEngine` from its call site.

## Observed, not asserted

Driven on the development machine in the logged-on desktop session, with the
Whisper CUDA library moved aside to force a genuine start failure, then restored
and re-hashed identical.

```
RuntimeSelectionObserved      engine=Whisper hardwareClass=NvidiaCuda runtimeSelection=GpuSelected
DictationTranscriptionDegraded failure=RuntimeProvider errorCode=RuntimeProviderUnavailable
                               runtimeSelection=ProcessorSelectedAfterGpuFailedToStart
```

Read out of the app's accessibility tree at the same moment:

```
Text "Transcription engine"
Text "Your graphics card did not start, so dictation is slower"
```

The healthy path was observed first, unmodified: `runtimeSelection=GpuSelected`
and the card reading `Local transcription ready`.

Both directions of the provisioning guard were run on this machine, which has an
NVIDIA card: it refuses by default, `-SkipCuda` passes it, and nothing was
created either time.

## Gates

- Portable gate green, 1111 passed / 4 skipped / 1115.
- The mapping guard was proved by deleting one arm; it went red on exactly the
  three cases for that member, and was restored.
- Three existing privacy gates caught real gaps and are closed in this branch:
  the new field had to be validated on read-back, disclosed in the data
  dictionary, and copied onto the local line.

## One correction to an existing gate

`EveryStatusHandedToTheWindowNamesItsPill` tested for the exact substring
`DictationStatus.`, so a call site that wraps the line between the type and its
factory — which the line length forces once a status is also marked for the card —
was reported as deciding its appearance somewhere unseen. It was not; it named
the type on the line above. The gate was pinning the line break rather than the
property it holds. It now matches the type naming a factory across whitespace,
and a new test asserts both directions so the relaxation cannot have opened it.

## Machine note, not a code result

One portable-gate run aborted with the test host crashing (`0xc0000005`,
faulting module unknown) alongside a `VBCSCompiler` crash on CoreCLR
10.0.1126.37416 — the fault family already tracked on this machine. The identical
assembly ran complete and green before and after. Worth naming rather than
recording as runner noise: `dotnet test` printed `Passed!` on the truncated run
and only the exit code disagreed, which is the shape #79 describes. The gate read
the exit code and failed correctly.

Part of #102
