### PR TITLE
the app and the harness that judges it ask one question about CUDA

### DIFF
--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -1806,17 +1806,12 @@ public partial class App : Application, IAsyncDisposable
             Language: language));
     }
 
-    private static string? ResolveCudaRuntimeDirectory(string dataDirectory)
-    {
-        var configured = Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR");
-        if (!string.IsNullOrWhiteSpace(configured) && Directory.Exists(configured))
-        {
-            return Path.GetFullPath(configured);
-        }
-
-        var installed = Path.Combine(dataDirectory, "runtime", "cuda");
-        return Directory.Exists(installed) ? installed : null;
-    }
+    // MOVED TO CORE, UNCHANGED IN BEHAVIOUR, so the harnesses that judge this app can ask the same
+    // question and get the same answer. They used to read the environment variable alone, so on a
+    // machine with the runtime provisioned and the variable unset the app ran on the card while the
+    // gate reported that CUDA could not load. Ref: #129.
+    private static string? ResolveCudaRuntimeDirectory(string dataDirectory) =>
+        CudaRuntimeDirectory.ForApplication(dataDirectory);
 
     private string? ResolveModelDirectory(
         string modelId,

--- a/src/Production/EnviousWispr.Architecture.Tests/CudaRuntimeDirectoryTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/CudaRuntimeDirectoryTests.cs
@@ -1,0 +1,110 @@
+using EnviousWispr.Core.Runtime;
+
+namespace EnviousWispr.Architecture.Tests;
+
+public sealed class CudaRuntimeDirectoryTests
+{
+    private static Func<string, bool> Existing(params string[] directories) =>
+        candidate => directories.Contains(Path.GetFullPath(candidate), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void TheDefectThatWasReadAsAProductFault()
+    {
+        // THE EXACT SHAPE OF #45 AND #129. The runtime is provisioned under the data directory and the
+        // environment variable is unset. The app found it; the harness, reading the variable alone,
+        // did not - and reported that the product could not load CUDA on a machine where it could.
+        // One rule, so both get the same answer.
+        var data = Path.GetFullPath(Path.Combine("C:", "data"));
+        var installed = Path.Combine(data, "runtime", "cuda");
+
+        var resolved = CudaRuntimeDirectory.Resolve(
+            configured: null,
+            dataDirectories: [data],
+            directoryExists: Existing(installed));
+
+        Assert.Equal(installed, resolved);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NothingConfiguredAndNothingInstalledIsNoDirectory(string? configured)
+    {
+        var resolved = CudaRuntimeDirectory.Resolve(
+            configured,
+            dataDirectories: [Path.GetFullPath(Path.Combine("C:", "data"))],
+            directoryExists: Existing());
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void AConfiguredDirectoryWins()
+    {
+        var configured = Path.GetFullPath(Path.Combine("C:", "chosen"));
+        var data = Path.GetFullPath(Path.Combine("C:", "data"));
+        var installed = Path.Combine(data, "runtime", "cuda");
+
+        var resolved = CudaRuntimeDirectory.Resolve(
+            configured,
+            [data],
+            Existing(configured, installed));
+
+        Assert.Equal(configured, resolved);
+    }
+
+    [Fact]
+    public void AConfiguredDirectoryThatIsNotThereIsNotHonoured()
+    {
+        // POINTING SOMEWHERE EMPTY IS NOT AN ANSWER. Returning it would put the caller on a path with
+        // no files in it and call that success, which is the failure this type exists to stop.
+        var data = Path.GetFullPath(Path.Combine("C:", "data"));
+        var installed = Path.Combine(data, "runtime", "cuda");
+
+        var resolved = CudaRuntimeDirectory.Resolve(
+            configured: Path.GetFullPath(Path.Combine("C:", "missing")),
+            [data],
+            Existing(installed));
+
+        Assert.Equal(installed, resolved);
+    }
+
+    [Fact]
+    public void DataDirectoriesAreTriedInTheOrderGiven()
+    {
+        var first = Path.GetFullPath(Path.Combine("C:", "first"));
+        var second = Path.GetFullPath(Path.Combine("C:", "second"));
+        var secondInstalled = Path.Combine(second, "runtime", "cuda");
+
+        var resolved = CudaRuntimeDirectory.Resolve(
+            configured: null,
+            [first, second],
+            Existing(secondInstalled));
+
+        Assert.Equal(secondInstalled, resolved);
+    }
+
+    [Fact]
+    public void AnEmptyDataDirectoryInTheListIsSkippedRatherThanCombined()
+    {
+        // Path.Combine("", "runtime", "cuda") is a RELATIVE path, which Directory.Exists would then
+        // resolve against the process's working directory - a different machine's answer depending on
+        // where the harness was launched from.
+        var data = Path.GetFullPath(Path.Combine("C:", "data"));
+        var installed = Path.Combine(data, "runtime", "cuda");
+
+        var resolved = CudaRuntimeDirectory.Resolve(
+            configured: null,
+            ["", "  ", data],
+            Existing(installed));
+
+        Assert.Equal(installed, resolved);
+    }
+
+    [Fact]
+    public void TheApplicationRefusesToResolveWithoutADataDirectory()
+    {
+        Assert.Throws<ArgumentException>(() => CudaRuntimeDirectory.ForApplication("  "));
+    }
+}

--- a/src/Production/EnviousWispr.Core/Runtime/CudaRuntimeDirectory.cs
+++ b/src/Production/EnviousWispr.Core/Runtime/CudaRuntimeDirectory.cs
@@ -1,0 +1,106 @@
+using EnviousWispr.Core.Distribution;
+
+namespace EnviousWispr.Core.Runtime;
+
+/// <summary>
+/// Where the CUDA runtime files live, answered the same way for the app and for the harnesses that
+/// judge it.
+/// </summary>
+/// <remarks>
+/// ONE ANSWER, BECAUSE TWO ANSWERS WERE READ AS A PRODUCT DEFECT. The app looked in the environment
+/// variable and then in its own data directory; the acceptance harnesses looked only at the variable.
+/// So on a machine where the runtime had been provisioned but the variable was unset, the app selected
+/// and ran on the card while the gate reported that CUDA could not load - and #45 was filed on that
+/// output, against the product, for a fault that was in the measurement. A gate that fails where the
+/// product succeeds teaches people to ignore it. Ref: #129.
+/// </remarks>
+public static class CudaRuntimeDirectory
+{
+    public const string EnvironmentVariable = "ENVIOUSWISPR_CUDA_RUNTIME_DIR";
+    public const string DataDirectoryVariable = "ENVIOUSWISPR_DATA_DIRECTORY";
+
+    private const string RuntimeFolder = "runtime";
+    private const string CudaFolder = "cuda";
+
+    /// <summary>
+    /// The rule itself, with nothing read from the machine, so it can be tested without one.
+    /// </summary>
+    /// <remarks>
+    /// AN EXPLICIT SETTING WINS EVEN WHEN IT IS WRONG, ONLY IF IT EXISTS. A configured directory that
+    /// is not there is not honoured: it would put the caller on a path with no files in it and report
+    /// success, which is the failure this whole type exists to stop.
+    /// </remarks>
+    public static string? Resolve(
+        string? configured,
+        IEnumerable<string> dataDirectories,
+        Func<string, bool> directoryExists)
+    {
+        ArgumentNullException.ThrowIfNull(dataDirectories);
+        ArgumentNullException.ThrowIfNull(directoryExists);
+        if (!string.IsNullOrWhiteSpace(configured) && directoryExists(configured))
+        {
+            return Path.GetFullPath(configured);
+        }
+
+        foreach (var dataDirectory in dataDirectories)
+        {
+            if (string.IsNullOrWhiteSpace(dataDirectory))
+            {
+                continue;
+            }
+
+            var candidate = Path.Combine(dataDirectory, RuntimeFolder, CudaFolder);
+            if (directoryExists(candidate))
+            {
+                return Path.GetFullPath(candidate);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// What the running app uses: its own data directory and nothing else's.
+    /// </summary>
+    public static string? ForApplication(string dataDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
+        return Resolve(
+            Environment.GetEnvironmentVariable(EnvironmentVariable),
+            [dataDirectory],
+            Directory.Exists);
+    }
+
+    /// <summary>
+    /// What a harness uses, which has no data directory of its own.
+    /// </summary>
+    /// <remarks>
+    /// EVERY CHANNEL, IN A FIXED ORDER, because a development machine may have a stable install, a
+    /// founder install, or both, and a harness that guessed one would fail on the other for a reason
+    /// nobody could read. This is deliberately NOT what the app does: the app knows which channel it
+    /// is and must never reach into another one's folder.
+    /// </remarks>
+    public static string? ForTooling() => Resolve(
+        Environment.GetEnvironmentVariable(EnvironmentVariable),
+        ToolingDataDirectories(),
+        Directory.Exists);
+
+    private static IEnumerable<string> ToolingDataDirectories()
+    {
+        var configured = Environment.GetEnvironmentVariable(DataDirectoryVariable);
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            yield return configured;
+        }
+
+        var localApplicationData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData);
+        foreach (var channel in Enum.GetValues<ReleaseChannel>())
+        {
+            yield return Path.Combine(
+                localApplicationData,
+                "Envious Labs",
+                ReleaseIdentity.For(channel).DataDirectoryName);
+        }
+    }
+}

--- a/tools/app-journey-uat/Program.cs
+++ b/tools/app-journey-uat/Program.cs
@@ -709,7 +709,7 @@ try
         throw new JourneyExpectationException("The production journey left an owned local-polish worker running.");
     }
 
-    var hardware = await new WindowsHardwareDiscovery().ProbeAsync();
+    var hardware = await new WindowsHardwareDiscovery(CudaRuntimeDirectory.ForTooling()).ProbeAsync();
     string provider;
     string modelPack;
     if (englishParakeet)

--- a/tools/asr-incremental-spike/Program.cs
+++ b/tools/asr-incremental-spike/Program.cs
@@ -80,7 +80,7 @@ await using var engine = new RuntimeWorkerTranscriptionEngine(new RuntimeWorkerT
     Engine: FinalAsrEngine.Whisper,
     WhisperPack: WhisperModelPack.PreviewSmall,
     Language: "auto",
-    CudaRuntimeDirectory: Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR")));
+    CudaRuntimeDirectory: CudaRuntimeDirectory.ForTooling()));
 
 var started = await engine.StartAsync();
 if (!started.Succeeded)

--- a/tools/asr-uat/Program.cs
+++ b/tools/asr-uat/Program.cs
@@ -38,7 +38,7 @@ var cuda = requestedProvider is null or "cuda"
             RuntimeProviderKind.Cuda,
             ParakeetModelPack.FullPrecision,
             IntraOpThreads: 1,
-            CudaRuntimeDirectory: Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR")),
+            CudaRuntimeDirectory: CudaRuntimeDirectory.ForTooling()),
         clips)
     : null;
 var isolated = requestedProvider is null or "cuda"
@@ -62,7 +62,7 @@ static async Task<IsolatedResult> RunIsolatedAsync(
         "Release",
         "net10.0-windows10.0.26100.0",
         "EnviousWispr.RuntimeWorker.exe");
-    var cudaRuntimeDirectory = Environment.GetEnvironmentVariable("ENVIOUSWISPR_CUDA_RUNTIME_DIR");
+    var cudaRuntimeDirectory = CudaRuntimeDirectory.ForTooling();
     await using var engine = new RuntimeWorkerTranscriptionEngine(new RuntimeWorkerTranscriptionOptions(
         workerExecutable,
         modelDirectory,

--- a/tools/compatibility-uat/Program.cs
+++ b/tools/compatibility-uat/Program.cs
@@ -9,7 +9,7 @@ using EnviousWispr.Services.Runtime;
 using Microsoft.Win32;
 
 var outputPath = ArgumentValue(args, "--output");
-var hardware = await new WindowsHardwareDiscovery().ProbeAsync();
+var hardware = await new WindowsHardwareDiscovery(CudaRuntimeDirectory.ForTooling()).ProbeAsync();
 using var deviceCatalog = new WasapiDeviceCatalog();
 var captureDevices = await deviceCatalog.GetCaptureDevicesAsync();
 var operatingSystem = Environment.OSVersion.Version;

--- a/tools/runtime-uat/Program.cs
+++ b/tools/runtime-uat/Program.cs
@@ -9,7 +9,7 @@ var repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
 var modelDirectory = Path.Combine(repositoryRoot, "models", "parakeet-tdt-0.6b-v3");
 var workerExecutable = Path.Combine(AppContext.BaseDirectory, "EnviousWispr.RuntimeWorker.exe");
 
-var hardware = await new WindowsHardwareDiscovery().ProbeAsync();
+var hardware = await new WindowsHardwareDiscovery(CudaRuntimeDirectory.ForTooling()).ProbeAsync();
 var models = new LocalParakeetModelProbe().Probe(modelDirectory);
 var selection = ParakeetRuntimeSelector.Select(hardware, models);
 

--- a/tools/whisper-uat/Program.cs
+++ b/tools/whisper-uat/Program.cs
@@ -94,8 +94,7 @@ static async Task<ProviderResult> RunProviderAsync(
         Engine: FinalAsrEngine.Whisper,
         WhisperPack: modelPack,
         Language: "auto",
-        CudaRuntimeDirectory: Environment.GetEnvironmentVariable(
-            "ENVIOUSWISPR_CUDA_RUNTIME_DIR")));
+        CudaRuntimeDirectory: CudaRuntimeDirectory.ForTooling()));
 
     var loadTimer = Stopwatch.StartNew();
     var started = await engine.StartAsync();
