### PR TITLE
the fixture recording arrives at the speed a person speaks

### DIFF
--- a/src/Production/EnviousWispr.App/PublicFixtureAudioCapture.cs
+++ b/src/Production/EnviousWispr.App/PublicFixtureAudioCapture.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using EnviousWispr.Core.Audio;
 using EnviousWispr.Core.Dictation;
 using EnviousWispr.Core.Errors;
@@ -20,6 +21,10 @@ internal sealed class PublicFixtureAudioCapture : IAudioCapture, IAudioSnapshotS
     private readonly float[] _samples;
     private AudioCaptureRequest? _request;
     private bool _disposed;
+    // THE MOMENT THE RECORDING STARTED, SO A READER MID-TAKE SEES ONLY WHAT HAS ARRIVED. Without it
+    // this capture handed its whole file to the first snapshot, which is not a recording anybody
+    // makes and which overstated the streaming head start's benefit. Ref: #85, #96.
+    private long _startedTicks;
 
     private PublicFixtureAudioCapture(float[] samples)
     {
@@ -75,6 +80,7 @@ internal sealed class PublicFixtureAudioCapture : IAudioCapture, IAudioSnapshotS
         }
 
         _request = request;
+        _startedTicks = Stopwatch.GetTimestamp();
         LevelChanged?.Invoke(this, MeasureLevel(_samples));
         return Task.FromResult(new AudioOperationResult(Succeeded: true));
     }
@@ -131,10 +137,21 @@ internal sealed class PublicFixtureAudioCapture : IAudioCapture, IAudioSnapshotS
         var maximumSamples = requestedSamples >= int.MaxValue
             ? int.MaxValue
             : Math.Max(1, (int)requestedSamples);
-        var offset = Math.Max(0, _samples.Length - maximumSamples);
+        // ONLY WHAT A MICROPHONE WOULD HAVE PRODUCED BY NOW. Stopping still returns the whole fixture,
+        // so transcripts are unchanged; this is what anything reading DURING the recording can see.
+        var arrived = ArrivedAudio.Count(
+            Stopwatch.GetElapsedTime(_startedTicks),
+            _samples.Length,
+            RequiredSampleRate);
+        if (arrived <= 0)
+        {
+            return null;
+        }
+
+        var offset = Math.Max(0, arrived - maximumSamples);
         return new AudioSnapshot(
             request.SessionId,
-            _samples.AsMemory(offset),
+            _samples.AsMemory(offset, arrived - offset),
             RequiredSampleRate,
             Channels: 1);
     }

--- a/src/Production/EnviousWispr.Architecture.Tests/ArrivedAudioTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/ArrivedAudioTests.cs
@@ -1,0 +1,55 @@
+using EnviousWispr.Core.Audio;
+
+namespace EnviousWispr.Architecture.Tests;
+
+/// <summary>A recording holds only what has been spoken into it so far.</summary>
+public sealed class ArrivedAudioTests
+{
+    private const int Rate = 16_000;
+
+    [Fact]
+    public void NothingHasArrivedBeforeTheRecordingStarts()
+    {
+        Assert.Equal(0, ArrivedAudio.Count(TimeSpan.Zero, 10 * Rate, Rate));
+    }
+
+    /// <summary>A clock going backwards is not a recording that has not started.</summary>
+    [Fact]
+    public void ANegativeElapsedTimeYieldsNothingRatherThanANegativeIndex()
+    {
+        Assert.Equal(0, ArrivedAudio.Count(TimeSpan.FromSeconds(-5), 10 * Rate, Rate));
+    }
+
+    [Theory]
+    [InlineData(1, 16_000)]
+    [InlineData(2, 32_000)]
+    [InlineData(0.5, 8_000)]
+    public void AudioArrivesAtTheSampleRate(double seconds, int expected)
+    {
+        Assert.Equal(expected, ArrivedAudio.Count(TimeSpan.FromSeconds(seconds), 10 * Rate, Rate));
+    }
+
+    /// <summary>Holding longer than the fixture lasts does not read past its end.</summary>
+    /// <remarks>
+    /// THE ORDINARY CASE, NOT AN EDGE ONE. The harness holds a recording for a fixed time and the
+    /// fixtures are shorter than some of those holds, so the audio simply runs out partway through.
+    /// </remarks>
+    [Fact]
+    public void HoldingLongerThanTheFixtureStopsAtItsEnd()
+    {
+        Assert.Equal(3 * Rate, ArrivedAudio.Count(TimeSpan.FromSeconds(99), 3 * Rate, Rate));
+    }
+
+    /// <summary>The one that was actually wrong: half a second in, half a second exists.</summary>
+    /// <remarks>
+    /// THE DEFECT THIS REPLACES, STATED AS A NUMBER. The streaming head start polls at 500 ms, and the
+    /// capture used to hand it the entire file at that moment - so a five second take was fully
+    /// committed before the speaker had said a second word, and the measured benefit was the benefit
+    /// of having the future available. Ref: #96.
+    /// </remarks>
+    [Fact]
+    public void AtTheFirstPollOnlyTheFirstHalfSecondExists()
+    {
+        Assert.Equal(8_000, ArrivedAudio.Count(TimeSpan.FromMilliseconds(500), 5 * Rate, Rate));
+    }
+}

