### PR TITLE
what a live preview pass costs is measured instead of reasoned about

### DIFF
--- a/docs/performance/windows-laptop-readiness.md
+++ b/docs/performance/windows-laptop-readiness.md
@@ -54,6 +54,29 @@ Automatic Parakeet therefore selected its tested quantized CPU path.
 | Parakeet / Whisper / preview cancellation | 165 / 596 / 603 ms | 2,000 ms |
 | Reliability cycles / handle delta | 1,000 / 9 | 1,000 / at most 12 |
 
+## The preview budget on this page and the preview cadence in the code disagree
+
+**Measured 2026-09-03 on the same rig, and this row needs re-deciding rather than re-running.** The
+budget above allows a preview update 5,000 ms through 20 seconds; #113 has since made the loop ask for
+one every 2,500 ms. So the run below passes this page and saturates the loop at the same time, and
+"preview latency passes" is true only against the older of the two numbers.
+
+Cost of one preview pass, whisper-small, the thread count `ConfigureLivePreview` picks, three real
+recordings, three runs each, median:
+
+| speech so far | 0.5 s | 1 s | 2.5 s | 5 s | 7.5 s | 10 s | 15 s | 20 s |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| card | 51 | 48 | 65 | 88 | 108 | 142 | 232 | 308 |
+| processor | 2,047 | 2,050 | 2,171 | 2,226 | 2,240 | 2,255 | 2,381 | 2,495 |
+
+**The two shortest columns are the point.** On the processor, half a second of speech costs 2,047 ms -
+82% of what twenty seconds costs. The cost is a floor, not a function of how long somebody has been
+speaking, so the loop on a processor runs a 2.0-2.5 second pass against a 2.5 second cadence with no
+headroom at any window length. On a card the same figures are a floor of 48 ms and growth to 308,
+which is an eighth of the cadence and reaches nobody.
+
+Reproduce with `tools/asr-incremental-spike`. Ref: #99.
+
 Parakeet, shell/runtime readiness, recording, cancellation, and repeated lifecycle pass on this machine.
 Whisper CPU final latency fails the provisional laptop budget even on this desktop. Its German language
 detection and Spanish public-fixture quality also failed in this run. Preview latency passes, French and

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -311,6 +311,12 @@ try {
     Write-Host "Building native Whisper UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/whisper-uat/EnviousWispr.Whisper.Uat.csproj", "-c", "Release", "--nologo")
 
+    # BUILT BY THE GATE THOUGH THE GATE CANNOT RUN IT. It needs a model pack and long recordings that
+    # are not in the repository, so it is a measuring instrument rather than a check. Compiling it here
+    # is what stops it rotting into something that cannot be pointed at the next question.
+    Write-Host "Building live-preview cost spike (Release)..."
+    Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/asr-incremental-spike/EnviousWispr.Asr.Incremental.Spike.csproj", "-c", "Release", "--nologo")
+
     Write-Host "Building production WinUI end-to-end journey UAT harness (Release)..."
     Invoke-DotNet -Executable $dotnet10Exe -Arguments @("build", "tools/app-journey-uat/EnviousWispr.AppJourney.Uat.csproj", "-c", "Release", "--nologo")
 

