### PR TITLE
the head start does work for the first time, and the wait after you speak halves

### DIFF
--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -236,6 +236,13 @@ try {
         Invoke-DotNet -Executable $dotnet10Exe -Arguments @("run", "--project", "tools/app-journey-uat/EnviousWispr.AppJourney.Uat.csproj", "-c", "Release", "--no-build")
         Write-Host "Running the production WinUI English Parakeet journey..."
         Invoke-DotNet -Executable $dotnet10Exe -Arguments @("run", "--project", "tools/app-journey-uat/EnviousWispr.AppJourney.Uat.csproj", "-c", "Release", "--no-build", "--", "--english-parakeet")
+        # ARMS THE HEAD-START CHECK, WHICH IS THE POINT OF ADDING IT. The streaming head start polls
+        # every 500 ms and every other journey holds a recording for a fraction of that, so nothing
+        # here had ever reached the first poll: the feature was abandoned 511 ms into every recording
+        # from the day it shipped and the gate stayed green throughout. A guard nobody runs is not a
+        # guard, so this costs the four seconds it takes to hold a recording long enough to matter.
+        Write-Host "Running the streaming head-start journey..."
+        Invoke-DotNet -Executable $dotnet10Exe -Arguments @("run", "--project", "tools/app-journey-uat/EnviousWispr.AppJourney.Uat.csproj", "-c", "Release", "--no-build", "--", "--english-parakeet", "--head-start")
     }
     else {
         Write-Host "Running portable contract tests..."

--- a/src/Production/EnviousWispr.App/PublicFixtureAudioCapture.cs
+++ b/src/Production/EnviousWispr.App/PublicFixtureAudioCapture.cs
@@ -123,9 +123,14 @@ internal sealed class PublicFixtureAudioCapture : IAudioCapture, IAudioSnapshotS
             return null;
         }
 
-        var maximumSamples = Math.Max(
-            1,
-            checked((int)Math.Ceiling(maximumDuration.TotalSeconds * RequiredSampleRate)));
+        // THE TWIN OF THE CLAMP IN `WasapiAudioCapture`, and it has to move with it. Both answer the
+        // same contract for the same callers, so a duration that is safe against a live microphone
+        // and fatal against a fixture would make the harness disagree with the app about whether a
+        // dictation works. Same reason, written once there. Ref: #96.
+        var requestedSamples = Math.Ceiling(maximumDuration.TotalSeconds * RequiredSampleRate);
+        var maximumSamples = requestedSamples >= int.MaxValue
+            ? int.MaxValue
+            : Math.Max(1, (int)requestedSamples);
         var offset = Math.Max(0, _samples.Length - maximumSamples);
         return new AudioSnapshot(
             request.SessionId,

--- a/src/Production/EnviousWispr.Architecture.Tests/WasapiAudioCaptureTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/WasapiAudioCaptureTests.cs
@@ -85,6 +85,58 @@ public sealed class WasapiAudioCaptureTests
         Assert.Null(capture.GetSnapshot(TimeSpan.FromSeconds(1)));
     }
 
