### PR TITLE
two gates that could fail green now ask the parser instead of the text

### DIFF
--- a/src/Production/EnviousWispr.Architecture.Tests/DesignSystemTokenTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/DesignSystemTokenTests.cs
@@ -884,31 +884,43 @@ public sealed partial class DesignSystemTokenTests
         var shell = File.ReadAllText(Path.Combine(
             FindRepositoryRoot(), "src", "Production", "EnviousWispr.App", "App.xaml.cs"));
 
-        var unscoped = new List<string>();
-        var flows = 0;
-        foreach (Match match in DictationFlowRegex().Matches(shell))
-        {
-            flows++;
-            var body = shell[match.Index..];
-            var stop = body.IndexOf("\n    private ", 20, StringComparison.Ordinal);
-            if (stop > 0)
-            {
-                body = body[..stop];
-            }
+        // THE PARSER DECIDES WHAT A FLOW IS, BECAUSE THE REGEX FAILED GREEN. It required the exact
+        // text `private async Task`, and C# lets a method carry its modifiers in any order with any
+        // trivia between them, so ONE extra valid modifier hid a whole flow while the floor below
+        // still counted five and passed. A method that never opened a scope would have read as
+        // ABSENT rather than as unscoped, which is the one outcome a check must never have. Ref: #82.
+        //
+        //     private static async Task HandleAsync(DictationSessionId sessionId) { ... }
+        var methods = DictationFlows(shell);
 
+        var unscoped = new List<string>();
+        var flows = methods.Length;
+        foreach (var method in methods)
+        {
             // THE SCOPE MUST BE OPENED BEFORE THE FLOW LOGS ANYTHING, which is the property that
             // actually matters and needs no window at all. Two earlier drafts guessed at one - six
             // hundred characters, then eight lines - and a reviewer pointed out that a longer
             // signature, a blank line or a block comment moves a correct scope past either. A
             // window is a proxy; this is the thing itself.
             //
+            // COMPARED AS CALLS RATHER THAN AS TEXT, which closes the false alarm the old version
+            // admitted to in its own remarks: `_logger.Write(` written inside a comment or a string
+            // counted as the flow logging, and would have accused a correctly scoped method.
+            //
             // A flow that never logs is fine either way, and is required to open one anyway,
             // because the next line added to it will be a log line.
-            var firstWrite = body.IndexOf("_logger.Write(", StringComparison.Ordinal);
-            var opening = firstWrite > 0 ? body[..firstWrite] : body;
-            if (!opening.Contains("DictationScope.Begin(", StringComparison.Ordinal))
+            var calls = ((SyntaxNode?)method.Body ?? method.ExpressionBody)
+                ?.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .ToArray() ?? [];
+            var firstWrite = calls.FirstOrDefault(call => call.Expression.ToString()
+                .EndsWith("_logger.Write", StringComparison.Ordinal));
+            var opensScope = calls.FirstOrDefault(call => call.Expression.ToString()
+                .EndsWith("DictationScope.Begin", StringComparison.Ordinal));
+            if (opensScope is null ||
+                (firstWrite is not null && opensScope.SpanStart > firstWrite.SpanStart))
             {
-                unscoped.Add(match.Groups[1].Value);
+                unscoped.Add(method.Identifier.ValueText);
             }
         }
 
@@ -921,16 +933,89 @@ public sealed partial class DesignSystemTokenTests
             "These methods are handed a dictation and never open its scope, so every line they "
                 + "write is joined to nothing: " + string.Join(", ", unscoped));
     }
+    /// <summary>Every method the shell has that is handed a dictation and awaits under it.</summary>
+    /// <remarks>
+    /// A METHOD RATHER THAN AN INLINE QUERY SO THE RULE CAN BE PROVED. The shapes that broke the
+    /// regex this replaces do not appear in the repository, so a gate exercised only against the
+    /// real file cannot show it is better than what it replaced. This is called both by the gate
+    /// and by proofs written against source that exists nowhere else.
+    /// </remarks>
+    private static MethodDeclarationSyntax[] DictationFlows(string code) =>
+        CSharpSyntaxTree.ParseText(code).GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(method =>
+                method.Modifiers.Any(SyntaxKind.PrivateKeyword) &&
+                method.Modifiers.Any(SyntaxKind.AsyncKeyword) &&
+                ReturnsTask(method.ReturnType) &&
+                method.ParameterList.Parameters.Any(parameter =>
+                    parameter.Type is IdentifierNameSyntax
+                    {
+                        Identifier.ValueText: "DictationSessionId",
+                    }))
+            .ToArray();
 