--- a/tools/asr-incremental-spike/EnviousWispr.Asr.Incremental.Spike.csproj
+++ b/tools/asr-incremental-spike/EnviousWispr.Asr.Incremental.Spike.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Core\EnviousWispr.Core.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.Services\EnviousWispr.Services.csproj" />
+    <ProjectReference Include="..\..\src\Production\EnviousWispr.RuntimeWorker\EnviousWispr.RuntimeWorker.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Target Name="CopyRuntimeWorker" AfterTargets="Build">
+    <ItemGroup>
+      <RuntimeWorkerFiles Include="..\..\src\Production\EnviousWispr.RuntimeWorker\bin\$(Configuration)\net10.0-windows10.0.26100.0\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RuntimeWorkerFiles)" DestinationFiles="@(RuntimeWorkerFiles->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/tools/asr-incremental-spike/Program.cs
+++ b/tools/asr-incremental-spike/Program.cs
@@ -1,0 +1,249 @@
+// WHAT THIS MEASURES, AND WHY IT IS SEPARATE FROM THE PRODUCT. Live preview re-transcribes the whole
+// window on every pass, so its cost is claimed to grow with how long somebody has been speaking - the
+// second of the three faults on #99. That claim is arithmetic about the decoder, not about our loop,
+// and #111 has already shown what happens when a decoder change is made from reasoning alone. This
+// runs the SAME model pack and thread count live preview runs, over real archived dictations, at the
+// window lengths the loop actually sees, and prints what it cost. It answers one question: does the
+// cost grow enough, inside the 20-second cap, to matter.
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Runtime;
+using EnviousWispr.Core.Settings;
+using EnviousWispr.Services.Runtime;
+
+const int sampleRate = 16_000;
+
+var repositoryRoot = ArgumentValue("--repo") ?? FindRepositoryRoot(AppContext.BaseDirectory);
+var audioDirectory = ArgumentValue("--audio") ?? Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+    "Envious Labs",
+    "EnviousWispr",
+    "audio-archive");
+var provider = args.Contains("cpu", StringComparer.OrdinalIgnoreCase)
+    ? RuntimeProviderKind.Cpu
+    : RuntimeProviderKind.Cuda;
+var repeats = int.TryParse(ArgumentValue("--repeats"), out var parsed) ? Math.Max(1, parsed) : 3;
+// NO PADDING, NO LOOPING, NO SYNTHESIS: A WINDOW IS ONLY MEASURED WHERE REAL AUDIO REACHES IT.
+// Looping a short take up to the window length was tried and thrown away. It produced a flat curve -
+// 83 ms at 20 seconds, the same as at 7.5 - and the transcripts said why: the decoder collapsed the
+// repetition and emitted the SAME 56-character sentence at both lengths. Decoder cost tracks tokens
+// emitted, so a tiled window measures a 20-second encode with a 7.5-second decode and understates
+// exactly the growth this exists to find. Give it a directory of genuinely long recordings instead.
+
+// THE LENGTHS THE LOOP ACTUALLY SEES. The loop starts a pass as soon as it holds 8,000 samples, so
+// half a second is a real window and not a synthetic one; the cadence is a 2.5-second floor and the
+// window is capped at 20, so a long dictation walks these and then stays at 20 for the rest of it.
+// THE TWO SHORTEST ROWS ARE THE CONTROL. If cost tracked how long somebody has been speaking, half a
+// second would be nearly free. Anything it costs there is a floor being paid on every pass whatever
+// the window, which is what tells a cost that grows apart from a cost that is simply large.
+double[] windowSeconds = [0.5, 1, 2.5, 5, 7.5, 10, 15, 20];
+
+var modelDirectory = Path.Combine(repositoryRoot, "models", "whisper-small");
+if (!Directory.Exists(modelDirectory))
+{
+    Console.Error.WriteLine($"The preview model pack is not at {modelDirectory}.");
+    return 2;
+}
+
+if (!Directory.Exists(audioDirectory))
+{
+    Console.Error.WriteLine($"There are no archived dictations at {audioDirectory}.");
+    return 2;
+}
+
+var clips = Directory.EnumerateFiles(audioDirectory, "*.wav")
+    .OrderBy(path => path, StringComparer.Ordinal)
+    .Select(path => new Clip(ShortName(path), ReadWaveFile(path)))
+    .Where(clip => clip.Samples.Length >= (int)(windowSeconds[0] * sampleRate))
+    .ToList();
+if (clips.Count == 0)
+{
+    Console.Error.WriteLine($"No archived dictation in {audioDirectory} is long enough to measure.");
+    return 2;
+}
+
+var worker = Path.Combine(AppContext.BaseDirectory, "EnviousWispr.RuntimeWorker.exe");
+// THE SAME THREAD COUNT LIVE PREVIEW USES, worked out the same way, because that number is half of
+// what the measurement is about. Ref: ConfigureLivePreview.
+var threads = Math.Clamp(Math.Max(1, Environment.ProcessorCount / 2), 2, 8);
+await using var engine = new RuntimeWorkerTranscriptionEngine(new RuntimeWorkerTranscriptionOptions(
+    worker,
+    modelDirectory,
+    provider,
+    ParakeetModelPack.Quantized,
+    IntraOpThreads: threads,
+    CpuFallbackThreads: threads,
+    StartupTimeout: TimeSpan.FromSeconds(30),
+    TranscriptionTimeout: TimeSpan.FromSeconds(120),
+    Engine: FinalAsrEngine.Whisper,
+    WhisperPack: WhisperModelPack.PreviewSmall,
+    Language: "auto",
+    CudaRuntimeDirectory: Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR")));
+
+var started = await engine.StartAsync();
+if (!started.Succeeded)
+{
+    Console.Error.WriteLine($"The preview engine did not start on {provider}: {started.Error}.");
+    return 3;
+}
+
+// DISCARDED ON PURPOSE. The first call through this engine pays for warm-up that no later pass pays,
+// and #91 was measured wrong once by keeping it.
+_ = await TranscribeAsync(engine, Prefix(clips[0].Samples, 2.5));
+
+var measurements = new List<Measurement>();
+foreach (var window in windowSeconds)
+{
+    foreach (var clip in clips)
+    {
+        var prefix = Prefix(clip.Samples, window);
+        if (prefix.Length < (int)(window * sampleRate))
+        {
+            continue;
+        }
+
+        for (var run = 0; run < repeats; run++)
+        {
+            var timer = Stopwatch.StartNew();
+            var transcript = await TranscribeAsync(engine, prefix);
+            timer.Stop();
+            measurements.Add(new Measurement(
+                clip.Name,
+                window,
+                run,
+                timer.ElapsedMilliseconds,
+                transcript.Text?.Trim() ?? string.Empty));
+        }
+    }
+}
+
+Console.WriteLine(
+    $"provider={provider} threads={threads} clips={clips.Count} " +
+    $"repeats={repeats}");
+Console.WriteLine();
+Console.WriteLine("window  clips  fastest  median  slowest   over the 2.5s cadence");
+foreach (var window in windowSeconds)
+{
+    var forWindow = measurements.Where(measurement => measurement.WindowSeconds == window).ToList();
+    if (forWindow.Count == 0)
+    {
+        continue;
+    }
+
+    var costs = forWindow.Select(measurement => measurement.Milliseconds).Order().ToList();
+    Console.WriteLine(string.Format(
+        CultureInfo.InvariantCulture,
+        "{0,5:0.0}s  {1,5}  {2,7}  {3,6}  {4,7}   {5} of {6}",
+        window,
+        forWindow.Select(measurement => measurement.Clip).Distinct().Count(),
+        costs[0],
+        costs[costs.Count / 2],
+        costs[^1],
+        costs.Count(cost => cost > 2_500),
+        costs.Count));
+}
+
+Console.WriteLine();
+Console.WriteLine(JsonSerializer.Serialize(measurements));
+return 0;
+
+// A NAME SHORT ENOUGH TO READ IN A TABLE, WITHOUT ASSUMING ONE. The archived dictations are named by
+// a 32-character id and the spike clips are named clip10; truncating to a fixed width threw on the
+// second directory this was ever pointed at.
+static string ShortName(string path)
+{
+    var name = Path.GetFileNameWithoutExtension(path);
+    return name.Length <= 8 ? name : name[..8];
+}
+
+static float[] Prefix(float[] samples, double seconds)
+{
+    var wanted = (int)(seconds * sampleRate);
+    return wanted >= samples.Length ? samples : samples[..wanted];
+}
+
+static Task<Transcript> TranscribeAsync(RuntimeWorkerTranscriptionEngine engine, float[] samples) =>
+    engine.TranscribeAsync(new CapturedAudio(
+        DictationSessionId.Create(),
+        samples,
+        sampleRate,
+        Channels: 1));
+
+string? ArgumentValue(string name)
+{
+    var index = Array.FindIndex(
+        args,
+        value => string.Equals(value, name, StringComparison.OrdinalIgnoreCase));
+    return index >= 0 && index + 1 < args.Length ? args[index + 1] : null;
+}
+
+static string FindRepositoryRoot(string start)
+{
+    var directory = new DirectoryInfo(start);
+    while (directory is not null &&
+        !Directory.Exists(Path.Combine(directory.FullName, ".git")) &&
+        !File.Exists(Path.Combine(directory.FullName, ".git")))
+    {
+        directory = directory.Parent;
+    }
+
+    return directory?.FullName ?? start;
+}
+
+static float[] ReadWaveFile(string path)
+{
+    var bytes = File.ReadAllBytes(path);
+    byte[]? format = null;
+    var position = 12;
+    while (position + 8 <= bytes.Length)
+    {
+        var chunkId = bytes.AsSpan(position, 4);
+        var chunkSize = BitConverter.ToInt32(bytes, position + 4);
+        position += 8;
+        if (chunkId.SequenceEqual("fmt "u8))
+        {
+            format = bytes.AsSpan(position, chunkSize).ToArray();
+        }
+        else if (chunkId.SequenceEqual("data"u8) && format is { Length: >= 16 })
+        {
+            var channels = BitConverter.ToInt16(format, 2);
+            var sourceRate = BitConverter.ToInt32(format, 4);
+            var bitsPerSample = BitConverter.ToInt16(format, 14);
+            var bytesPerSample = bitsPerSample / 8;
+            var sampleCount = chunkSize / bytesPerSample / channels;
+            var samples = new float[sampleCount];
+            for (var index = 0; index < sampleCount; index++)
+            {
+                var offset = position + (index * bytesPerSample * channels);
+                samples[index] = bitsPerSample switch
+                {
+                    16 => BitConverter.ToInt16(bytes, offset) / 32768f,
+                    32 => BitConverter.ToSingle(bytes, offset),
+                    _ => throw new InvalidDataException($"{path} uses an unsupported sample width."),
+                };
+            }
+
+            if (sourceRate != sampleRate)
+            {
+                throw new InvalidDataException($"{path} is {sourceRate} Hz, not {sampleRate} Hz.");
+            }
+
+            return samples;
+        }
+
+        position += chunkSize + (chunkSize % 2);
+    }
+
+    throw new InvalidDataException($"{path} has no supported audio data.");
+}
+
+internal sealed record Clip(string Name, float[] Samples);
+
+internal sealed record Measurement(
+    string Clip,
+    double WindowSeconds,
+    int Run,
+    long Milliseconds,
+    string Text);


### PR DESCRIPTION
Fault 2 of #99 proposes transcribing only the new audio, because the pass cost grows with how long
somebody has been speaking. **Measured, that fix cannot land where the problem is.**

One preview pass, whisper-small, the thread count `ConfigureLivePreview` picks, three real recordings
(10 s, 20 s and 91.5 s of continuous speech), three runs each, median ms:

| speech so far | 0.5 s | 1 s | 2.5 s | 5 s | 7.5 s | 10 s | 15 s | 20 s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| card | 51 | 48 | 65 | 88 | 108 | 142 | 232 | 308 |
| processor | 2,047 | 2,050 | 2,171 | 2,226 | 2,240 | 2,255 | 2,381 | 2,495 |

The two shortest columns are the control. On the processor half a second of speech costs 82% of what
twenty seconds costs, so only 448 ms of the 2,495 is growth; on a card the growth is most of the cost
and the whole pass is an eighth of the 2.5 second cadence. The fix helps where nobody feels it and
misses where it hurts.

## What this changes

- `tools/asr-incremental-spike` - the instrument, built by the gate and not runnable by it (needs a
  model pack and long recordings that are not in the repository).
- `docs/performance/windows-laptop-readiness.md` - records the measurement, and names the fact that
  its 5,000 ms preview budget predates the 2,500 ms cadence #113 set, so the build passes that page
  and saturates the loop at the same time. It does not re-baseline the budget; that is a decision.

## The version of the instrument that lied

Every archived dictation on this machine is under ten seconds, so the long windows were unreachable.
Looping a take to fill the window gave a **flat** curve - 83 ms at 20 seconds, same as 7.5 - and the
transcripts said why: the decoder collapsed the repetition and emitted the identical 56-character
sentence at both lengths. That measures a long encode with a short decode and understates exactly the
growth the tool exists to find. Deleted, with the reason left where the next person will reach for it.

It also crashed the first time it was pointed at a second directory: fixed-width clip names, and
`clip10` is six characters.

Gate green on this branch before this was opened: `Validation passed`, 1,149 of 1,149 tests ran.
