### PR TITLE
a restart stops looking like a crash in the record

### DIFF
--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -665,8 +665,20 @@ public partial class App : Application, IAsyncDisposable
             SystemLifecycleTransition.Resumed => AppEventCode.SystemResumed,
             SystemLifecycleTransition.SessionLocked => AppEventCode.SessionLocked,
             SystemLifecycleTransition.SessionUnlocked => AppEventCode.SessionUnlocked,
+            SystemLifecycleTransition.SessionEnding => AppEventCode.SystemSessionEnding,
             _ => AppEventCode.UnhandledFailure,
         };
+        if (transition == SystemLifecycleTransition.SessionEnding && _runId is { } endingRunId)
+        {
+            // RECORDED HERE, NOT AT TEARDOWN, BECAUSE TEARDOWN MAY NEVER COME. Windows gives the
+            // process a short and unguaranteed window after this notification and can kill it at any
+            // point, so the one chance to write down that the ending was EXPECTED is now. Without it
+            // a deliberate restart is stored as an interruption, which is the same trace a crash
+            // leaves. Fire and forget for the same reason: waiting on a disk write inside a shutdown
+            // notification is how an app becomes the thing that delays somebody's shutdown. Ref: #93.
+            _ = _runStateStore.NoteSystemEndingAsync(endingRunId, DateTimeOffset.UtcNow);
+        }
+
         // WINDOWS LOCKING MID-DICTATION IS A FACT ABOUT THAT DICTATION. Written before the recovery
         // flow opens its own scope, so it opens one here too; otherwise the event that EXPLAINS the
         // recovery is the one line of it joined to nothing.

--- a/src/Production/EnviousWispr.Architecture.Tests/ReliabilityStoreTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/ReliabilityStoreTests.cs
@@ -167,6 +167,137 @@ public sealed class ReliabilityStoreTests
         }
     }
 