-    /// <summary>A method that takes a dictation and does work under it.</summary>
+    /// <summary>A flow is found however its signature is written.</summary>
+    /// <remarks>
+    /// THREE OF THESE SIX WERE INVISIBLE YESTERDAY, checked by running the old pattern against
+    /// them rather than assumed: a modifier in front of `async` (A), a qualified return type (B),
+    /// and modifiers split across lines (D). The regex required the literal text
+    /// `private async Task`. A hidden method is not reported as unscoped - it is not reported at
+    /// all, and the floor below still counted five and passed. Ref: #82.
+    ///
+    /// THE OTHER THREE ARE NOT MISSES AND ARE HERE ON PURPOSE. C, E and F were already matched, so
+    /// they are what proves the parser did not BUY the three above by dropping shapes the pattern
+    /// used to catch. A rewrite that trades one blind spot for another looks identical to a fix.
+    /// </remarks>
+    [Theory]
+    [InlineData("private static async Task A(DictationSessionId id) { }")]
+    [InlineData("private async System.Threading.Tasks.Task B(DictationSessionId id) { }")]
+    [InlineData("private async Task<int> C(DictationSessionId id) { return 0; }")]
+    [InlineData("private|async|Task D(DictationSessionId id) { }")]
+    [InlineData("private async Task E(|DictationSessionId id) { }")]
+    [InlineData("private async Task F(string first, DictationSessionId id) { }")]
+    public void AFlowIsFoundHoweverItsSignatureIsWritten(string declaration)
+    {
+        // The bar stands for a line break: a signature split across lines is one of the shapes
+        // the pattern this replaces could not see, and it cannot be written inside an attribute.
+        var found = DictationFlows("class C { " + declaration.Replace('|', '\n') + " }");
+
+        Assert.Single(found);
+    }
+
+    /// <summary>A method that only starts a flow is not one, and neither is a stranger.</summary>
+    /// <remarks>
+    /// THE CONTROL. Without it, a finder that matched every method would satisfy every row above
+    /// and prove nothing at all.
+    /// </remarks>
+    [Theory]
+    [InlineData("private Task Starts(DictationSessionId id) => Task.CompletedTask;")]
+    [InlineData("public async Task NotPrivate(DictationSessionId id) { }")]
+    [InlineData("private async void NotATask(DictationSessionId id) { }")]
+    [InlineData("private async Task NoDictation(string id) { }")]
+    public void SomethingThatIsNotAFlowIsNotFound(string declaration)
+    {
+        Assert.Empty(DictationFlows("class C { " + declaration + " }"));
+    }
+
+    /// <summary>Whether a method returns a Task, however that Task is written.</summary>
     /// <remarks>
     /// `async` is the discriminator between a flow and a starter. A method that merely kicks one
     /// off is synchronous here and passes the id on; the ones that log under it are the ones that
     /// await.
+    ///
+    /// SYNTAX, NOT SEMANTICS, AND THE DIFFERENCE IS WRITTEN DOWN RATHER THAN IMPLIED. This believes
+    /// any type spelled `Task`, so a different `Task` brought in by a using directive would be
+    /// accepted, and a task-like type under another name would be missed. Closing that needs a
+    /// semantic model - #82.
     /// </remarks>
-    [GeneratedRegex(@"private async Task(?:<[^>]+>)? (\w+)\([^)]*DictationSessionId ",
-        RegexOptions.Singleline | RegexOptions.CultureInvariant)]
-    private static partial Regex DictationFlowRegex();
+    private static bool ReturnsTask(TypeSyntax returnType) => returnType switch
+    {
+        IdentifierNameSyntax name => name.Identifier.ValueText == "Task",
+        GenericNameSyntax generic => generic.Identifier.ValueText == "Task",
+        QualifiedNameSyntax qualified => ReturnsTask(qualified.Right),
+        _ => false,
+    };
 
     /// <summary>The journey harness reports its own failures instead of crashing.</summary>
     /// <remarks>

