### PR TITLE
the night's reasoning is written down, and one blocker turns out not to be one

### DIFF
--- a/.claude/knowledge/mac-parity-audit.md
+++ b/.claude/knowledge/mac-parity-audit.md
@@ -302,6 +302,36 @@ Re-swept against the tree rather than read off the tables above, because four of
 three need a product decision. A session that can only reach the machine over SSH cannot close them by
 writing more code, and writing more code around them is how the unverified pile grows.
 
+## FACT: the-machine-IS-reachable-interactively-2026-09-03
+**The premise under "Blocked on a person at the machine" is no longer true, and five rows rest on it.**
+That table and its closing paragraph say a session here can only reach the machine over SSH, lands in
+Windows session 0, and therefore cannot drive a WinUI app or see a pixel. A session on 2026-09-03 ran in
+**session 1, the logged-on interactive desktop**, alongside the user's own shell.
+
+Demonstrated rather than asserted, three ways in one night:
+
+- Launched the app from `scripts/one-build.ps1 -Launch` and it drew.
+- Read its own accessibility tree with `tools/ui-capture/probe-ui.ps1` and asserted on the text of a
+  settings card - which is how the #102 sentence was confirmed on screen rather than described.
+- Drove `tools/app-journey-uat --live-preview` end to end six times, each launching the real app,
+  recording from a fixture and delivering into a target window.
+
+**So `tools/ui-capture/start-capture.ps1` and its scheduled-task hop are not required from a session
+like this one.** That script exists because an SSH session IS session 0; check which session you are in
+(`(Get-Process -Id $PID).SessionId`) before assuming you need it. Both routes still work.
+
+**What this unblocks.** Every row in that table whose blocker is "somebody has to be at the machine" is
+reachable by a session that can check it is in session 1: the 2026-08-29 UI work, `Ctrl+Win` on a real
+keyboard, and the parts of the fourth delivery tier that do not need Word and Excel open. It does NOT
+unblock the rows needing hardware nobody has - a Bluetooth headset - or a product decision.
+
+**One thing it deliberately does not unblock: playing audio out loud.** The machine is in the founder's
+home. A synthetic sender through `ENVIOUSWISPR_UAT_AUDIO_FIXTURE` covers the whole dictation journey
+without a sound, and that is the right instrument for almost everything. Recording new microphone
+fixtures is the exception and wants the room free rather than the small hours.
+
+Ref: 2026-09-03, verified while closing #102 and #99.
+
 ## FACT: a-claimed-uncertainty-is-worth-closing-before-it-becomes-a-rebuild
 The streaming seam was recorded as "unaudited" on the morning of 2026-08-29 and closed the same day by
 reading two files. It cost five minutes and it removes a row that, left standing, is exactly the shape

--- a/LOG.md
+++ b/LOG.md
@@ -21,6 +21,112 @@ No machine paths, no personal data, no credentials. This file is public.
 
 ---
 