+    /// <summary>A Windows shutdown reads as a known ending, not an unexplained one.</summary>
+    /// <remarks>
+    /// THE TWO USED TO BE ONE RECORD. A run only writes a clean exit when the app completes one
+    /// itself, and Windows shutting the machine down kills the process first - so a deliberate
+    /// Restart was stored with exactly the trace a crash leaves. Ref: #93.
+    /// </remarks>
+    [Fact]
+    public async Task AWindowsEndingIsRecordedAsKnownRatherThanInterrupted()
+    {
+        using var temp = new TemporaryDirectory();
+        var path = Path.Combine(temp.Path, "run-state.json");
+        using (var store = new JsonApplicationRunStateStore(path))
+        {
+            var run = await store.BeginRunAsync(Timestamp(0));
+            Assert.True(await store.NoteSystemEndingAsync(run.RunId, Timestamp(1)));
+        }
+
+        using (var next = new JsonApplicationRunStateStore(path))
+        {
+            var recovered = await next.BeginRunAsync(Timestamp(2));
+
+            Assert.Equal(RunStateLoadStatus.PreviousRunEndedByWindows, recovered.Status);
+            // NOT AN INTERRUPTION, WHICH IS THE WHOLE POINT: nothing downstream should treat a
+            // restart as a fault, and no error should travel with it.
+            Assert.False(recovered.RecoveredInterruptedRun);
+            Assert.Null(recovered.Error);
+        }
+    }
+
+    /// <summary>A shutdown does not claim the app tidied up after itself.</summary>
+    /// <remarks>
+    /// WINDOWS ENDING THE SESSION MEANS THE ENDING WAS EXPECTED, not that teardown ran. The process
+    /// can still be killed part-way through. If this wrote a clean shutdown, a restart would be
+    /// indistinguishable from a proper exit and the next run would report `Started` - erasing the
+    /// distinction in the other direction.
+    /// </remarks>
+    [Fact]
+    public async Task AWindowsEndingIsNotRecordedAsACleanShutdown()
+    {
+        using var temp = new TemporaryDirectory();
+        var path = Path.Combine(temp.Path, "run-state.json");
+        using (var store = new JsonApplicationRunStateStore(path))
+        {
+            var run = await store.BeginRunAsync(Timestamp(0));
+            Assert.True(await store.NoteSystemEndingAsync(run.RunId, Timestamp(1)));
+        }
+
+        using (var next = new JsonApplicationRunStateStore(path))
+        {
+            Assert.NotEqual(RunStateLoadStatus.Started, (await next.BeginRunAsync(Timestamp(2))).Status);
+        }
+    }
+
+    /// <summary>A shutdown during a dictation still says a dictation was in flight.</summary>
+    /// <remarks>
+    /// THE ONE THING A USER GENUINELY NEEDS TELLING SURVIVES. Recovery text is written only after
+    /// transcription completes, so an ending mid-dictation loses it whether Windows caused the
+    /// ending or not.
+    /// </remarks>
+    [Fact]
+    public async Task AWindowsEndingDuringADictationStillReportsTheDictation()
+    {
+        using var temp = new TemporaryDirectory();
+        var path = Path.Combine(temp.Path, "run-state.json");
+        using (var store = new JsonApplicationRunStateStore(path))
+        {
+            var run = await store.BeginRunAsync(Timestamp(0));
+            Assert.True(await store.SetDictationActiveAsync(run.RunId, true, Timestamp(1)));
+            Assert.True(await store.NoteSystemEndingAsync(run.RunId, Timestamp(2)));
+        }
+
+        using (var next = new JsonApplicationRunStateStore(path))
+        {
+            var recovered = await next.BeginRunAsync(Timestamp(3));
+
+            Assert.Equal(RunStateLoadStatus.PreviousRunEndedByWindows, recovered.Status);
+            Assert.True(recovered.PreviousRunWasDictating);
+        }
+    }
+
+    /// <summary>A heartbeat arriving after the notice does not erase it.</summary>
+    /// <remarks>
+    /// WINDOWS ANNOUNCING THE END OF THE SESSION DOES NOT STOP BEING TRUE. The heartbeat runs on a
+    /// timer and knows nothing about it; if it cleared the flag, the very case this records would be
+    /// lost whenever the process lived a moment longer than the notice.
+    /// </remarks>
+    [Fact]
+    public async Task AHeartbeatAfterTheNoticeDoesNotEraseIt()
+    {
+        using var temp = new TemporaryDirectory();
+        var path = Path.Combine(temp.Path, "run-state.json");
+        using (var store = new JsonApplicationRunStateStore(path))
+        {
+            var run = await store.BeginRunAsync(Timestamp(0));
+            Assert.True(await store.NoteSystemEndingAsync(run.RunId, Timestamp(1)));
+            Assert.True(await store.HeartbeatAsync(run.RunId, Timestamp(2)));
+        }
+
+        using (var next = new JsonApplicationRunStateStore(path))
+        {
+            Assert.Equal(
+                RunStateLoadStatus.PreviousRunEndedByWindows,
+                (await next.BeginRunAsync(Timestamp(3))).Status);
+        }
+    }
+
+    /// <summary>An ending nobody announced is still an interruption.</summary>
+    /// <remarks>
+    /// THE CONTROL. Task Manager, a forced kill and a power cut genuinely cannot be told from a
+    /// crash by the process they end, and must stay exactly as they were.
+    /// </remarks>
+    [Fact]
+    public async Task AnUnannouncedEndingIsStillAnInterruption()
+    {
+        using var temp = new TemporaryDirectory();
+        var path = Path.Combine(temp.Path, "run-state.json");
+        using (var store = new JsonApplicationRunStateStore(path))
+        {
+            var run = await store.BeginRunAsync(Timestamp(0));
+            Assert.True(await store.HeartbeatAsync(run.RunId, Timestamp(1)));
+        }
+
+        using (var next = new JsonApplicationRunStateStore(path))
+        {
+            var recovered = await next.BeginRunAsync(Timestamp(2));
+
+            Assert.Equal(RunStateLoadStatus.PreviousRunInterrupted, recovered.Status);
+            Assert.True(recovered.RecoveredInterruptedRun);
+        }
+    }
+
     private static DateTimeOffset Timestamp(int minute) => new(
         year: 2026,
         month: 8,

--- a/src/Production/EnviousWispr.Core/Diagnostics/AppEventCode.cs
+++ b/src/Production/EnviousWispr.Core/Diagnostics/AppEventCode.cs
@@ -91,6 +91,9 @@ public enum AppEventCode
     SystemResumed,
     SessionLocked,
     SessionUnlocked,
+
+    /// <summary>Windows is shutting down, restarting, or logging the user off.</summary>
+    SystemSessionEnding,
     AudioDevicesChanged,
     LivePreviewStarted,
     LivePreviewUpdated,

--- a/src/Production/EnviousWispr.Core/Reliability/ReliabilityContracts.cs
+++ b/src/Production/EnviousWispr.Core/Reliability/ReliabilityContracts.cs
@@ -9,6 +9,23 @@ public enum RunStateLoadStatus
     PreviousRunInterrupted,
     InvalidStateRecovered,
     Unavailable,
+
+    /// <summary>Windows ended the previous run: a shutdown, a restart, or a log off.</summary>
+    /// <remarks>
+    /// "WE DO NOT KNOW" AND "WINDOWS ENDED IT" ARE DIFFERENT FACTS AND USED TO BE THE SAME RECORD.
+    /// A run only records a clean exit when the app completes one itself, and Windows shutting the
+    /// machine down terminates the process before that can happen - so a deliberate Restart from the
+    /// Start menu was written down as an interruption, indistinguishable from a fault.
+    ///
+    /// NOTHING A USER SEES DEPENDS ON THIS. The banner that once accused the product on this basis
+    /// is gone, and what replaced it asks whether a dictation was actually in flight. This is about
+    /// a diagnostics export being honest: somebody reading a run history should not have to treat a
+    /// week of ordinary restarts as a week of crashes. Ref: #93.
+    ///
+    /// IT DOES NOT COVER Task Manager, a forced kill, or the power going out. Those genuinely cannot
+    /// be told from a crash by the process they end, and they stay `PreviousRunInterrupted`.
+    /// </remarks>
+    PreviousRunEndedByWindows,
 }
 
 /// <param name="PreviousRunWasDictating">