--- a/src/Production/EnviousWispr.Core/Audio/ArrivedAudio.cs
+++ b/src/Production/EnviousWispr.Core/Audio/ArrivedAudio.cs
@@ -1,0 +1,41 @@
+namespace EnviousWispr.Core.Audio;
+
+/// <summary>How much of a recording exists yet, given how long it has been running.</summary>
+/// <remarks>
+/// A FIXTURE THAT ARRIVES INSTANTLY MEASURES A RECORDING NOBODY MAKES. The public-fixture capture used
+/// by the journey harness reads its whole WAV at construction and hands all of it back on the first
+/// snapshot - so anything reading the recording mid-take sees a complete one half a second in, rather
+/// than the half second a microphone would have produced.
+///
+/// IT PRODUCED A WRONG NUMBER BEFORE IT PRODUCED THIS FILE. The streaming head start was measured
+/// against that capture and reported cutting the wait after release roughly in half. The direction was
+/// right and the magnitude was not: the head start had the entire recording available at its first
+/// poll, committed nearly all of it at once, and left the final pass with almost nothing to do. The
+/// log said so plainly - one commit 786 ms into a five second take and then silence - and was read
+/// past. Ref: #96, corrected there; #85, which asks for exactly this technique.
+///
+/// THE FINAL CAPTURE IS DELIBERATELY UNAFFECTED. Stopping still returns the whole fixture, so every
+/// transcript assertion in the harness keeps its meaning. What changes is only what a reader
+/// mid-recording can see, which is the thing that was pretending.
+/// </remarks>
+public static class ArrivedAudio
+{
+    /// <summary>Samples a capture of <paramref name="totalSamples"/> would hold after this long.</summary>
+    /// <remarks>
+    /// CLAMPED AT BOTH ENDS. A negative elapsed time is a clock going backwards rather than a
+    /// recording that has not started, and a take held longer than the fixture is the ordinary case
+    /// once the audio runs out - neither may produce an index outside the buffer.
+    /// </remarks>
+    public static int Count(TimeSpan elapsed, int totalSamples, int sampleRate)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(totalSamples);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
+        if (elapsed <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        var arrived = elapsed.TotalSeconds * sampleRate;
+        return arrived >= totalSamples ? totalSamples : (int)arrived;
+    }
+}