+    /// <summary>Asking for the whole recording returns it instead of throwing.</summary>
+    /// <remarks>
+    /// THE STREAMING HEAD START ASKS FOR EXACTLY THIS AND HAS NEVER ONCE SURVIVED IT. Its loop wants
+    /// the whole recording rather than a window - a commit is a range measured from the start, so a
+    /// rolling window would make those indices mean something different on every poll - and it says
+    /// so by passing `TimeSpan.MaxValue`. That is about 9.2e11 seconds; multiplied by the sample rate
+    /// it is about 1.5e16, and the `checked` cast to `int` threw `OverflowException` on the FIRST
+    /// poll of every recording ever made.
+    ///
+    /// THE EXCEPTION WAS INVISIBLE BECAUSE THE FEATURE IS DESIGNED TO GIVE UP QUIETLY. Any failure
+    /// abandons the head start and the release transcribes the whole take, which is correct and is
+    /// why nothing on screen was ever wrong. Measured 2026-09-03: `StreamingAbandoned` 511 ms after
+    /// the recording started, matching the poll interval, with no error code because an
+    /// `OverflowException` is not a transcription failure. Ref: #96.
+    ///
+    /// A CEILING THAT CANNOT BE REACHED IS NOT A LIMIT. `maximumDuration` only ever trims, so
+    /// saturating it changes nothing for any duration a caller could mean and removes the one value
+    /// that turned "give me everything" into a crash.
+    /// </remarks>
+    [Fact]
+    public async Task AskingForTheWholeRecordingReturnsItRatherThanOverflowing()
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+        var sessionId = DictationSessionId.Create();
+
+        await capture.StartAsync(new AudioCaptureRequest(sessionId));
+        recorder.Emit(0.1f, 0.2f, 0.3f, 0.4f);
+        var snapshot = capture.GetSnapshot(TimeSpan.MaxValue);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal(sessionId, snapshot.SessionId);
+        Assert.Equal(CompletePreviewFixture, snapshot.Samples.ToArray());
+    }
+
+    /// <summary>Every duration a caller could mean is accepted, including the extremes.</summary>
+    [Theory]
+    [InlineData(long.MaxValue)]
+    [InlineData(long.MaxValue / 2)]
+    [InlineData(TimeSpan.TicksPerDay * 365)]
+    [InlineData(TimeSpan.TicksPerSecond * 20)]
+    public async Task NoReachableDurationThrows(long ticks)
+    {
+        var recorder = new FakeRecorderSession();
+        await using var capture = CreateCapture(recorder);
+
+        await capture.StartAsync(new AudioCaptureRequest(DictationSessionId.Create()));
+        recorder.Emit(0.1f, 0.2f, 0.3f, 0.4f);
+
+        Assert.NotNull(capture.GetSnapshot(TimeSpan.FromTicks(ticks)));
+    }
+
     [Fact]
     public async Task UnexpectedStopPreservesTakeAsRetryableInterruption()
     {

--- a/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
+++ b/src/Production/EnviousWispr.Audio/WasapiAudioCapture.cs
@@ -66,11 +66,26 @@ public sealed class WasapiAudioCapture :
     public AudioSnapshot? GetSnapshot(TimeSpan maximumDuration)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maximumDuration, TimeSpan.Zero);
-        var maximumSamples = Math.Max(
-            1,
-            checked((int)Math.Ceiling(
-                maximumDuration.TotalSeconds * AudioSampleConverter.TargetSampleRate)));
-        var maximumBytes = checked(maximumSamples * sizeof(float));
+        // SATURATES RATHER THAN OVERFLOWS, AND A CALLER ASKING FOR EVERYTHING IS THE REASON. The
+        // streaming head start wants the whole recording rather than a window - a commit is a range
+        // measured from the start, so a rolling window would make those indices mean something
+        // different on every poll - and it says so with `TimeSpan.MaxValue`. That is about 9.2e11
+        // seconds; times the sample rate it is about 1.5e16, and the `checked` cast threw
+        // `OverflowException` on the FIRST poll of every recording ever made. Measured 2026-09-03:
+        // the head start was abandoned 511 ms in, every single time, since the day it shipped.
+        //
+        // NOT ONLY THE SENTINEL. A year-long duration overflowed too, so this was never about one
+        // magic value being mishandled.
+        //
+        // A CEILING THAT CANNOT BE REACHED IS NOT A LIMIT. This value only ever TRIMS the buffer, so
+        // clamping it changes nothing for any duration a caller could mean, and it removes the one
+        // way "give me everything" could become a crash. Ref: #96.
+        var requestedSamples = Math.Ceiling(
+            maximumDuration.TotalSeconds * AudioSampleConverter.TargetSampleRate);
+        var maximumSamples = requestedSamples >= int.MaxValue
+            ? int.MaxValue
+            : Math.Max(1, (int)requestedSamples);
+        var maximumBytes = (long)maximumSamples * sizeof(float);
         byte[] bytes;
         DictationSessionId sessionId;
         lock (_bufferGate)

