### PR TITLE
live preview asks about the engine it actually runs

### DIFF
--- a/src/Production/EnviousWispr.ASR/WhisperPreviewRuntime.cs
+++ b/src/Production/EnviousWispr.ASR/WhisperPreviewRuntime.cs
@@ -1,0 +1,41 @@
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.ASR;
+
+/// <summary>Which processor Live Preview's engine runs on.</summary>
+/// <remarks>
+/// IT USED TO ASK ABOUT THE WRONG LIBRARY. Live Preview runs whisper.cpp, and the decision required
+/// `IsOnnxRuntimeCudaDependencySetAvailable` - an onnxruntime probe. onnxruntime is what PARAKEET
+/// uses; whisper.cpp ships its own CUDA build and neither knows nor cares whether onnxruntime's
+/// dependency set is present. So a machine whose graphics card works perfectly well for whisper.cpp
+/// was put on the processor because a different library's files were missing.
+///
+/// THE CONDITION IS NOW THE ONE `WhisperRuntimeSelector` ALREADY USES for the final Whisper engine -
+/// a driver and at least one device - so the preview and the final transcription agree about what
+/// this machine can do. Two answers to one question was the defect; there is now one answer.
+///
+/// LIFTED OUT OF THE APP SO IT CAN BE TESTED AT ALL. It lived inline in a WinUI startup path that no
+/// test in this repository can reach, which is why a probe for the wrong runtime sat there
+/// unnoticed. Ref: #99.
+///
+/// THIS IS NOT A SPEED CLAIM ON THE DEVELOPMENT MACHINE. Both probes are true there, so the fix
+/// changes nothing locally and could not be measured by running it. What it changes is the machine
+/// where they disagree, and the tests below are that machine.
+/// </remarks>
+public static class WhisperPreviewRuntime
+{
+    /// <param name="forceCpu">
+    /// Set when the final engine has already fallen back to the processor. The preview must not then
+    /// claim the card: it would be competing with a transcription that already failed to get it.
+    /// </param>
+    public static RuntimeProviderKind Select(HardwareSnapshot hardware, bool forceCpu = false)
+    {
+        ArgumentNullException.ThrowIfNull(hardware);
+        return !forceCpu &&
+            hardware.Architecture == ProcessorArchitectureKind.X64 &&
+            hardware.Cuda.IsDriverAvailable &&
+            hardware.Cuda.DeviceCount > 0
+                ? RuntimeProviderKind.Cuda
+                : RuntimeProviderKind.Cpu;
+    }
+}

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -1636,12 +1636,12 @@ public partial class App : Application, IAsyncDisposable
             return;
         }
 
