### PR TITLE
live preview keeps up with the speaker instead of showing one stale fragment

### DIFF
--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -2969,16 +2969,25 @@ public partial class App : Application, IAsyncDisposable
         IAudioSnapshotSource audioCapture,
         CancellationToken cancellationToken)
     {
-        var cadence = TimeSpan.FromMilliseconds(2_500);
         var maximumWindow = TimeSpan.FromSeconds(20);
         try
         {
             while (true)
             {
-                await Task.Delay(cadence, cancellationToken).ConfigureAwait(false);
+                // THE WAIT MOVED TO THE FAR SIDE OF THE WORK, WHICH IS THE WHOLE FIX. It used to sit
+                // here, so the period was the interval PLUS the cost of a pass rather than the larger
+                // of the two, and nothing could reach the screen before both had elapsed however fast
+                // the engine became. On the measured 7.9-second take that bought exactly one update
+                // and the second was not slow but impossible. Ref: #99 and `LivePreviewCadence`.
                 var snapshot = audioCapture.GetSnapshot(maximumWindow);
                 if (snapshot is null || snapshot.Samples.Length < 8_000)
                 {
+                    // NOT THE CADENCE, BECAUSE THIS IS NOT AN UPDATE. There is not yet enough audio to
+                    // transcribe, and waiting the full interval to re-ask is what made a person watch
+                    // "Listening..." for four seconds. Half the threshold this guard enforces, so the
+                    // first pass cannot start more than a quarter second late.
+                    await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken)
+                        .ConfigureAwait(false);
                     continue;
                 }
 
@@ -3004,6 +3013,12 @@ public partial class App : Application, IAsyncDisposable
                     ElapsedMilliseconds: timer.ElapsedMilliseconds));
                 _window?.DispatcherQueue.TryEnqueue(() =>
                     _window?.SetLivePreview(update.Text));
+
+                // A FLOOR, NOT AN ADDITION. A pass slower than the interval waits nothing and the next
+                // one starts immediately; a fast one still cannot flood the screen. The engine is a
+                // limb and must not spend the machine the final transcript is waiting on.
+                await Task.Delay(LivePreviewCadence.DelayAfter(timer.Elapsed), cancellationToken)
+                    .ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Production/EnviousWispr.Architecture.Tests/LivePreviewCadenceTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/LivePreviewCadenceTests.cs
@@ -1,0 +1,92 @@
+using EnviousWispr.Core.Presentation;
+
+namespace EnviousWispr.Architecture.Tests;
+
+/// <summary>Live Preview keeps up, and the arithmetic that stopped it is asserted directly.</summary>
+public sealed class LivePreviewCadenceTests
+{
+    [Fact]
+    public void TheIntervalIsTheFloorRatherThanAnAddition()
+    {
+        Assert.Equal(TimeSpan.FromMilliseconds(1_500), LivePreviewCadence.DelayAfter(TimeSpan.FromMilliseconds(1_000)));
+        Assert.Equal(TimeSpan.FromMilliseconds(2_500), LivePreviewCadence.DelayAfter(TimeSpan.Zero));
+    }
+
+    /// <summary>A pass slower than the interval waits no time at all, and never a negative span.</summary>
+    /// <remarks>
+    /// THE NORMAL CASE ON A PROCESSOR, NOT AN EDGE ONE. The measured pass cost 2374 ms against a
+    /// 2500 ms interval on the machine this shipped from; anything slower exceeds it outright. A
+    /// negative span thrown into the delay would stop the preview loop rather than slow it.
+    /// </remarks>
+    [Theory]
+    [InlineData(2_500)]
+    [InlineData(2_501)]
+    [InlineData(11_000)]
+    public void APassSlowerThanTheIntervalWaitsNothingAndNeverGoesNegative(int passMilliseconds)
+    {
+        var delay = LivePreviewCadence.DelayAfter(TimeSpan.FromMilliseconds(passMilliseconds));
+
+        Assert.Equal(TimeSpan.Zero, delay);
+        Assert.True(delay >= TimeSpan.Zero);
+    }
+
+    /// <summary>The measured take, walked under both schemes, and the longer takes behind it.</summary>
+    /// <remarks>
+    /// THE DEFECT, REPLAYED RATHER THAN DESCRIBED. Numbers from the recording on #99: preview started
+    /// 545 ms after the recording did, one pass cost 2374 ms, and the capture finished at 7873 ms.
+    /// Under the old scheme - wait the whole interval, then work - the first update landed at 5421 ms
+    /// and the second was due at 10295 ms, after the recording had already ended.
+    ///
+    /// WRITING THE SIMULATION IS WHAT PRODUCED THE NUMBER. The first version of this test asserted
+    /// three updates on the 7.9-second take because that was the improvement it felt like; walking it
+    /// gives two. The gain is real and it grows with the take - a fifteen-second one goes from two
+    /// updates to five - but the eight-second case doubles rather than triples, and a claim about a
+    /// feature that keeps up is worth having right.
+    /// </remarks>
+    [Theory]
+    [InlineData(7_873, 1, 2)]
+    [InlineData(10_000, 1, 3)]
+    [InlineData(15_000, 2, 5)]
+    public void TheSameTakeProducesMoreUpdatesWhenTheIntervalIsAFloor(
+        int captureMilliseconds,
+        int before,
+        int after)
+    {
+        var startup = TimeSpan.FromMilliseconds(545);
+        var pass = TimeSpan.FromMilliseconds(2_374);
+        var captureEnded = TimeSpan.FromMilliseconds(captureMilliseconds);
+
+        Assert.Equal(before, UpdatesBefore(captureEnded, startup, pass, waitBeforeWorking: true));
+        Assert.Equal(after, UpdatesBefore(captureEnded, startup, pass, waitBeforeWorking: false));
+    }
+
+    /// <summary>Walks one take and counts the updates that reach the screen before it ends.</summary>
+    private static int UpdatesBefore(
+        TimeSpan captureEnded,
+        TimeSpan startup,
+        TimeSpan pass,
+        bool waitBeforeWorking)
+    {
+        var now = startup;
+        var updates = 0;
+        while (true)
+        {
+            if (waitBeforeWorking)
+            {
+                now += LivePreviewCadence.Interval;
+            }
+
+            now += pass;
+            if (now > captureEnded)
+            {
+                return updates;
+            }
+
+            updates++;
+            if (!waitBeforeWorking)
+            {
+                now += LivePreviewCadence.DelayAfter(pass);
+            }
+        }
+    }
+}

