### PR TITLE
a message on the error stream is not a reason to abandon the gate

### DIFF
--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -172,8 +172,26 @@ function Invoke-DotNetTest {
     $common = @("test", $Project, "-c", "Release", "--nologo") + $ExtraArguments
     # ASSIGNED FIRST, THEN BRANCHED. A pipeline reports its LAST command's status, so testing
     # $LASTEXITCODE after piping the output anywhere would report the pipe.
-    $output = & $Executable @common 2>&1
-    $exitCode = $LASTEXITCODE
+    #
+    # AND STDERR IS MERGED UNDER 'Continue', WHICH IS LOAD-BEARING. This script runs with
+    # ErrorActionPreference = Stop, and under Stop a native command writing ANYTHING to stderr raises
+    # a terminating NativeCommandError at the moment of capture - before any of the checks below can
+    # run. Measured: a crashing test host printed its abort line to stderr and the gate died here with
+    # `NativeCommandError`, so the run failed for the right reason with the wrong explanation, twice.
+    #
+    # THE SAME TRAP IS ALREADY DOCUMENTED IN `Resolve-Python` IN THIS FILE, and knowing about it did
+    # not stop it being reintroduced fifty lines away. Restored in a finally, so a throw inside the
+    # capture cannot leave the rest of the gate running with errors non-terminating.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $Executable @common 2>&1
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+    }
+
     $output | ForEach-Object { Write-Host $_ }
 
     $aborted = @($output | Select-String -Pattern 'Test host process crashed|The active test run was aborted')
@@ -188,7 +206,13 @@ function Invoke-DotNetTest {
 
     # --no-build BECAUSE THE RUN ABOVE JUST BUILT IT, and re-building here would let a discovery
     # against different bytes agree with a run it never described.
-    $listed = & $Executable @($common + @("--no-build", "--list-tests")) 2>&1
+    $ErrorActionPreference = 'Continue'
+    try {
+        $listed = & $Executable @($common + @("--no-build", "--list-tests")) 2>&1
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+    }
     $discovered = @($listed | Select-String -Pattern '^\s{4}\S').Count
     $reported = 0
     foreach ($match in ($output | Select-String -Pattern 'Total:\s*(\d+)' -AllMatches)) {


### PR DESCRIPTION
## A defect I introduced in #117

The whole-run check captures the test runner's output. It did so in a way that cannot survive the
runner writing anything to **stderr**:

```powershell
$output = & $Executable @common 2>&1     # under $ErrorActionPreference = 'Stop'
```

Under `Stop`, a native command writing to stderr raises a **terminating** `NativeCommandError` at the
moment of capture — *before* any of the checks below it can run.

So when the test host crashed and printed its abort line to stderr, the gate died like this:

```
dotnet.exe : The active test run was aborted. Reason: Test host process crashed : Fatal error.
At ...\validate.ps1:175 char:15
+     $output = & $Executable @common 2>&1
    + FullyQualifiedErrorId : NativeCommandError
```

It failed **for the right reason with the wrong explanation**, twice in a row — and the explanation is
the entire value of that check.

## The trap was already documented in this file

`Resolve-Python`, fifty lines away, carries a comment describing exactly this:

> a native command writing to stderr is a terminating NativeCommandError under this script's
> ErrorActionPreference, so the probe designed to tolerate a missing Python was itself ending the run

Knowing about it did not stop me reintroducing it. The preference is now lowered around each capture
(the run and the discovery) and restored in a `finally`, so a throw inside cannot leave the rest of the
gate running with errors non-terminating.

## Both directions

| | Result |
| --- | --- |
| Crashing host | `The test run was ABORTED, so its summary describes only the tests that finished: …` |
| Clean run | passes — `verified: 34 of 34`, `verified: 1137 of 1137` |

## An error I made twice in this change, worth stating

The first attempt wrote the file from the *unmodified* string twice, so the second edit silently
discarded the first. It looked applied and was not; the gate failed identically and I nearly blamed the
fix. Caught by re-reading the failing line rather than trusting that the edit had landed.

## Machine note

The test host crashed on **three of five consecutive runs** while confirming this — much higher than
the four occurrences across a long session reported on #112. The machine has been under sustained load
for hours. That belongs to #112; the point here is that the gate now says so clearly.