--- a/src/Production/EnviousWispr.Architecture.Tests/TranscriptionEngineNameTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/TranscriptionEngineNameTests.cs
@@ -1013,7 +1013,7 @@ public sealed partial class DesignSystemTokenTests
         // and nowhere else.
         //
         // So: strip that one array, and ask whether the name survives anywhere in the file.
-        var reachableCode = SettingsSectionsArray().Replace(code, string.Empty);
+        var reachableCode = CodeWithoutTheHideList(code);
 
         var unreachable = sections
             .Where(section => !reachableCode.Contains(section, StringComparison.Ordinal))
@@ -1873,13 +1873,91 @@ public sealed partial class DesignSystemTokenTests
     [GeneratedRegex(@"x:Name=""(\w+Section)""")]
     private static partial Regex SectionName();
 
+    /// <summary>The hide list is removed however its declaration is written.</summary>
+    /// <remarks>
+    /// THREE OF THESE FIVE WERE INVISIBLE YESTERDAY, checked by running the old pattern against
+    /// them rather than assumed: a comment between the parameter list and the arrow, a block body
+    /// instead of an expression body, and the property form with no parameter list. The pattern
+    /// required `SettingsSections() =>` with nothing but whitespace between. When it missed, the
+    /// hide list stayed in the text, every section name inside it read as reached - including an
+    /// orphaned one - and the gate passed. Ref: #82.
+    ///
+    /// THE OTHER TWO ALREADY MATCHED AND ARE HERE AS THE CONTROL, so a rewrite that traded one
+    /// blind spot for another could not pass as a fix.
+    /// </remarks>
+    [Theory]
+    [InlineData("private Border[] SettingsSections() /* inventory */ => [ PrivacySection ];")]
+    [InlineData("private Border[] SettingsSections() => [ PrivacySection ];")]
+    [InlineData("private Border[] SettingsSections()|    {|        return [ PrivacySection ];|    }")]
+    [InlineData("private Border[] SettingsSections => [ PrivacySection ];")]
+    [InlineData("private System.Collections.Generic.List<Border> SettingsSections() => [ PrivacySection ];")]
+    public void TheHideListIsRemovedHoweverItIsWritten(string declaration)
+    {
+        var code = "class C { " + declaration.Replace('|', '\n') + " void Other() { } }";
+
+        var remaining = CodeWithoutTheHideList(code);
+
+        Assert.DoesNotContain("PrivacySection", remaining, StringComparison.Ordinal);
+        // The control: it removed the hide list and not the whole file.
+        Assert.Contains("void Other()", remaining, StringComparison.Ordinal);
+    }
+
+    /// <summary>A hide list that is not there stops the gate rather than emptying it.</summary>
+    /// <remarks>
+    /// UNDER THE PATTERN THIS REPLACES, NOT FINDING IT REMOVED NOTHING AND THE TEST STILL PASSED.
+    /// A check whose own blindness is indistinguishable from the property holding is worse than no
+    /// check, because it is counted as coverage.
+    /// </remarks>
+    [Fact]
+    public void AMissingHideListFailsLoudly()
+    {
+        Assert.ThrowsAny<Exception>(() => CodeWithoutTheHideList("class C { void Other() { } }"));
+    }
+
     /// <summary>
-    /// The array the settings page iterates in order to HIDE sections.
+    /// The window's code with the hide-list member removed, so a name left only there does not
+    /// count as reached.
     /// </summary>
     /// <remarks>
