### PR TITLE
an overlay shot has to photograph the overlay

### DIFF
--- a/tools/ui-capture/capture-window.ps1
+++ b/tools/ui-capture/capture-window.ps1
@@ -1,0 +1,99 @@
+# Photograph a window's OWN pixels, not the screen it happens to be on. RUNS IN THE LOGGED-IN SESSION.
+#
+# WHY THIS EXISTS BESIDE session-run.ps1. That script grabs the SCREEN, so an overlay shot is a
+# photograph of whatever is in front of the overlay. The first attempt to photograph the recording
+# pill returned a music player, because somebody's music player was on top of it - and nothing in the
+# capture could say so, which is the occlusion limit probe-ui.ps1 already declares. PrintWindow asks
+# the window to draw ITSELF into a bitmap, so the result is the pill whatever the z-order, and it
+# needs nobody's desktop cleared.
+#
+# ITS OWN LIMIT, STATED: this is what the window RENDERS, not what the screen SHOWS. It cannot tell
+# you the pill was legible over somebody's document, because the document is not in the picture. Use
+# it to judge the pill itself; use a screen grab to judge the pill in company.
+#
+# THE TRANSIENT SEVERITIES NEED A SHORT SETTLE. A notice with no action dismisses itself on its dwell,
+# so a six-second settle photographs nothing and reports no window at all. The advisory keeps its pill
+# because it carries a button. 1500 ms catches the rest.
+param(
+    [Parameter(Mandatory = $true)][string] $AppExe,
+    [Parameter(Mandatory = $true)][string] $OverlayState,
+    [Parameter(Mandatory = $true)][string] $OutputPath,
+    [Parameter(Mandatory = $true)][string] $DataDirectory,
+    [string] $WindowTitleMatch = 'dictation status',
+    [int] $SettleMilliseconds = 1500
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Drawing
+Add-Type @"
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+public static class Shot {
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr dc, uint flags);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr p);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetWindowTextW(IntPtr h, StringBuilder s, int n);
+  public delegate bool EnumProc(IntPtr h, IntPtr p);
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int Left, Top, Right, Bottom; }
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr ctx);
+}
+"@
+
+# WITHOUT THIS THE PICTURE IS A CROP THAT LOOKS LIKE A LAYOUT FAULT. Windows PowerShell is not
+# per-monitor DPI aware, so GetWindowRect returns virtualised DIP - 380x150 for a window rendering
+# at 570x225 - and PrintWindow then draws the real pixels into a bitmap two thirds the size. What
+# came back was the top-left of the pill with the body text running off the right edge and the
+# button below the frame, which reads exactly like clipped content and was the instrument.
+# -4 is DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2.
+if (-not [Shot]::SetProcessDpiAwarenessContext([IntPtr](-4))) {
+    throw "Could not take per-monitor DPI awareness, so every measurement here would be silently scaled."
+}
+
+$env:ENVIOUSWISPR_DATA_DIRECTORY = $DataDirectory
+$env:ENVIOUSWISPR_UAT_OVERLAY_STATE = $OverlayState
+$env:ENVIOUSWISPR_UAT_EXIT_AFTER_MILLISECONDS = $SettleMilliseconds + 6000
+
+$app = Start-Process -FilePath $AppExe -PassThru
+Start-Sleep -Milliseconds $SettleMilliseconds
+
+$target = [IntPtr]::Zero
+$rect = New-Object Shot+RECT
+$callback = [Shot+EnumProc] {
+    param($h, $p)
+    $owner = 0
+    $null = [Shot]::GetWindowThreadProcessId($h, [ref] $owner)
+    if ($owner -ne $app.Id -or -not [Shot]::IsWindowVisible($h)) { return $true }
+    $title = New-Object System.Text.StringBuilder 200
+    $null = [Shot]::GetWindowTextW($h, $title, $title.Capacity)
+    if ($title.ToString() -notmatch $WindowTitleMatch) { return $true }
+    $script:target = $h
+    return $false
+}
+$null = [Shot]::EnumWindows($callback, [IntPtr]::Zero)
+
+if ($script:target -eq [IntPtr]::Zero) {
+    Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
+    throw "No window matching '$WindowTitleMatch' for overlay state '$OverlayState'. A transient notice may have dismissed itself already - try a shorter settle."
+}
+
+$null = [Shot]::GetWindowRect($script:target, [ref] $rect)
+$width = $rect.Right - $rect.Left
+$height = $rect.Bottom - $rect.Top
+Write-Host "window ${width}x${height} at $($rect.Left),$($rect.Top)"
+
+$bitmap = New-Object System.Drawing.Bitmap $width, $height
+$graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+$dc = $graphics.GetHdc()
+# 2 = PW_RENDERFULLCONTENT, which is what makes this work for a composited window.
+$ok = [Shot]::PrintWindow($script:target, $dc, 2)
+$graphics.ReleaseHdc($dc)
+$graphics.Dispose()
+$bitmap.Save($OutputPath, [System.Drawing.Imaging.ImageFormat]::Png)
+$bitmap.Dispose()
+Write-Host "PrintWindow returned $ok -> $OutputPath"
+
+Start-Sleep -Seconds 8
+if (-not $app.HasExited) { Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue }

--- a/tools/ui-capture/session-run.ps1
+++ b/tools/ui-capture/session-run.ps1
@@ -109,18 +109,32 @@ public static class UiCaptureWindows {
     // MOVED, NEVER RESIZED. The size is the app's own answer and is one of the things being
     // measured; only where it sits is the tool's business.
     public static string Anchor(uint target) {
+        // THE MAIN WINDOW ONLY, BY NAME, AND THIS IS THE WHOLE POINT OF THE REWRITE. This used to
+        // move EVERY visible window of the process bigger than 200x200. The recording pill is
+        // 570x225, so it qualified, and an overlay shot therefore moved the pill to 0,0 and then
+        // moved the main window to 0,0 ON TOP OF IT. Both windows reported [0,0] in the automation
+        // tree - which reads like an unpositioned overlay and was actually this tool stacking them -
+        // and the photograph showed the main window where the pill was supposed to be. The run then
+        // published SUCCESS, because its success test is that SOME visible window exists.
+        //
+        // It also destroyed the thing an overlay shot exists to show: where the overlay actually
+        // sits is a user setting, and moving it to the corner answers a question nobody asked.
+        //
+        // Selected by NAME rather than by size, for the same reason the design system already
+        // requires it of UIA lookups: this app has two top-level windows and picking by a property
+        // they share picks the wrong one silently.
         var moved = "no window to move";
         EnumWindows((h, p) => {
             uint pid; GetWindowThreadProcessId(h, out pid);
-            if (pid == target && IsWindowVisible(h)) {
-                RECT r; GetWindowRect(h, out r);
-                if (r.Right - r.Left > 200 && r.Bottom - r.Top > 200) {
-                    // SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE
-                    SetWindowPos(h, IntPtr.Zero, 0, 0, 0, 0, 0x0001 | 0x0004 | 0x0010);
-                    moved = string.Format("moved {0}x{1} from {2},{3} to 0,0",
-                        r.Right - r.Left, r.Bottom - r.Top, r.Left, r.Top);
-                }
-            }
+            if (pid != target || !IsWindowVisible(h)) { return true; }
+            var title = new System.Text.StringBuilder(200);
+            GetWindowTextW(h, title, title.Capacity);
+            if (title.ToString() != "EnviousWispr") { return true; }
+            RECT r; GetWindowRect(h, out r);
+            // SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE
+            SetWindowPos(h, IntPtr.Zero, 0, 0, 0, 0, 0x0001 | 0x0004 | 0x0010);
+            moved = string.Format("moved {0}x{1} from {2},{3} to 0,0",
+                r.Right - r.Left, r.Bottom - r.Top, r.Left, r.Top);
             return true;
         }, IntPtr.Zero);
         return moved;
@@ -203,6 +217,39 @@ Add-Type -Namespace UiCapture -Name Dpi -MemberDefinition @'
         throw "The app is running but has no visible window. A photograph now would show the desktop and read as a photograph of the app."
     }
     foreach ($line in $windows) { Note "window $line" }
+
+    # AN OVERLAY SHOT MUST PROVE IT PHOTOGRAPHED THE OVERLAY. The success test above is that SOME
+    # visible window exists, which the main window satisfies on its own - so an overlay run that
+    # never drew a pill, or drew one underneath the main window, published a .ok marker and a
+    # perfectly valid photograph of the wrong thing. That happened: the anchor used to move the pill
+    # to 0,0 as well, the main window landed on top of it, and the shot was reported as captured.
+    #
+    # WHAT THIS CAN AND CANNOT SEE, because an unstated limit reads as coverage. It proves the pill
+    # EXISTS and that it is not wholly inside the main window's rectangle. It cannot see another
+    # application on top - a music player covering the screen occludes the pill and nothing here
+    # will say so, which is the same limit `probe-ui.ps1` declares as occlusion-and-other-clips.
+    if ($OverlayState) {
+        $pill = $windows | Where-Object { $_ -match 'dictation status' }
+        if (-not $pill) {
+            throw "Overlay state '$OverlayState' was asked for and no pill window is on screen. A photograph now would be of the main window and would read as a photograph of the pill."
+        }
+
+        $main = $windows | Where-Object { $_ -match '"EnviousWispr"$' } | Select-Object -First 1
+        if ($main -and ($pill -join ' ') -match '^(\d+)x(\d+) at (-?\d+),(-?\d+)') {
+            $pw = [int]$Matches[1]; $ph = [int]$Matches[2]
+            $px = [int]$Matches[3]; $py = [int]$Matches[4]
+            if ($main -match '^(\d+)x(\d+) at (-?\d+),(-?\d+)') {
+                $mw = [int]$Matches[1]; $mh = [int]$Matches[2]
+                $mx = [int]$Matches[3]; $my = [int]$Matches[4]
+                if ($px -ge $mx -and $py -ge $my -and
+                    ($px + $pw) -le ($mx + $mw) -and ($py + $ph) -le ($my + $mh)) {
+                    throw "The pill sits entirely inside the main window's rectangle, so the photograph shows the main window where the pill should be. Close or move the main window for overlay shots."
+                }
+            }
+        }
+
+        Note "overlay present: $pill"
+    }
 
     # PRESS WHAT WAS ASKED FOR, IN ORDER, BEFORE ANYTHING IS RECORDED. Each press settles before the
     # next, because a control that appears as a RESULT of the previous press does not exist yet.


### PR DESCRIPTION
Found while answering the visual half of #76, which had been closed on the accessibility path with
everything perceptual left open. Three instrument defects, all of which fail toward a confident wrong
answer.

## 1. The harness moved the pill under the main window and reported success

`Anchor` moved **every** visible window of the process bigger than 200x200 to `0,0`. The pill is
570x225, so it qualified — the pill went to the corner, then the main window went to the corner on top
of it. Both then reported `[0,0]` in the automation tree, which reads like an unpositioned overlay and
was this tool stacking them, and the run published its `.ok` marker because the success test is that
SOME visible window exists.

It also destroyed the overlay's real placement, which is a user setting and the thing an overlay shot
exists to show. Proof both ways, same command either side of the change:

| | pill reported at |
| --- | --- |
| before | `0,0` — underneath the main window, success published |
| after | **`1635,42`** — where the app actually put it |

Now anchors the main window only, chosen **by name**, for the same reason
`FACT: the-app-has-two-top-level-windows-and-the-overlay-can-win-a-uia-race` already requires it.

## 2. An overlay run now has to prove it photographed the overlay

It refuses when no pill is on screen, or when the pill lies wholly inside the main window's rectangle.
It states what it still cannot see — another application on top — which is the same limit
`probe-ui.ps1` declares as `occlusion-and-other-clips=UNMEASURED`.

## 3. `capture-window.ps1`, so an overlay can be judged without clearing somebody's desktop

A screen grab of an overlay photographs whatever is in front of it, and the first pill picture was a
music player. This asks the window to render itself, so z-order stops mattering.

**It takes per-monitor DPI awareness before measuring anything.** Without it, Windows PowerShell reports
the pill as 380x150 while it renders at 570x225, and the capture draws real pixels into a bitmap two
thirds the size: body text running off the right edge, button below the frame. That reads exactly like a
clipped layout and is entirely the instrument. Proven both ways — captures at a 1500 ms settle, refuses
loudly at 9000 ms with a message naming the likely cause, because a notice with no action dismisses
itself on its dwell.

## What it produced

`ActionNoticeHeight` was 150, derived as 108 + 8 + 34 and never measured. Measured: notices without an
action are 108 DIP, the advisory with its button is **150** — and the button clears the frame by 27 DIP.
Every severity carries its own tint on screen. Full findings on #76.

Gate green on this branch: `Validation passed`, 1,174 of 1,174 tests ran. The first attempt was refused
by the run-completeness guard — 1,110 of 1,174 in one second with the test host crashed, which is #112
still live, and the guard doing exactly its job.
