### PR TITLE
the Whisper card says it is not yet recommended (#101)

### DIFF
--- a/src/Production/EnviousWispr.App/MainWindow.xaml.cs
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml.cs
@@ -137,7 +137,11 @@ public sealed partial class MainWindow : Window, IDisposable
     [
         new("Automatic", "Chooses the best available local engine for this PC."),
         new("Parakeet", "Fast local English transcription with automatic hardware selection."),
-        new("Whisper", "Local multilingual transcription using your chosen language."),
+        // NOT PRESENTED AS PARAKEET'S EQUAL, BECAUSE IT IS NOT YET. Six of six live takes on this rig
+        // pasted sentences nobody said (#101): the engine elaborates room noise into fluent prose,
+        // where Parakeet degrades into a fragment a person can see is wrong. Until that closes, the
+        // card says so, and the sentence names the condition rather than the mechanism.
+        new("Whisper", "Multilingual, but not yet recommended: with room noise it can add words that were never spoken."),
     ];
 
     private static readonly SelectableChoiceOption[] PolishProviderChoices =


### PR DESCRIPTION
## What changes

The Whisper engine card on the Transcription page now reads: **Multilingual, but not yet recommended: with room noise it can add words that were never spoken.** Parakeet's copy and the default are unchanged.

## Why

#101 measured six of six live takes pasting sentences nobody said, and its own record says the Settings card should say so rather than presenting the two engines as equals until the fabrication closes. This is that interim step; it does not close #101, whose fix still needs the fabricating condition recorded with a real microphone.

## Gate

validate.ps1 green (1196 of 1196 ran). Copy only; no token, layout or behaviour change.