--- a/tools/app-journey-uat/Program.cs
+++ b/tools/app-journey-uat/Program.cs
@@ -1368,15 +1368,30 @@ static void RequireLivePreviewJourneyEvents(IReadOnlyList<string> events)
 /// </remarks>
 static void RequireHeadStartJourneyEvents(IReadOnlyList<string> events)
 {
-    var required = new[] { "StreamingSegmentCommitted", "StreamingHeadStartUsed" };
-    var missing = required.Where(eventName => !events.Any(value => value.StartsWith(
-        eventName + '/',
-        StringComparison.Ordinal))).ToArray();
-    if (missing.Length > 0)
+    // AN EARLIER VERSION ALSO DEMANDED A COMMITTED SEGMENT, AND THAT WAS WRONG. It passed only
+    // because the fixture capture was lying: it handed the whole WAV to the first snapshot, so the
+    // planner saw a complete recording half a second in and committed nearly all of it at once. Once
+    // the fixture began arriving at the sample rate, as a microphone does, the same run committed
+    // NOTHING - and that is correct behaviour rather than a regression.
+    //
+    // THE PLANNER CANNOT COMMIT ON THIS FIXTURE AND SHOULD NOT. It refuses to end a commit anywhere
+    // but in silence and never commits the last segment, because a segment at the end of the audio so
+    // far is indistinguishable from the first half of a word still being said. This journey's fixture
+    // is 2.71 seconds of one continuous sentence: no interior silence to commit at, and the tail is
+    // the only thing that ever arrives. Requiring a commit here asserts that the audio is fake.
+    //
+    // SO IT ASSERTS THE THING THAT WAS ACTUALLY BROKEN. Before the overflow fix the head start threw
+    // on the FIRST poll of every recording ever made and was abandoned every time, so "did not give
+    // up" is exactly the regression this catches - and it catches it on a fixture this short.
+    //
+    // WHAT IT DOES NOT PROVE is that the head start ever saves anybody time. That needs a fixture
+    // long enough to contain a pause, which this repository does not have. Ref: #96, #85.
+    if (!events.Any(value => value.StartsWith(
+        "DictationRecordingStarted/",
+        StringComparison.Ordinal)))
     {
         throw new JourneyExpectationException(
-            "The head-start journey omitted content-free stages: " + string.Join(", ", missing)
-                + ". The streaming head start did no work this recording could use.");
+            "The head-start journey never recorded, so nothing about the head start was exercised.");
     }
 
     if (events.Any(value => value.StartsWith("StreamingAbandoned/", StringComparison.Ordinal)))


### PR DESCRIPTION
## The instrument was lying, and it had already produced a wrong number

`PublicFixtureAudioCapture` read its whole WAV at construction and returned all of it from the first
snapshot. So anything reading a recording **while it was still running** saw a complete one half a
second in, rather than the half second a microphone would have produced.

**This is not hypothetical.** The streaming head start was measured against that capture yesterday
(#116) and reported cutting the wait after release roughly in half. The direction was right; the size
was not. The head start had the entire recording at its first poll, committed nearly all of it at once,
and left the final pass with almost nothing to do.

The evidence was in the log I posted at the time and I read past it:

```
10:22:36.016  DictationRecordingStarted
10:22:36.802  StreamingSegmentCommitted     <- one commit, 786 ms in
10:22:41.039  DictationCaptureFinalized     <- a five second hold
```

One commit, immediately, then four seconds of nothing. That is what committing an already-complete
recording looks like.

## What changes

Only what a reader **mid-recording** can see. Stopping still returns the whole fixture, so every
transcript assertion in the harness keeps its meaning.

## The result, which is more interesting than the change

With audio arriving at the sample rate, the same journey commits **nothing at all**, three runs
running — and transcription is back to ~417–447 ms.

**That is correct, not a regression.** The commit planner refuses to end a commit anywhere but in
silence and never commits the last segment, because a segment at the end of the audio so far cannot be
told from the first half of a word still being said. This journey's fixture is **2.71 seconds of one
continuous sentence**: no interior silence to commit at, and the tail is the only thing that ever
arrives.

## So the guard I added with that fix was asserting the audio was fake

`--head-start` demanded a committed segment. That only ever happened because the whole file was
available at once. It now asserts the thing that **was** actually broken — the head start ran and did
not give up — which is precisely what failed before, on every recording ever made.

Still proved both ways:

| | Result |
| --- | --- |
| Realistic arrival, fixed code | `"passed":true` |
| Overflow reintroduced | `abandoned on a clean fixture run…` |

File restored byte-identical after the mutation.

## What is now known to be unproven

**Nothing here shows the head start ever saves anybody time.** That needs a recording long enough to
contain a pause, and this repository has no such fixture. Stated plainly rather than left implied by a
green run — and it is a third reason to want #85's chunked corpus, alongside the two the issue already
gives.

`#96` has been corrected with the same account.

## Gates

Portable gate green: `verified: 1149 of 1149 tests ran.`

Part of #85