### PR TITLE
the number normaliser's slow input is named and measured instead of guessed at

### DIFF
--- a/src/Production/EnviousWispr.Architecture.Tests/DeterministicTextPipelineTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/DeterministicTextPipelineTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using EnviousWispr.Core.Dictation;
 using EnviousWispr.Core.Settings;
 using EnviousWispr.Pipeline;
@@ -52,7 +53,30 @@ public sealed class DeterministicTextPipelineTests
         {
             var row = JsonSerializer.Deserialize<MacParityRow>(line, SerializerOptions)
                 ?? throw new InvalidOperationException($"Invalid parity row in {fileName}.");
-            var actual = InverseTextNormalizer.Normalize(row.Input, spokenPunctuation: true);
+            string actual;
+            try
+            {
+                actual = InverseTextNormalizer.Normalize(row.Input, spokenPunctuation: true);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // NAMES THE ROW INSTEAD OF DYING ANONYMOUSLY. This test failed once on CI with a
+                // timeout thrown from inside the replace, and nothing in the output said which of
+                // 3756 inputs had caused it - so the one thing needed to reproduce it was the one
+                // thing the failure did not carry. Recorded as a failure like a mismatch, and the
+                // loop continues, so a single slow row cannot hide every other difference behind it.
+                // Ref: #91.
+                if (failures.Count < 10)
+                {
+                    failures.Add(
+                        $"[{row.Category}/{row.Slice}] row {rowCount + 1} TIMED OUT on input " +
+                        $"'{row.Input}' ({row.Input.Length} chars)");
+                }
+
+                rowCount++;
+                continue;
+            }
+
             if (!string.Equals(row.Expected, actual, StringComparison.Ordinal) && failures.Count < 10)
             {
                 failures.Add(

--- a/src/Production/EnviousWispr.Architecture.Tests/InverseTextNormalizerLongInputTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/InverseTextNormalizerLongInputTests.cs
@@ -1,0 +1,40 @@
+using EnviousWispr.PostProcessing;
+
+namespace EnviousWispr.Architecture.Tests;
+
+/// <summary>Inverse text normalisation survives a long dictation.</summary>
+/// <remarks>
+/// THE BOUNDARY IS REAL, REACHABLE, AND MEASURED RATHER THAN INFERRED FROM ONE CI FLAKE. The patterns
+/// that recognise spoken numbers are repeated alternations, and they cost quadratic time to FAIL -
+/// which is the common case, because most text is not a number. Measured on the development machine
+/// against text of the form "one two three ... nine" repeated, warm, three runs each:
+///
+///     400 words    540, 553, 543 ms
+///     800 words    1581, 1533, 1617 ms
+///     1600 words   RegexMatchTimeoutException, every time
+///
+/// **AND THE EXPENSIVE INPUT IS NOT CHANGED AT ALL.** The passage comes back exactly as it went in:
+/// the whole cost is patterns scanning and failing. That is the shape of the defect and the reason
+/// the assertion below is an equality rather than a transformation.
+///
+/// Production degrades rather than loses - the deterministic stage catches the timeout and returns the
+/// previous text marked degraded - so a user dictating sixteen hundred spoken numbers keeps their
+/// words and quietly stops getting any of them formatted.
+///
+/// THIS GUARDS THE HEADROOM, NOT THE CLIFF. It runs a length comfortably inside the boundary, because
+/// pinning one near the limit would make the suite fail on a busy runner, which is precisely the
+/// flake that started #91. A regression that made the cost materially worse pushes even this length
+/// over. The cliff itself is NOT fixed, is deliberately not asserted here, and #91 stays open for it.
+/// </remarks>
+public sealed class InverseTextNormalizerLongInputTests
+{
+    [Fact]
+    public void ALongPassageOfSpokenNumbersComesBackIntactInsteadOfTimingOut()
+    {
+        var text = string.Join(' ', Enumerable.Repeat(
+            "one two three four five six seven eight nine",
+            30));
+
+        Assert.Equal(text, InverseTextNormalizer.Normalize(text));
+    }
+}


### PR DESCRIPTION
## What changes

Two test changes. **No production code**, and that is the finding rather than an omission.

## 1. The failure now names the input

The oracle test timed out once on CI and said nothing about which of 3756 rows caused it — the one
thing needed to reproduce it was the one thing the failure did not carry. It now records the row,
its category and the input, and **continues**, so one slow row cannot hide every other difference
behind it.

Proved by dropping the regex timeout to a single tick:

```
TIMED OUT on input 'five hundred fifty six…
TIMED OUT on input '556…
TIMED OUT on input 'five thousand four hundred twenty…
```

File restored byte-identical afterwards.

## 2. The boundary is measured, not inferred from a flake

The issue calls this "load-sensitive rather than deterministic". It is deterministic and reachable.
Warm, three runs each, text of the form `one two three … nine` repeated:

| words | time |
| --- | --- |
| 400 | 540, 553, 543 ms |
| 800 | 1581, 1533, 1617 ms |
| **1600** | **`RegexMatchTimeoutException`, every time** |

**And the expensive passage comes back completely unchanged.** The entire cost is patterns scanning
and failing — which is why the new regression test asserts an *equality* rather than a transformation.

It guards the **headroom, not the cliff**: pinning a length near the limit would make the suite fail on
a busy runner, which is precisely the flake that started this issue.

## 3. Atomic grouping was built, measured, and thrown away

The issue proposes three approaches — "token parsing, atomic grouping, or another non-backtracking
approach". Atomic grouping is the cheap one, so I tried it first, on every site where it is provably
safe (everywhere the following literal cannot be a number word; `between X and Y` is excluded because
`and` **is** a number word and its run must be able to give one back).

| words | before | atomic |
| --- | --- | --- |
| 400 | 540, 553, 543 ms | 446, 468, 472 ms |
| 800 | 1581, 1533, 1617 ms | 1286, 1292, 1314 ms |
| 1600 | THREW | **THREW** |

~15% faster and **the failure point does not move at all**. It was byte-for-byte correct — the pinned
macOS oracle passed 50/50 — so it was shippable. It is not worth new regex complexity in the component
that is supposed to be the reliability floor, for a gain that leaves the cliff exactly where it was.

A second round making the sibling word-only run atomic as well changed nothing measurable and was
dropped for the same reason.

**#91 stays open.** Its item 2 needs a genuine rewrite; this rules out the cheapest of its three
suggested routes and hands the next attempt a measured baseline and a named failure.

## An instrument note worth having

The first measurements were taken on a cold process and threw at 800 words where warm runs complete in
~1.5 s. The first `Normalize` call pays JIT and regex construction, which alone can cross the 250 ms
per-call guard. Any future measurement here must discard the first run.

## Gates

Portable gate green: `verified: 1128 of 1128 tests ran.`

One earlier run of the same gate was **stopped by the abort-detection merged in #117** rather than
reporting a truncated pass — its first real encounter with a host crash, working as intended.

Part of #91