--- a/src/Production/EnviousWispr.Core/Presentation/LivePreviewCadence.cs
+++ b/src/Production/EnviousWispr.Core/Presentation/LivePreviewCadence.cs
@@ -1,0 +1,41 @@
+namespace EnviousWispr.Core.Presentation;
+
+/// <summary>How often Live Preview may put words on screen, and when the next pass is due.</summary>
+/// <remarks>
+/// THE CADENCE WAS AN ADDITION AND IT NEEDED TO BE A FLOOR. The loop waited the full interval and
+/// only then started work, so the real period was the interval PLUS the cost of a pass rather than
+/// the larger of the two. Measured on a 7.9-second dictation: the interval is 2500 ms, a pass cost
+/// 2374 ms, and the first update reached the screen at 5421 ms against a prediction of 5419 - two
+/// milliseconds apart, so the loop was behaving exactly as written and there was nothing
+/// intermittent to chase. The second update was due at 10295 ms. The recording ended at 7873 ms.
+/// It was not slow; it was impossible.
+///
+/// THE ARITHMETIC IS THE WHOLE DEFECT. Updates a take can produce is (duration - startup) / (interval
+/// + cost), so eight seconds bought one, ten seconds bought one, and fifteen bought two - for a
+/// feature whose entire promise is keeping up with a speaker.
+///
+/// WAITING AFTER THE WORK RATHER THAN BEFORE IT ALSO ANSWERS THE FIRST UPDATE. Nothing could reach
+/// the screen before interval plus cost however fast the engine became, so a person watched
+/// "Listening..." for four seconds and read it as broken. A pass that starts as soon as there is
+/// enough audio to transcribe puts the first words up in about the cost alone.
+///
+/// A FLOOR RATHER THAN NO LIMIT AT ALL, because the pass is not free and this is a limb. Live
+/// preview is display-only and can never change the final transcript; it must not be allowed to
+/// spend the machine that the final transcript is waiting on.
+/// </remarks>
+public static class LivePreviewCadence
+{
+    /// <summary>The shortest gap between two updates reaching the screen.</summary>
+    public static readonly TimeSpan Interval = TimeSpan.FromMilliseconds(2_500);
+
+    /// <summary>How long to wait after a pass that took <paramref name="passCost"/>.</summary>
+    /// <remarks>
+    /// NEVER NEGATIVE, AND THAT IS NOT DEFENSIVENESS. A pass slower than the interval is the normal
+    /// case on a processor rather than a graphics card - 2374 ms against 2500 ms was measured on the
+    /// machine this shipped from, and a slower machine exceeds it outright. Subtracting without a
+    /// floor would hand `Task.Delay` a negative span and throw inside the loop, turning a slow engine
+    /// into a preview that stops entirely.
+    /// </remarks>
+    public static TimeSpan DelayAfter(TimeSpan passCost) =>
+        passCost >= Interval ? TimeSpan.Zero : Interval - passCost;
+}

