### PR TITLE
inverse text normalisation scans in linear time (#91)

### DIFF
--- a/src/Production/EnviousWispr.Architecture.Tests/InverseTextNormalizerLongInputTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/InverseTextNormalizerLongInputTests.cs
@@ -21,10 +21,20 @@ namespace EnviousWispr.Architecture.Tests;
 /// previous text marked degraded - so a user dictating sixteen hundred spoken numbers keeps their
 /// words and quietly stops getting any of them formatted.
 ///
-/// THIS GUARDS THE HEADROOM, NOT THE CLIFF. It runs a length comfortably inside the boundary, because
-/// pinning one near the limit would make the suite fail on a busy runner, which is precisely the
-/// flake that started #91. A regression that made the cost materially worse pushes even this length
-/// over. The cliff itself is NOT fixed, is deliberately not asserted here, and #91 stays open for it.
+/// THE CLIFF IS GONE, AND THE NUMBERS BELOW SAY WHERE IT WENT. Every pattern is built once and on the
+/// non-backtracking engine wherever that engine allows it, which makes a scan linear in the input;
+/// the four patterns that opened with a number run behind a lookbehind - the two money forms and the
+/// two clock forms - were rewritten to consume the guarded character instead, because a lookbehind
+/// keeps a pattern on the backtracking engine. Measured warm on the development machine after that:
+///
+///     400 words     ~1 ms
+///     800 words     ~2 ms
+///     1600 words    ~4 ms      (used to throw, every time)
+///     6400 words    ~16 ms
+///
+/// The second test pins a length four times the old cliff. It is still well inside the per-pattern
+/// guard on a linear cost, so a busy runner cannot flake it; only a return of the quadratic term
+/// could push it over, which is what it is for.
 /// </remarks>
 public sealed class InverseTextNormalizerLongInputTests
 {
@@ -36,5 +46,29 @@ public sealed class InverseTextNormalizerLongInputTests
             30));
 
         Assert.Equal(text, InverseTextNormalizer.Normalize(text));
+    }
+
+    [Fact]
+    public void FourTimesTheOldCliffComesBackIntactBecauseTheScanIsLinear()
+    {
+        var text = string.Join(' ', Enumerable.Repeat(
+            "one two three four five six seven eight nine",
+            6400 / 9));
+
+        Assert.Equal(text, InverseTextNormalizer.Normalize(text));
+    }
+
+    [Theory]
+    [InlineData("I paid twenty five dollars and ten cents", "I paid $25.10")]
+    [InlineData("it cost five cents", "it cost $0.05")]
+    [InlineData("meet at seven thirty p m", "meet at 7:30 PM")]
+    [InlineData("meet at seven o'clock", "meet at 7:00")]
+    [InlineData("3.5 dollars", "3.5 dollars")]
+    public void TheGuardedCharacterIsPutBackWhereALookbehindUsedToLeaveIt(string spoken, string expected)
+    {
+        // THE FOUR REWRITTEN PATTERNS. The character that must not precede a money or clock form is now
+        // consumed by the match rather than looked behind at, so each of these proves it is returned
+        // to the text, and the last one proves the guard still refuses a digit or a dot before the run.
+        Assert.Equal(expected, InverseTextNormalizer.Normalize(spoken));
     }
 }