@@ -33,6 +50,10 @@ public sealed record ApplicationRunStartResult(
     bool PreviousRunWasDictating,
     AppError? Error = null)
 {
+    /// <remarks>
+    /// A WINDOWS ENDING IS DELIBERATELY NOT ONE OF THESE. It is a known ending rather than an
+    /// unexplained one, which is the entire reason for telling them apart.
+    /// </remarks>
     public bool RecoveredInterruptedRun => Status is
         RunStateLoadStatus.PreviousRunInterrupted or
         RunStateLoadStatus.InvalidStateRecovered;
@@ -58,6 +79,19 @@ public interface IApplicationRunStateStore
     Task<bool> SetDictationActiveAsync(
         Guid runId,
         bool active,
+        DateTimeOffset timestamp,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Records that Windows is ending this run, before it gets the chance to end itself.</summary>
+    /// <remarks>
+    /// NOT `CompleteRunAsync`, AND THE DIFFERENCE IS THE POINT. A clean completion says the app tore
+    /// itself down and everything in that teardown succeeded. Windows ending the session says only
+    /// that the ending was expected; the process may still be killed part-way through whatever it was
+    /// doing. Writing the stronger claim here would make every shutdown look like a clean exit and
+    /// lose the distinction this exists to record. Ref: #93.
+    /// </remarks>
+    Task<bool> NoteSystemEndingAsync(
+        Guid runId,
         DateTimeOffset timestamp,
         CancellationToken cancellationToken = default);
 
@@ -127,6 +161,9 @@ public enum SystemLifecycleTransition
     Resumed,
     SessionLocked,
     SessionUnlocked,
+
+    /// <summary>Windows is shutting down, restarting, or logging the user off.</summary>
+    SessionEnding,
 }
 
 public interface ISystemLifecycleMonitor : IDisposable

--- a/src/Production/EnviousWispr.Services/Lifecycle/WindowsSystemLifecycleMonitor.cs
+++ b/src/Production/EnviousWispr.Services/Lifecycle/WindowsSystemLifecycleMonitor.cs
@@ -11,6 +11,10 @@ public sealed class WindowsSystemLifecycleMonitor : ISystemLifecycleMonitor
     {
         SystemEvents.PowerModeChanged += OnPowerModeChanged;
         SystemEvents.SessionSwitch += OnSessionSwitch;
+        // WINDOWS ANNOUNCES ITS OWN ENDINGS AND NOBODY WAS LISTENING. A shutdown, a restart or a log
+        // off kills the process before it can record that it exited cleanly, so every one of them was
+        // written down as an interruption - the same trace a crash leaves. Ref: #93.
+        SystemEvents.SessionEnding += OnSessionEnding;
     }
 
     public event EventHandler<SystemLifecycleTransition>? Transitioned;
@@ -25,6 +29,7 @@ public sealed class WindowsSystemLifecycleMonitor : ISystemLifecycleMonitor
         _disposed = true;
         SystemEvents.PowerModeChanged -= OnPowerModeChanged;
         SystemEvents.SessionSwitch -= OnSessionSwitch;
+        SystemEvents.SessionEnding -= OnSessionEnding;
     }
 
     internal static SystemLifecycleTransition? Map(PowerModes mode) => mode switch