--- a/src/Production/EnviousWispr.Core/Audio/AudioContracts.cs
+++ b/src/Production/EnviousWispr.Core/Audio/AudioContracts.cs
@@ -118,6 +118,19 @@ public interface ICaptureDiagnostics
 
 public interface IAudioSnapshotSource
 {
+    /// <summary>The most recent <paramref name="maximumDuration"/> of the take so far.</summary>
+    /// <param name="maximumDuration">
+    /// A ceiling, never a requirement. A duration longer than what has been captured returns
+    /// everything captured, so `TimeSpan.MaxValue` is the supported way to ask for the whole
+    /// recording rather than a rolling window.
+    /// </param>
+    /// <remarks>
+    /// THAT LAST SENTENCE IS WRITTEN DOWN BECAUSE BOTH IMPLEMENTATIONS USED TO CRASH ON IT. Each
+    /// converted the duration to a sample count with a `checked` cast, so a caller asking for
+    /// everything got an `OverflowException` instead of everything. The streaming head start asks
+    /// for exactly that, and was abandoned 511 ms into every recording ever made. A contract that
+    /// only one value can break is a contract that needs stating. Ref: #96.
+    /// </remarks>
     AudioSnapshot? GetSnapshot(TimeSpan maximumDuration);
 }
 

--- a/tools/app-journey-uat/Program.cs
+++ b/tools/app-journey-uat/Program.cs
@@ -58,6 +58,21 @@ var livePreview = args.Any(argument => string.Equals(
     argument,
     "--live-preview",
     StringComparison.OrdinalIgnoreCase));
+// HOLDS THE RECORDING LONG ENOUGH FOR THE HEAD START TO POLL, WHICH NOTHING DID BEFORE. The
+// streaming head start polls every 500 ms and the ordinary journey holds a recording for a fraction
+// of that, so no run this harness has ever made reached the first poll. The feature was broken from
+// the day it shipped - abandoned 511 ms into every recording - and every gate stayed green, because
+// the only thing that could have noticed was never given a long enough take. Ref: #96.
+var headStart = args.Any(argument => string.Equals(
+    argument,
+    "--head-start",
+    StringComparison.OrdinalIgnoreCase));
+if (headStart && livePreview)
+{
+    throw new JourneyExpectationException(
+        "--head-start and --live-preview are mutually exclusive: the head start deliberately stands "
+            + "down when Live Preview is on, so asking for both asserts a state the app refuses.");
+}
 var deterministicProfileArgument = ArgumentValue(args, "--deterministic-profile");
 var deterministicProfile = deterministicProfileArgument?.ToLowerInvariant() switch
 {
@@ -445,6 +460,14 @@ try
         {
             appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_HOLD_MILLISECONDS"] = "2000";
         }
+        else if (headStart)
+        {
+            // FOUR SECONDS BUYS SEVEN POLLS AT THE 500 ms INTERVAL, and the planner needs more than
+            // one because it refuses to commit the final segment - a segment at the end of the audio
+            // so far is indistinguishable from the first half of a word still being said. One poll
+            // would assert nothing about committing.
+            appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_HOLD_MILLISECONDS"] = "4000";
+        }
     }
     app = StartOrExplain(appStart) ?? throw new JourneyExpectationException(
         "The production WinUI app did not start.");
@@ -656,6 +679,10 @@ try
     if (livePreview)
     {
         RequireLivePreviewJourneyEvents(diagnosticEvents);
+    }
+    if (headStart)
+    {
+        RequireHeadStartJourneyEvents(diagnosticEvents);
     }
     var polishEvidence = ReadPolishJourneyEvidence(diagnosticPath, polishProvider);
     if (polishProvider != PolishProvider.None)