--- a/tools/app-journey-uat/Program.cs
+++ b/tools/app-journey-uat/Program.cs
@@ -717,6 +717,14 @@ try
         livePreviewUpdated = livePreview && diagnosticEvents.Any(value => value.StartsWith(
             "LivePreviewUpdated/",
             StringComparison.Ordinal)),
+        // A BOOLEAN CANNOT ANSWER THE QUESTION THIS FEATURE IS JUDGED ON. "Did any update arrive" was
+        // true throughout the period when Live Preview put ONE stale fragment on screen and then
+        // froze for the rest of the sentence: the arithmetic allowed exactly one update per take and
+        // the harness reported success. The count is the measurement; the flag above only says the
+        // path is wired. Ref: #99.
+        livePreviewUpdateCount = diagnosticEvents.Count(value => value.StartsWith(
+            "LivePreviewUpdated/",
+            StringComparison.Ordinal)),
         appExitedCleanly,
         ownedWorkerStartedCount = ownedWorkerIds.Length,
         ownedWorkerCount,


### PR DESCRIPTION
## What a person gets

Live Preview showed one line of text a few seconds into a dictation and then sat there, unchanged,
while they kept talking. It now keeps updating, and the first words arrive sooner.

## It was arithmetic, not flakiness

The loop waited the full interval and only then started work, so the period between updates was
`interval + cost` rather than `max(interval, cost)`.

From the recording on #99: interval 2500 ms, a pass cost 2374 ms, first update predicted at 5419 ms
and observed at **5421 ms**. Two milliseconds apart — the loop was doing exactly what it said. The
second update was due at 10295 ms; the recording ended at 7873 ms. It was not late, it was impossible.

## The change

- **The wait moved to the far side of the work, and is the remainder rather than the whole interval.**
  A pass slower than the interval waits nothing and the next starts at once; a fast one still cannot
  flood the screen, because preview is a limb and must not spend the machine the final transcript is
  waiting on.
- **The first pass starts as soon as there is enough audio**, using the threshold already in the code
  rather than a new one. Four seconds of `Listening...` is what made this read as broken.
- **The arithmetic lives in `LivePreviewCadence`** so it can be tested, since the loop itself sits in
  the app where no test here can reach it.

## Measured on the machine

Synthetic journey harness, `--live-preview`, three runs each way, same machine, only the loop differing:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| before | 1 | 1 | 1 |
| after | **2** | **2** | **2** |

That is a 5-second synthetic hold, so it is the short end. Walking the same numbers over longer takes,
a 15-second dictation goes from 2 updates to 5.

## The harness could not have caught this

It reported `livePreviewUpdated: true` — a boolean, which stayed true for the entire period when the
feature put one frozen fragment on screen and stopped. It now also reports `livePreviewUpdateCount`,
because the count is the thing this feature is judged on. A test asserting the flag would have passed
against the defect.

## A number I got wrong and the test caught

The first version of the simulation test asserted three updates on the 7.9-second take, because that
is what the improvement felt like. Walking it gives two. The test is written as a walk over both
schemes rather than as an assertion of a remembered figure, which is why the wrong number failed
instead of shipping.

## Deliberately not in this change

The preview still re-transcribes its whole window every pass, so cost grows with how long somebody has
been speaking (#99's second fault). That is a change to **what the decoder is given** rather than when
it runs, and #111 has just finished measuring what happens when that kind of change is made from
reasoning alone. It wants its own before-and-after.

Fault 3 — whether the preview engine is on the right provider — is unchanged and still worth measuring.

## Gates

Portable gate green: 1118 passed / 4 skipped / 1122.

One earlier run of the same gate aborted with the test host crashing while still printing `Passed!` on
a truncated count; that is filed as #112 and is not this change — a documentation-only branch hit it
too, and both branches ran complete and green on retry.

Part of #99