-    /// The one place a section name appears without showing anything, which is why an orphaned
-    /// section is invisible to a plain search: it sits here and nowhere else.
+    /// ASKS THE PARSER WHERE THE MEMBER IS, BECAUSE THE REGEX THAT DID THIS FAILED GREEN. It
+    /// matched `SettingsSections\(\) =>\s*\[[^\]]*\]`, and C# allows trivia between every one of
+    /// those parts - a comment between the parameter list and the arrow was enough to leave the
+    /// hide list in the text. The gate then found every section name inside the array it had
+    /// failed to remove, concluded all of them were reachable, and passed. An orphaned section
+    /// would have read as used, which is the exact defect this test exists to catch. Ref: #82.
+    ///
+    /// ```csharp
+    /// private Border[] SettingsSections() /* inventory */ => [ PrivacySection ];
+    /// ```
+    ///
+    /// A MISSING MEMBER NOW FAILS LOUDLY. Under the regex, not finding the declaration removed
+    /// nothing and the test still passed; the one outcome a check must never have is that its own
+    /// blindness looks like the property holding.
+    ///
+    /// LIMIT, STATED RATHER THAN IMPLIED: this is syntax, not semantics. It finds the member by
+    /// NAME, so a second member of the same name in a partial class elsewhere is not considered,
+    /// and a hide list built somewhere other than a member called `SettingsSections` is not seen.
+    /// The durable fix for that whole class is an analyser with a semantic model - #82.
     /// </remarks>
-    [GeneratedRegex(@"SettingsSections\(\) =>\s*\[[^\]]*\]", RegexOptions.Singleline)]
-    private static partial Regex SettingsSectionsArray();
+    private static string CodeWithoutTheHideList(string code)
+    {
+        var root = CSharpSyntaxTree.ParseText(code).GetRoot();
+        var declaration = root.DescendantNodes()
+            .FirstOrDefault(node => node switch
+            {
+                MethodDeclarationSyntax method =>
+                    method.Identifier.ValueText == "SettingsSections",
+                PropertyDeclarationSyntax property =>
+                    property.Identifier.ValueText == "SettingsSections",
+                _ => false,
+            });
+
+        Assert.True(
+            declaration is not null,
+            "The window has no SettingsSections member. Either it was renamed - in which case this "
+                + "test no longer removes the hide list and would call an orphaned section reached - "
+                + "or the hide list is gone and this test should be too.");
+
+        return code.Remove(declaration!.FullSpan.Start, declaration.FullSpan.Length);
+    }
 }


### PR DESCRIPTION
Part of #82 — the two gates it ranks as the dangerous ones, because their failures are **silent green**.

## Which shapes were actually invisible, run rather than assumed

| gate | shapes tried | old pattern missed |
| --- | ---: | --- |
| hide list (`SettingsSectionsArray`) | 5 | comment before the arrow; block body; property form |
| dictation flow (`DictationFlowRegex`) | 6 | modifier before `async`; qualified return type; modifiers split across lines |

When the hide-list pattern missed, the array stayed in the text, so **every section name inside it read
as reached — an orphaned one included**, and the test passed. When the flow pattern missed, the method
was not reported as unscoped; it was not reported at all, and the floor of five still passed.

## What changed

- Both find their declarations with `CSharpSyntaxTree`, so trivia between any two parts is irrelevant.
- **A hide list that cannot be found now stops the test.** Under the regex, not finding it removed
  nothing and the test still passed — a check whose own blindness is indistinguishable from the
  property holding is worse than no check, because it is counted as coverage.
- The flow gate compares **calls** rather than text, closing the false alarm its own remarks admitted
  to: `_logger.Write(` inside a comment or a string used to count as the flow logging, which would have
  accused a correctly scoped method.
- The finder is a method rather than an inline query, because the shapes that broke the regex do not
  appear in this repository — a gate exercised only against the real file cannot show it improved.

## The rows that already matched are kept on purpose

Three of the six flow rows and two of the five hide-list rows were never misses. They are the control: a
rewrite that trades one blind spot for another looks identical to a fix without them.

## What this does not do

Three gates in the same class remain, all of which fail **loudly**, and the durable fix #82 asks for — a
Roslyn analyser with a semantic model, making the mistake impossible to write rather than reported
afterwards — is untouched. Both new helpers state in their own remarks that they are syntax and not
semantics, and what that leaves unseen: a different `Task` brought in by a using directive, a task-like
type under another name, a hide list built somewhere other than a member of that name.

Gate green on this branch: `Validation passed`, 1,174 of 1,174 tests ran.