--- a/src/Production/EnviousWispr.PostProcessing/InverseTextNormalizer.cs
+++ b/src/Production/EnviousWispr.PostProcessing/InverseTextNormalizer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -159,6 +160,17 @@ public static class InverseTextNormalizer
     private static readonly string SimpleOrdinalAlternation = Alternation(
         Ordinals.Keys.Where(key => !key.Contains(' ')));
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(250);
+
+    // A LOOKBEHIND WOULD KEEP THESE PATTERNS ON THE BACKTRACKING ENGINE, and these four are the ones
+    // that open with a number run, which is exactly where the quadratic re-scan lived: measured on
+    // the 800-word #91 input, the two money patterns cost 593 ms and the two time patterns 138 ms
+    // while every non-backtracking pass cost nothing. So the character that must not precede the
+    // match is CONSUMED as a named group instead of looked behind at, and each evaluator puts it
+    // back in front of what it returns. A match that gives back match.Value is unchanged, because
+    // the lead is already in it.
+    private const string Lead = "lead";
+    private static readonly string NotAfterDigitOrDot = $@"(?<{Lead}>^|[^\d.])";
+    private static readonly string NotAfterDigitOrColon = $@"(?<{Lead}>^|[^\d:])";
 
     public static string Normalize(string text, bool spokenPunctuation = false)
     {
@@ -486,7 +498,7 @@ public static class InverseTextNormalizer
     {
         var result = Replace(
             input,
-            $@"(?<![\d.])\b(?:and\s+)?(?<dollars>{NumberOrDigitRun})\s+dollars?(?:\s+and\s+(?<cents>{NumberOrDigitRun})\s+cents?)?\b",
+            $@"{NotAfterDigitOrDot}\b(?:and\s+)?(?<dollars>{NumberOrDigitRun})\s+dollars?(?:\s+and\s+(?<cents>{NumberOrDigitRun})\s+cents?)?\b",
             match =>
             {
                 var dollars = WordsToInteger(SplitWords(match.Groups["dollars"].Value));
@@ -498,16 +510,16 @@ public static class InverseTextNormalizer
                 if (match.Groups["cents"].Success &&
                     WordsToInteger(SplitWords(match.Groups["cents"].Value)) is long cents)
                 {
-                    return $"${FormatInteger(dollars.Value)}.{cents:00}";
+                    return match.Groups[Lead].Value + $"${FormatInteger(dollars.Value)}.{cents:00}";
                 }
 
-                return "$" + FormatInteger(dollars.Value);
+                return match.Groups[Lead].Value + "$" + FormatInteger(dollars.Value);
             });
         result = Replace(
             result,
-            $@"(?<![\d.])\b(?:and\s+)?(?<cents>{NumberRun})\s+cents?\b",
+            $@"{NotAfterDigitOrDot}\b(?:and\s+)?(?<cents>{NumberRun})\s+cents?\b",
             match => WordsToInteger(SplitWords(match.Groups["cents"].Value)) is long cents
-                ? (cents / 100m).ToString("$0.00", CultureInfo.InvariantCulture)
+                ? match.Groups[Lead].Value + (cents / 100m).ToString("$0.00", CultureInfo.InvariantCulture)
                 : match.Value);
         return Replace(
             result,
@@ -521,7 +533,7 @@ public static class InverseTextNormalizer
     {
         var result = Replace(
             input,
-            $@"(?<![\d:])\b(?<hour>{HourToken})(?:\s+(?<minute>{NumberOrDigitRun}))?\s+(?<period>[ap])\s*m\b",
+            $@"{NotAfterDigitOrColon}\b(?<hour>{HourToken})(?:\s+(?<minute>{NumberOrDigitRun}))?\s+(?<period>[ap])\s*m\b",
             match =>
             {
                 var hour = WordsToInteger(SplitWords(match.Groups["hour"].Value));
@@ -533,13 +545,14 @@ public static class InverseTextNormalizer
                     return match.Value;
                 }
 
-                return $"{hour}:{minute:00} {match.Groups["period"].Value.ToUpperInvariant()}M";
+                return match.Groups[Lead].Value +
+                    $"{hour}:{minute:00} {match.Groups["period"].Value.ToUpperInvariant()}M";
             });
         return Replace(
             result,
-            $@"(?<![\d:])\b(?<hour>{HourToken})\s+o'?clock\b",
+            $@"{NotAfterDigitOrColon}\b(?<hour>{HourToken})\s+o'?clock\b",
             match => WordsToInteger(SplitWords(match.Groups["hour"].Value)) is long hour && hour is >= 1 and <= 12
-                ? $"{hour}:00"
+                ? match.Groups[Lead].Value + $"{hour}:00"
                 : match.Value);
     }
 
@@ -1058,10 +1071,46 @@ public static class InverseTextNormalizer
         string input,
         string pattern,
         MatchEvaluator evaluator,
-        bool ignoreCase = true) => Regex.Replace(
-            input,
-            pattern,
-            evaluator,
-            RegexOptions.CultureInvariant | (ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None),
-            RegexTimeout);
+        bool ignoreCase = true) => Compiled(pattern, ignoreCase).Replace(input, evaluator);
+
+    // EVERY PATTERN IS BUILT ONCE, AND BUILT NON-BACKTRACKING WHEREVER THE ENGINE ALLOWS IT.
+    //
+    // The cost that opened #91 was never one pattern: a run of spoken numbers is re-derived from
+    // every starting position by every pattern that begins with a number run, and a backtracking
+    // engine pays that quadratically to FAIL, which is the common case because most text is not a
+    // number. Atomic grouping was measured and left the exponent alone, because it removes retries
+    // inside the run and not the re-scan of the run per position. The non-backtracking engine
+    // guarantees linear time in the input; the same alternations then cost what they read.
+    //
+    // It refuses lookarounds, backreferences and atomic groups by throwing at construction, so a
+    // pattern that uses one is built the ordinary way and keeps the timeout as its guard. The choice
+    // is made once per pattern and remembered; the static Regex cache holds fifteen entries and this
+    // file has more patterns than that, so it was re-parsing them on every dictation.
+    private static readonly ConcurrentDictionary<(string Pattern, bool IgnoreCase), Regex> Patterns = new();
+
+    private static Regex Compiled(string pattern, bool ignoreCase) =>
+        Patterns.GetOrAdd((pattern, ignoreCase), static key =>
+        {
+            var options = RegexOptions.CultureInvariant |
+                (key.IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
+            try
+            {
+                return new Regex(key.Pattern, options | RegexOptions.NonBacktracking, RegexTimeout);
+            }
+            catch (NotSupportedException)
+            {
+                return new Regex(key.Pattern, options, RegexTimeout);
+            }
+        });
+
+    /// <summary>The patterns that still run on the backtracking engine, for the test that keeps that list short.</summary>
+    internal static IReadOnlyList<string> BacktrackingPatterns()
+    {
+        _ = Normalize("one point five dollars and two cents at half past three on the fourth of july nineteen ninety nine");
+        return Patterns
+            .Where(pair => (pair.Value.Options & RegexOptions.NonBacktracking) == 0)
+            .Select(pair => pair.Key.Pattern)
+            .OrderBy(pattern => pattern, StringComparer.Ordinal)
+            .ToArray();
+    }
 }