@@ -1324,6 +1351,39 @@ static void RequireLivePreviewJourneyEvents(IReadOnlyList<string> events)
     {
         throw new JourneyExpectationException(
             $"The live-preview journey omitted content-free stages: {string.Join(", ", missing)}.");
+    }
+}
+
+/// <summary>The head start committed work during the recording and the release used it.</summary>
+/// <remarks>
+/// ASSERTS THE OUTCOME AND THE ABSENCE, because either alone passes against the defect. Requiring
+/// only the committed segment would pass on a run that committed once and then abandoned; requiring
+/// only "not abandoned" would pass on a run that never polled at all, which is exactly what every
+/// journey before this one did.
+///
+/// ABANDONING IS CORRECT BEHAVIOUR AND IS STILL A FAILURE HERE. The head start gives up on any error
+/// rather than delivering half a dictation, and that design stays. This mode exists to assert the
+/// happy path is reachable at all - on a clean fixture, on a machine with a working engine, there is
+/// nothing to give up over.
+/// </remarks>
+static void RequireHeadStartJourneyEvents(IReadOnlyList<string> events)
+{
+    var required = new[] { "StreamingSegmentCommitted", "StreamingHeadStartUsed" };
+    var missing = required.Where(eventName => !events.Any(value => value.StartsWith(
+        eventName + '/',
+        StringComparison.Ordinal))).ToArray();
+    if (missing.Length > 0)
+    {
+        throw new JourneyExpectationException(
+            "The head-start journey omitted content-free stages: " + string.Join(", ", missing)
+                + ". The streaming head start did no work this recording could use.");
+    }
+
+    if (events.Any(value => value.StartsWith("StreamingAbandoned/", StringComparison.Ordinal)))
+    {
+        throw new JourneyExpectationException(
+            "The streaming head start was abandoned on a clean fixture run. Giving up is correct on "
+                + "a real failure, so read the abandoned record's error code: it names what failed.");
     }
 }
 


### PR DESCRIPTION
## What a person gets

Releasing the key finishes faster, because the work done while they were still talking is finally
kept. Measured on the machine, same fixture and engine, three runs each way:

| | before | after |
| --- | --- | --- |
| transcription after release | 444, 445 ms | **201, 213, 217 ms** |
| whole dictation | 542, 553 ms | **310, 320, 325 ms** |

## The head start has never worked, and the cause is one cast

The loop wants **the whole recording** rather than a rolling window — a commit is a range measured
from the start, so a window would make those indices mean something different on every poll — and it
says so by passing `TimeSpan.MaxValue`.

Both snapshot sources turned that into a sample count with a `checked` cast:

```csharp
checked((int)Math.Ceiling(maximumDuration.TotalSeconds * TargetSampleRate))
```

`TimeSpan.MaxValue.TotalSeconds` is about 9.2e11; times 16 000 it is about 1.5e16. It threw
`OverflowException` **on the first poll of every recording ever made**.

Reproduced before touching anything, on a real dictation through the app:

```
10:20:16.151  DictationRecordingStarted
10:20:16.662  StreamingAbandoned   failure=Unknown          <- 511 ms, no error code
```

511 ms matches the 500 ms poll interval and the four takes in the issue (511, 506, 510, 512). The
absent error code is the tell: the diagnostics landed since this was filed, and `Unknown` with no
code means it was never a transcription failure at all.

**Not only the sentinel** — a 365-day duration overflowed too, so this was never one magic value being
mishandled. The ceiling now saturates. It only ever *trims* the buffer, so clamping changes nothing
for any duration a caller could mean.

Fixed in **both** implementations, because they answer the same contract for the same callers, and the
contract now says in writing that a duration longer than the recording returns the recording.

## Why it was invisible for as long as the feature has existed

Giving up is correct: any failure abandons the head start and the release transcribes the whole take.
Nothing on screen was ever wrong and no words were ever lost. The feature simply never happened, and
the fallback is good enough that it went unnoticed. `StreamingSegmentCommitted` appears **zero** times
in any log this project has.

## Nothing could have caught it, so the harness gains a mode that can

The journey harness holds a recording for a fraction of the 500 ms poll interval, so **no run it has
ever made reached the first poll**. A new `--head-start` mode holds one for four seconds — seven polls,
because the planner deliberately never commits the final segment — and asserts the outcome **and** the
absence together:

- `StreamingSegmentCommitted` and `StreamingHeadStartUsed` must appear;
- `StreamingAbandoned` must not.

Either half alone passes against the defect: requiring only the commit passes on a run that committed
once then abandoned, and requiring only "not abandoned" passes on a run that never polled at all —
which is exactly what every journey before this one did.

**Proved in both directions**: green against the fix, and red against the same tree with the fix
stashed, reporting *"the streaming head start did no work this recording could use."*

It is armed in the `-IncludeLocalRuntime` gate, because a real dictation needs real models. CI cannot
run it; that is the honest limit of where this guard lives.

## Gates

Portable gate green. One run aborted with the test host crashing — #112, unrelated, and I have
corrected an inference I made on that issue in light of a fourth data point.

Part of #96