@@ -40,6 +45,17 @@ public sealed class WindowsSystemLifecycleMonitor : ISystemLifecycleMonitor
         SessionSwitchReason.SessionUnlock => SystemLifecycleTransition.SessionUnlocked,
         _ => null,
     };
+
+    /// <remarks>
+    /// EVERY REASON IS THE SAME ANSWER HERE, so the reason is not read. Windows distinguishes a
+    /// logoff from a system shutdown; this record only needs to say that the ending was expected
+    /// rather than unexplained, and both are.
+    ///
+    /// IT DOES NOT CANCEL THE ENDING. `SessionEndingEventArgs.Cancel` exists and is deliberately not
+    /// touched: a dictation tool must never be the reason somebody's shutdown does not happen.
+    /// </remarks>
+    private void OnSessionEnding(object sender, SessionEndingEventArgs args) =>
+        Transitioned?.Invoke(this, SystemLifecycleTransition.SessionEnding);
 
     private void OnPowerModeChanged(object sender, PowerModeChangedEventArgs args)
     {

--- a/src/Production/EnviousWispr.Services/Reliability/JsonApplicationRunStateStore.cs
+++ b/src/Production/EnviousWispr.Services/Reliability/JsonApplicationRunStateStore.cs
@@ -69,6 +69,15 @@ public sealed class JsonApplicationRunStateStore : IApplicationRunStateStore, ID
                     status = RunStateLoadStatus.InvalidStateRecovered;
                     consecutiveInterruptedRuns = 1;
                 }
+                else if (!previous!.CleanShutdown && previous.EndedBySystem)
+                {
+                    // A KNOWN ENDING, SO THE INTERRUPTED COUNT DOES NOT MOVE. Counting deliberate
+                    // restarts as interruptions is how one machine came to believe it had failed
+                    // nineteen times in a row. The dictation flag still travels, because a shutdown
+                    // DURING a dictation loses it exactly as any other ending would. Ref: #93.
+                    status = RunStateLoadStatus.PreviousRunEndedByWindows;
+                    previousRunWasDictating = previous.DictationActive;
+                }
                 else if (!previous!.CleanShutdown)
                 {
                     status = RunStateLoadStatus.PreviousRunInterrupted;
@@ -93,7 +102,10 @@ public sealed class JsonApplicationRunStateStore : IApplicationRunStateStore, ID
                 runId,
                 status,
                 previousRunWasDictating,
-                status == RunStateLoadStatus.Started
+                // NO ERROR FOR A KNOWN ENDING. A Windows shutdown is not a fault, so attaching
+                // `PreviousRunInterrupted` to it would put back, in the error field, exactly the
+                // conflation the status was split to remove. Ref: #93.
+                status is RunStateLoadStatus.Started or RunStateLoadStatus.PreviousRunEndedByWindows
                     ? null
                     : new AppError(
                         AppErrorCode.PreviousRunInterrupted,
@@ -131,6 +143,24 @@ public sealed class JsonApplicationRunStateStore : IApplicationRunStateStore, ID
         CancellationToken cancellationToken = default) =>
         UpdateAsync(runId, timestamp, cleanShutdown: false, dictationActive: active, cancellationToken);
 
+    /// <remarks>
+    /// DELIBERATELY DOES NOT SET `CleanShutdown`. Windows saying the session is ending means the
+    /// ending is EXPECTED, not that the app finished tidying up - the process can still be killed
+    /// part-way through. Claiming a clean shutdown here would make every restart look like a clean
+    /// exit and erase the distinction this method exists to record. Ref: #93.
+    /// </remarks>
+    public Task<bool> NoteSystemEndingAsync(
+        Guid runId,
+        DateTimeOffset timestamp,
+        CancellationToken cancellationToken = default) =>
+        UpdateAsync(
+            runId,
+            timestamp,
+            cleanShutdown: false,
+            dictationActive: null,
+            cancellationToken,
+            endedBySystem: true);
+
     public Task<bool> CompleteRunAsync(
         Guid runId,
         DateTimeOffset timestamp,
@@ -153,7 +183,8 @@ public sealed class JsonApplicationRunStateStore : IApplicationRunStateStore, ID
         DateTimeOffset timestamp,
         bool cleanShutdown,
         bool? dictationActive,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool? endedBySystem = null)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -172,6 +203,11 @@ public sealed class JsonApplicationRunStateStore : IApplicationRunStateStore, ID
                 LastHeartbeatAt = timestamp,
                 CleanShutdown = cleanShutdown,
                 DictationActive = dictationActive ?? _current.DictationActive,
+                // NULL LEAVES IT ALONE, LIKE THE FLAG ABOVE, and it is never cleared. Windows
+                // announcing the end of the session is not something that stops being true: a
+                // heartbeat landing after it must not erase the one fact that explains this run's
+                // ending.
+                EndedBySystem = endedBySystem ?? _current.EndedBySystem,
             };
             await JsonSettingsStore.WriteAtomicallyAsync(next, _path, cancellationToken)
                 .ConfigureAwait(false);