-        var useCuda = !forceCpu &&
-            hardware.Architecture == ProcessorArchitectureKind.X64 &&
-            hardware.Cuda.IsDriverAvailable &&
-            hardware.Cuda.DeviceCount > 0 &&
-            hardware.IsOnnxRuntimeCudaDependencySetAvailable;
-        var provider = useCuda ? RuntimeProviderKind.Cuda : RuntimeProviderKind.Cpu;
+        // ASKS ABOUT whisper.cpp NOW, WHICH IS WHAT LIVE PREVIEW ACTUALLY RUNS. This used to require
+        // onnxruntime's CUDA dependency set as well - a probe about the library PARAKEET uses - so a
+        // machine whose card works for whisper.cpp was put on the processor because a different
+        // library's files were absent. The rule lives beside the engine it describes and is tested
+        // there. Ref: #99.
+        var provider = WhisperPreviewRuntime.Select(hardware, forceCpu);
         var threads = Math.Clamp(
             hardware.PhysicalCoreCount > 0
                 ? hardware.PhysicalCoreCount

--- a/src/Production/EnviousWispr.Architecture.Tests/WhisperPreviewRuntimeTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/WhisperPreviewRuntimeTests.cs
@@ -1,0 +1,106 @@
+using EnviousWispr.ASR;
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+/// <summary>Live Preview picks its processor by asking about the library it actually runs.</summary>
+public sealed class WhisperPreviewRuntimeTests
+{
+    /// <summary>The case the old condition got wrong.</summary>
+    /// <remarks>
+    /// THIS IS THE WHOLE DEFECT, AND IT IS THE ONLY CASE THAT CHANGES. Live Preview runs whisper.cpp,
+    /// which ships its own CUDA build. The decision used to require onnxruntime's CUDA dependency set
+    /// as well - the library PARAKEET uses - so a machine with a working card and no onnxruntime
+    /// files was put on the processor for a reason that had nothing to do with the engine running
+    /// there. On the development machine both probes are true, so this could never have been found by
+    /// running it; it needed the two to disagree, which is what this test is. Ref: #99.
+    /// </remarks>
+    [Fact]
+    public void AWorkingCardIsUsedEvenWhenTheOtherRuntimesDependenciesAreMissing()
+    {
+        var hardware = Hardware(cuda: true, onnxRuntimeCudaDependencies: false);
+
+        Assert.Equal(RuntimeProviderKind.Cuda, WhisperPreviewRuntime.Select(hardware));
+    }
+
+    /// <summary>And the other library's presence never promotes a machine with no card.</summary>
+    [Fact]
+    public void TheOtherRuntimesDependenciesDoNotPromoteAMachineWithNoCard()
+    {
+        var hardware = Hardware(cuda: false, onnxRuntimeCudaDependencies: true);
+
+        Assert.Equal(RuntimeProviderKind.Cpu, WhisperPreviewRuntime.Select(hardware));
+    }
+
+    /// <summary>A driver with no device is not a card.</summary>
+    [Fact]
+    public void ADriverWithNoDeviceIsNotACard()
+    {
+        var hardware = Hardware(cuda: true, onnxRuntimeCudaDependencies: true) with
+        {
+            Cuda = new CudaDriverCapability(IsDriverAvailable: true, DeviceCount: 0, DriverVersion: 13_000),
+        };
+
+        Assert.Equal(RuntimeProviderKind.Cpu, WhisperPreviewRuntime.Select(hardware));
+    }
+
+    /// <summary>The preview stands down when the final engine already fell back.</summary>
+    /// <remarks>
+    /// NOT POLITENESS. The final engine falling back means it tried the card and failed; a preview
+    /// that then claimed the card would be asking for something already proved unavailable, on the
+    /// same machine, for the same reason.
+    /// </remarks>
+    [Fact]
+    public void ThePreviewDoesNotClaimACardTheFinalEngineAlreadyFailedToGet()
+    {
+        var hardware = Hardware(cuda: true, onnxRuntimeCudaDependencies: true);
+
+        Assert.Equal(RuntimeProviderKind.Cpu, WhisperPreviewRuntime.Select(hardware, forceCpu: true));
+    }
+
+    [Fact]
+    public void AnUnsupportedProcessorArchitectureStaysOnTheProcessor()
+    {
+        var hardware = Hardware(cuda: true, onnxRuntimeCudaDependencies: true) with
+        {
+            Architecture = ProcessorArchitectureKind.Arm64,
+        };
+
+        Assert.Equal(RuntimeProviderKind.Cpu, WhisperPreviewRuntime.Select(hardware));
+    }
+
+    /// <summary>The preview and the final Whisper engine agree about this machine.</summary>
+    /// <remarks>
+    /// TWO ANSWERS TO ONE QUESTION WAS THE DEFECT, so the fix is worth asserting as an agreement
+    /// rather than only as a corrected condition. If the final selector's rule changes and this one
+    /// does not, they part company again and this fails.
+    /// </remarks>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void ThePreviewAgreesWithTheFinalWhisperEngineAboutTheCard(
+        bool cuda,
+        bool onnxRuntimeCudaDependencies)
+    {
+        var hardware = Hardware(cuda, onnxRuntimeCudaDependencies);
+        var final = WhisperRuntimeSelector.Select(
+            hardware,
+            new WhisperModelInventory(QuantizedComplete: true, FullPrecisionComplete: true));
+
+        Assert.Equal(final.Provider, WhisperPreviewRuntime.Select(hardware));
+    }
+
+    private static HardwareSnapshot Hardware(bool cuda, bool onnxRuntimeCudaDependencies) => new(
+        HardwareProbeStatus.Complete,
+        ProcessorArchitectureKind.X64,
+        ProcessorVendor.Intel,
+        PhysicalCoreCount: 24,
+        LogicalProcessorCount: 32,
+        TotalPhysicalMemoryBytes: 64UL * 1024 * 1024 * 1024,
+        GraphicsAdapters: [],
+        IsDirectMlRuntimeAvailable: true,
+        new CudaDriverCapability(cuda, cuda ? 1 : 0, cuda ? 13_000 : null),
+        onnxRuntimeCudaDependencies);
+}


### PR DESCRIPTION
## The defect

Live Preview runs **whisper.cpp**. Its provider decision required this:

```csharp
hardware.IsOnnxRuntimeCudaDependencySetAvailable
```

That is an **onnxruntime** probe — the runtime **Parakeet** uses. whisper.cpp ships its own CUDA
build and neither knows nor cares whether onnxruntime's dependency set is present. A machine with a
working card and no onnxruntime CUDA files was put on the processor for a reason that had nothing to
do with the engine running there.

This is #99's third fault, filed as *"an onnxruntime dependency probe being used to pick the provider
for a whisper.cpp engine"*. It is exactly that.

## The fix

The condition is now the one `WhisperRuntimeSelector` already uses for the final Whisper engine — a
driver and at least one device. The preview and the transcription now agree about what the machine
can do; **two answers to one question was the defect**.

The rule also moved out of the WinUI startup path and next to the engine it describes, which is what
makes it testable. It sat inline in a window no test here can reach — which is how a probe for the
wrong library went unnoticed.

## This could not have been found by running it

Both probes are true on the development machine, so the change alters nothing locally and no
measurement here would show anything. **The machine where they disagree is the test:**

| | old | new |
| --- | --- | --- |
| working card, onnxruntime CUDA files absent | processor | **card** |
| no card, onnxruntime files present | processor | processor |
| driver present, zero devices | processor | processor |
| final engine already fell back | processor | processor |

Proved by putting the old clause back: **two tests go red**, the direct one and the one asserting the
preview still agrees with the final Whisper engine. File restored byte-identical.

The agreement test is a `[Theory]` over all four combinations rather than a restatement of the new
condition, so if the final selector's rule changes and this one does not, they part company and it
fails.

## Also asserted, because it is a rule rather than politeness

The preview stands down when the final engine has already fallen back to the processor: that fallback
means the card was tried and failed, so a preview claiming it would be asking for something already
proved unavailable on the same machine for the same reason.

## Gates

Portable gate green: `verified: 1137 of 1137 tests ran.`

Part of #99. Fault 2 — the preview re-transcribing its whole window every pass — is still open.