### PR TITLE
the timed-out-stage test can only end one way

### DIFF
--- a/src/Production/EnviousWispr.Architecture.Tests/DeterministicTextPipelineTests.cs
+++ b/src/Production/EnviousWispr.Architecture.Tests/DeterministicTextPipelineTests.cs
@@ -176,19 +176,31 @@ public sealed class DeterministicTextPipelineTests
     [Fact]
     public async Task TimedOutStageReturnsLastValidText()
     {
+        // THE STAGE CANNOT FINISH UNTIL THE ASSERTIONS HAVE RUN. This used to race a 5 ms timer
+        // against a 100 ms sleep, and on a loaded CI runner the timer callback arrived after the
+        // sleep had returned - the stage "won" at 117 ms and the run on main went red for a change
+        // in another file entirely. A stage held on a gate the test owns can only end one way.
+        using var release = new ManualResetEventSlim(false);
         var step = new DelegateStep(
             DeterministicTextStage.CustomWords,
             context =>
             {
-                Thread.Sleep(100);
+                release.Wait(TimeSpan.FromSeconds(30));
                 return context with { Text = "too late" };
             },
             TimeSpan.FromMilliseconds(5));
-        var result = await new DeterministicTextPipeline([step]).ProcessAsync(CreateRequest("safe"));
+        try
+        {
+            var result = await new DeterministicTextPipeline([step]).ProcessAsync(CreateRequest("safe"));
 
-        Assert.Equal("safe", result.Output.Text);
-        Assert.True(result.IsDegraded);
-        Assert.Equal(DeterministicStageStatus.TimedOut, Assert.Single(result.Receipts).Status);
+            Assert.Equal("safe", result.Output.Text);
+            Assert.True(result.IsDegraded);
+            Assert.Equal(DeterministicStageStatus.TimedOut, Assert.Single(result.Receipts).Status);
+        }
+        finally
+        {
+            release.Set();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## What changes

Test only. `TimedOutStageReturnsLastValidText` raced a 5 ms stage timeout against a 100 ms `Thread.Sleep`. The main run for ccb9254 lost that race on the CI runner: the timer callback arrived after the sleep returned, the stage completed at 117 ms, and the run went red for a change in a different file. The PR run of the same commit had passed.

The stage now blocks on a `ManualResetEventSlim` the test owns and releases in `finally`, so the timeout is the only way the stage can end. Run three times locally: 50/50 each.

## Why it matters

A gate that goes red on its own schedule teaches people to re-run it, which is the same lesson #112 records for the test-host crash. This removes one source of that.