@@ -241,5 +277,9 @@ public sealed class JsonApplicationRunStateStore : IApplicationRunStateStore, ID
         int ConsecutiveInterruptedRuns,
         // DEFAULTED, SO A FILE WRITTEN BY AN OLDER BUILD STILL READS. It deserialises to false,
         // which is the honest answer: that build never recorded whether a dictation was running.
-        bool DictationActive = false);
+        bool DictationActive = false,
+        // DEFAULTED FOR THE SAME REASON AS THE FLAG ABOVE. A file written before this existed reads
+        // as false, which is the honest answer: that build never observed a Windows ending, so it
+        // cannot claim one happened. Ref: #93.
+        bool EndedBySystem = false);
 }


### PR DESCRIPTION
## The record was wrong about what happened

A run only writes a clean exit when the app finishes tearing itself down. Windows shutting down,
restarting, or logging off kills the process before that — so **every deliberate restart was stored
with exactly the trace a crash leaves**. A week of ordinary restarts read back as a week of
interrupted runs.

Windows announces those endings, and nothing was listening. The app now hears the notice and records
that this ending was **expected**, so the next launch can tell *"Windows ended it"* from *"we do not
know"* — different facts that were one record.

## Three decisions worth stating

**It does not claim a clean shutdown.** Windows saying the session is ending means the ending was
expected, not that teardown ran; the process can still be killed part-way through. Writing the
stronger claim would make every restart indistinguishable from a proper exit and lose the same
distinction from the other side. There is a test for that direction specifically.

**It is written at the notice, not at teardown**, because teardown may never come — the window Windows
gives is short and not guaranteed. It is fire-and-forget, because a dictation tool must never be the
reason somebody's shutdown is slow, and `SessionEndingEventArgs.Cancel` is deliberately untouched.

**The interrupted count does not move for a known ending.** Counting deliberate restarts is how one
machine came to believe it had failed nineteen times in a row.

## What does not change

Nothing a user sees. The banner that accused the product on this basis is already gone, and what
replaced it asks whether a dictation was actually in flight — which still travels with a Windows
ending, because a shutdown mid-dictation loses the words exactly as any other ending would.

**Task Manager, a forced kill and a power cut are untouched** and still read as interruptions, because
a process genuinely cannot tell those from a fault. That is asserted as its own control test, so the
two paths cannot quietly merge again.

## Every test was made to fail first

With the notice not recorded, three of the five go red:

```
Failed  AWindowsEndingDuringADictationStillReportsTheDictation
Failed  AWindowsEndingIsRecordedAsKnownRatherThanInterrupted
Failed  AHeartbeatAfterTheNoticeDoesNotEraseIt
```

That last one covers a case worth naming: the heartbeat runs on a timer and knows nothing about the
notice, so if it cleared the flag the very ending this records would be lost whenever the process
outlived the notice by a minute.

## Gates

Portable gate green: `verified: 1142 of 1142 tests ran.`

The one thing not proved here is the real Windows event firing, which needs an actual shutdown. The
mapping and everything downstream of it are covered; the subscription itself is one line and is stated
as unobserved.

Part of #93