+## 2026-09-03 (overnight)
+
+### The most convincing parity gap this project has produced, and it was wrong
+
+Whisper sometimes returns sentences nobody said. macOS solves it by decoding only
+the parts of a recording where somebody was speaking, and its source carries the
+benchmark that settled the design: trailing phantom-phrase hallucination on 3 of
+107 clips against 14 of 107 for the approach it replaced. Windows did none of it
+and handed the decoder the whole buffer. On real dictations from this project's
+own machine, that buffer is about 8.6 seconds holding about 3.5 seconds of speech,
+so roughly 55% of what the decoder was asked to transcribe was never speech.
+
+Every step of that is true, and the port makes the output worse.
+
+Eleven archived dictations, the same sentence each, decoded five ways. The decoder
+was proved deterministic first — an identical re-run returned all eleven
+transcripts byte for byte — so the differences below are the change rather than
+noise.
+
+| What was decoded | Changed | Direction |
+|---|---|---|
+| Trimmed to the detected speech span | 6 of 11 | 2 better, 3 worse, 1 both |
+| Same span via a seek rather than a cut | 5 of 11 | 2 better, 3 worse |
+| Whole capture plus a half-second tail pad | 0 of 11 | no effect |
+| Capture cut at the last word, no pad | 2 of 11 | 2 better, 0 worse |
+| Capture cut at the last word, with pad | 2 of 11 | identical to above |
+
+Gating cost capitalisation and words: `Testing` became `testing` on two takes, and
+one turned the product's own name into `EnVyUs whisper`. Nothing downstream puts a
+lowered first word back — swept the deterministic pipeline and the delivery path,
+there is no sentence-case restoration anywhere — so it reaches the document lowered.
+
+Seeking is not a way out. It was tried precisely because it is closer to what the
+other platform does than cutting an array is; it agreed with the cut on 8 of the
+11 and carried the same regressions. The mechanism is not the variable.
+
+**The tail pad's own reason does not reproduce here either.** The other platform
+says abruptly-ending audio loses its last one to three words. Every archived take
+was recorded with two deliberate seconds of trailing silence, so the pad had
+nothing to do on them — which is why each recording was CUT at its last word to
+build the condition being described. Cut that way, nothing was lost, and the pad
+changed nothing.
+
+**What was measured is the cost and only the cost.** The recordings that actually
+fabricated had rolled off the twenty-file archive bound and no longer existed, so
+the benefit side is unmeasured. That is exactly why it must not ship: a change that
+demonstrably harms the ordinary path cannot be adopted on an unmeasured benefit.
+
+The lesson outlives the feature. This file already records that parity work fails
+toward building something that was already present. This is the same bias from a
+new direction — toward building something genuinely absent that still should not be
+built. **A capability being present on the other platform, absent here, and backed
+by a benchmark there is not evidence it helps here.** The runtimes differ, and only
+running it here settles it.
+
+### A surface was being filled by searching for words in a sentence
+
+The panel that reports which speech engine is loaded was updated by testing the
+status text for `ready`, `model is not installed`, `transcription is unavailable`
+and `worker could not start` — the same shape as the pill-appearance mapping that
+was deleted for one surface over.
+
+Four unrelated messages reached it, counted rather than assumed: a Windows resume,
+a finished Escape Recovery, and both cleanup-provider health lines. Each overwrote
+the engine line with a sentence about something else.
+
+It fails silently the other way too, and that direction is what forced the fix
+rather than a follow-up. A new sentence about a failed graphics card contains none
+of the four phrases, so the panel would have kept stale text while the notice said
+the card had failed. A status now carries the answer from its call site.
+
+Found by trying to add a sentence, not by looking for a defect. The general shape:
+**when a mechanism selects on text, adding text is what exposes it**, and the
+adding is more likely than the auditing.
+
+### Live preview was not slow, it was impossible
+
+The loop waited a full interval and only then started work, so the period was the
+interval plus the cost of a pass rather than the larger of the two. On the measured
+take the first update was predicted at 5419 ms and observed at 5421 ms — two
+milliseconds apart, so nothing was intermittent — and the second was due after the
+recording had already ended.
+
+Measured on the machine, three runs each way: one update per take before, two
+after, on a five-second hold. The harness could not have caught it: it reported
+live preview as a yes-or-no, which stayed true for the whole period when the
+feature showed one frozen fragment and stopped. **Existence is not function, and a
+boolean is the shape that hides the difference.** It now reports the count.
+
+A number was wrong on the way: the first simulation test asserted three updates
+because that is what the fix felt like. Walking it gives two. Writing the test as a
+walk over both schemes rather than an assertion of a remembered figure is what made
+the wrong number fail instead of ship.
+
+### The gate printed a success word on a truncated run
+
+Three times in one session the test host crashed during teardown and `dotnet test`
+printed `Passed!` beside a count roughly fifty tests short of a complete run. Only
+the exit code disagreed, and the gate reads the exit code, so it failed correctly.
+
+Recorded rather than dismissed as runner noise because two of the three aborts
+stopped at the identical count, and because a summary that says `Passed!` while
+fifty tests did not run is one careless parse away from a false green. Filed with
+the proposed fix: fail on the abort text as well as the exit code, and assert the
+suite size.
+
 ## 2026-08-30 (evening)
 
 ### The app knew, and did not say


### PR DESCRIPTION
## Two knowledge changes, no product code

### 1. `LOG.md` gains the session

Four things worth outliving the changes that produced them:

- **A parity port that was built, measured and rejected.** Decoding only the voiced part of a
  recording is what macOS does, macOS carries a benchmark for it, and on eleven real dictations it
  makes the output worse. The lesson generalises: a capability present on the other platform, absent
  here, and backed by numbers *there* is not evidence it helps *here*.
- **A surface being filled by searching a sentence for words**, found by trying to add a sentence
  rather than by auditing. When a mechanism selects on text, adding text is what exposes it — and the
  adding is far likelier than the auditing.
- **Live preview was not slow, it was impossible**, and the harness could not have caught it because
  it reported a boolean where the feature is judged on a count.
- **The gate printed `Passed!` beside a count fifty tests short**, three times in one session. Filed
  as #112.

### 2. The parity standing is corrected on a premise that was deciding what nobody attempted

`FACT: what-actually-stands-between-here-and-parity-2026-08-29` says a session here can only reach the
machine over SSH, lands in Windows session 0, and therefore cannot drive a WinUI app or see a pixel.
**Five capabilities are parked behind that sentence**, including the whole 2026-08-29 UI and `Ctrl+Win`
on a real keyboard.

It is not true of every session. This one ran in **session 1, the logged-on interactive desktop**, and
demonstrated it three ways in one night rather than asserting it:

- launched the app with `one-build.ps1 -Launch` and it drew;
- read its accessibility tree with `probe-ui.ps1` and asserted on a settings card's text, which is how
  the #102 sentence was confirmed on screen rather than described;
- drove `app-journey-uat --live-preview` end to end six times, each launching the real app, recording
  from a fixture and delivering into a target window.

So `start-capture.ps1` and its scheduled-task hop are not required from a session like this one — that
script exists because an SSH session *is* session 0. Check `(Get-Process -Id $PID).SessionId` before
assuming you need it.

**What it does not unblock:** rows waiting on hardware nobody owns (a Bluetooth headset) or on a
product decision. And deliberately not playing audio out loud — the machine is in somebody's home, and
a synthetic sender covers the whole journey silently. Recording new microphone fixtures is the
exception and wants the room free.

## Gates

Portable gate green: 1118 passed / 4 skipped / 1122.

Part of #101