@@ -191,8 +190,7 @@ static async Task<IReadOnlyList<LanguageResult>> RunFixedLanguageDiagnosticsAsyn
             Engine: FinalAsrEngine.Whisper,
             WhisperPack: modelPack,
             Language: language,
-            CudaRuntimeDirectory: Environment.GetEnvironmentVariable(
-                "ENVIOUSWISPR_CUDA_RUNTIME_DIR")));
+            CudaRuntimeDirectory: CudaRuntimeDirectory.ForTooling()));
         var started = await engine.StartAsync();
         if (!started.Succeeded)
         {


### PR DESCRIPTION
Closes #129.

`ResolveCudaRuntimeDirectory` in the app took `ENVIOUSWISPR_CUDA_RUNTIME_DIR` and then fell back to its
own data directory under `runtime/cuda`. `tools/asr-uat`, `tools/whisper-uat`, `tools/runtime-uat`,
`tools/compatibility-uat` and `tools/app-journey-uat` read the variable and nothing else.

**So the gate failed where the product succeeded, and #45 was filed on that output** — against the
product, for a fault that was in the measurement.

## Proved on the machine, not argued

`tools/runtime-uat`, no environment variable set, before and after:

| | `onnxRuntimeCudaDependencies` |
| --- | --- |
| before | `false` — reported the card unusable |
| after | **`true`** — finds the provisioned runtime, same as the app |

## What is here

- `CudaRuntimeDirectory` in Core holds the rule once. `Resolve` is pure — it takes the configured value,
  the candidate data directories and a `directoryExists` predicate — so the rule is tested without a
  machine. `ForApplication` uses the app's own data directory **and nothing else's**; `ForTooling` walks
  every release channel, because a development box may carry a stable install, a founder install or
  both, and a harness that guessed one would fail on the other for a reason nobody could read.
- A configured directory that does not exist is **not** honoured. Returning it would put the caller on a
  path with no files in it and call that success, which is the failure this type exists to stop.
- Nine tests, one named after the exact defect. Putting the old environment-variable-only behaviour back
  turns **four** of them red, including that one.

No path is reported anywhere: the compatibility report states it records no paths, and a path under the
user profile carries the account name.

Gate green on this branch: `Validation passed`, 1,158 of 1,158 tests ran.