### PR DESCRIPTION
## The cliff is gone

Inverse text normalisation on a long run of spoken numbers, warm, three runs each, same input as #91:

| words | before | after |
|---|---|---|
| 400 | 557, 403, 397 ms | 2, 1, 1 ms |
| 800 | 1559, 1556, 1553 ms | 2, 2, 2 ms |
| 1600 | threw, threw, threw | 3, 3, 5 ms |
| 3200 | threw | 8, 8, 40 ms |
| 6400 | threw | 16, 15, 14 ms |

Linear in the input. The mixed-sentence check (money, clock, dates, years, decimals, percent, 1,080 words) is unchanged at ~20 ms and produces the same text.

Closes #91.

## What the cost actually was

Not one pattern. Every pass that opens with a number run is re-derived by the backtracking engine from every starting position, and it pays that quadratically to *fail*, which is the common case. #118 measured that atomic grouping leaves the exponent alone, because it removes retries inside the run and not the re-scan per position. Only an engine that does not re-scan changes the exponent.

## What changed

- **Every pattern is built once, and on the non-backtracking engine wherever that engine allows it.** `Replace` now goes through a per-pattern cache; the static `Regex` cache holds fifteen entries and this file has more patterns than that, so it had been re-parsing them on every dictation. A pattern the non-backtracking engine refuses (lookarounds, atomic groups) is built the ordinary way with the same timeout guard.
- **The four patterns that opened a number run behind a lookbehind were rewritten to consume the guarded character instead** — the two money forms (`(?<![\d.])`) and the two clock forms (`(?<![\d:])`) — because a lookbehind keeps a pattern on the backtracking engine, and profiling each pass on the 800-word input showed those four were the entire remaining cost (593 ms money, 138 ms clock; every non-backtracking pass 0 ms). Each evaluator puts the consumed character back in front of what it returns; a match that returns `match.Value` is already whole.

## Evidence it is the same normaliser

- The pinned macOS oracle, byte-for-byte, and its holdout: green. This is the check that would have caught any semantic drift between the two engines.
- 57/57 in the deterministic pipeline and normaliser lanes; full suite and `validate.ps1` green.
- New tests: 6,400 words (four times the old cliff) come back intact; and six money/clock cases prove the consumed character is returned to the text and the guard still refuses a digit or dot before a run.

## Left on the backtracking engine, deliberately

Six patterns still need lookarounds (the URL and email forms, the `N to N` range, the magnitude keeper, the hyphenated number split, `a hundred`). None opens with a number run; each measured 0 ms on the pathological input. Rewriting them would be change without a number behind it.
