### PR TITLE
the first-run window fits its own content (#83)

### DIFF
--- a/src/Production/EnviousWispr.App/MainWindow.xaml
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml
@@ -167,7 +167,7 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <ScrollViewer x:Name="OnboardingScroll" AutomationProperties.Name="Welcome to EnviousWispr" HorizontalScrollMode="Disabled">
-                <Grid MaxWidth="{StaticResource BrandOnboardingContentMaxWidth}" Padding="{StaticResource BrandOnboardingContentPadding}" HorizontalAlignment="Center">
+                <Grid x:Name="OnboardingContent" MaxWidth="{StaticResource BrandOnboardingContentMaxWidth}" Padding="{StaticResource BrandOnboardingContentPadding}" HorizontalAlignment="Center">
                     <StackPanel Spacing="{StaticResource BrandSectionSpacing}">
                         <Border Style="{StaticResource BrandHeaderCardStyle}">
                             <Grid ColumnSpacing="{StaticResource BrandOnboardingWideSpacing}">
@@ -273,7 +273,7 @@
                     so a card is 960 wide. Padding the Border and capping its child instead let the
                     button reach the full 1040 and hang 40 pixels past the cards on a wide window.
                 -->
-                <Border Grid.Row="1" Background="{ThemeResource BrandPageBgBrush}" BorderBrush="{ThemeResource BrandDividerBrush}" BorderThickness="0,1,0,0">
+                <Border x:Name="OnboardingFooter" Grid.Row="1" Background="{ThemeResource BrandPageBgBrush}" BorderBrush="{ThemeResource BrandDividerBrush}" BorderThickness="0,1,0,0">
                     <Grid MaxWidth="{StaticResource BrandOnboardingContentMaxWidth}" Padding="{StaticResource BrandOnboardingFooterPadding}">
                     <StackPanel Spacing="{StaticResource BrandSpacingS}">
                         <Button x:Name="FinishOnboardingButton" x:Uid="FinishOnboardingButton" AccessKey="G" AutomationProperties.HelpText="Completes setup and opens the EnviousWispr home page. Press Control plus Enter from anywhere on this screen." Click="FinishOnboardingButton_Click" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Style="{StaticResource BrandPrimaryButtonStyle}" Content="Get started" TabIndex="0">

--- a/src/Production/EnviousWispr.App/MainWindow.xaml.cs
+++ b/src/Production/EnviousWispr.App/MainWindow.xaml.cs
@@ -4110,6 +4110,8 @@ public sealed partial class MainWindow : Window, IDisposable
         toggle.IsOn = !toggle.IsOn;
     }
 
+    private bool _windowFitsOnboarding;
+
     private void ShowOnboarding(bool show)
     {
         OnboardingView.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
@@ -4117,7 +4119,56 @@ public sealed partial class MainWindow : Window, IDisposable
         if (show)
         {
             FinishOnboardingButton.Focus(FocusState.Programmatic);
+            OnboardingView.LayoutUpdated += FitWindowToOnboardingOnce;
         }
+        else if (_windowFitsOnboarding)
+        {
+            // THE RESIZE IS DELIBERATE AND HAPPENS ONCE, when setup finishes and the navigation
+            // list the default height was measured for comes on screen. Leaving the window at
+            // the onboarding height would put that list back behind a scrollbar.
+            _windowFitsOnboarding = false;
+            ResizeToDefault();
+        }
+    }
+
+    /// <summary>
+    /// Fits the first-run window to the onboarding content, measured on the live layout.
+    /// </summary>
+    /// <remarks>
+    /// The default height is measured for the navigation list, and on first run that list is not
+    /// on screen - so the window opened 171 layout pixels taller than the only thing it showed,
+    /// ending in a blank band below the last card. Ref: #83.
+    ///
+    /// NOTHING HERE IS DERIVED. The chrome is whatever the client area holds that is not the
+    /// onboarding view, read from the live window; the content is the scroll content's own laid-out
+    /// height, which a ScrollViewer measures unconstrained, so it is the natural height whatever the
+    /// viewport; the footer is its own laid-out height. Every previous number in this file that was
+    /// derived from arithmetic was wrong, which is why this one reads the layout instead. It runs
+    /// once, on the first layout pass where both parts have a height, and clamps to the work area
+    /// the way the default does, so a short display still opens to fit and scrolls.
+    /// </remarks>
+    private void FitWindowToOnboardingOnce(object? sender, object e)
+    {
+        if (OnboardingContent.DesiredSize.Height <= 0 || OnboardingFooter.DesiredSize.Height <= 0 || OnboardingView.ActualHeight <= 0)
+        {
+            return;
+        }
+
+        OnboardingView.LayoutUpdated -= FitWindowToOnboardingOnce;
+        var scale = DisplayScale();
+        var clientDips = AppWindow.ClientSize.Height / scale;
+        var chromeDips = Math.Max(0, clientDips - OnboardingView.ActualHeight);
+        var wantedClientDips = chromeDips + OnboardingContent.DesiredSize.Height + OnboardingFooter.DesiredSize.Height;
+        var nonClientPixels = AppWindow.Size.Height - AppWindow.ClientSize.Height;
+        var height = wantedClientDips * scale + nonClientPixels;
+        var workArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest)?.WorkArea;
+        if (workArea is { } area && area.Height > 0)
+        {
+            height = Math.Min(height, area.Height * 0.94);
+        }
+
+        _windowFitsOnboarding = true;
+        AppWindow.Resize(new SizeInt32(AppWindow.Size.Width, (int)Math.Round(height)));
     }
 
     private void ShowPage(string tag)


### PR DESCRIPTION
## What a new user sees

The first-run window is now the height of the onboarding it shows, and grows to the default height the moment they press **Get started** and the navigation list appears.

Measured on the running app at 150% (this machine), fresh data directory, through UI Automation:

| | before | after |
|---|---|---|
| first-run window height | 1590 px | 1444 px |
| scroll content | stretched to fill | fits, not vertically scrollable, view 100% |
| title, Get started, footer helper | on-screen | on-screen |
| after Get started | 1590 px, navigation visible | 1590 px, navigation visible |

Closes #83.

## How the height is found

Nothing is derived. On the first layout pass where the parts have a size, the handler reads the live window: the chrome is whatever the client area holds that is not the onboarding view; the content is the scroll content's **measured** height (`DesiredSize`, which a ScrollViewer takes unconstrained, so it is the natural height); the footer is its own measured height. It runs once, clamps to 94% of the work area exactly as the default does, and `ShowOnboarding(false)` calls `ResizeToDefault()` only when the window was fitted this way.

The first attempt read `ActualHeight` and changed nothing, because a ScrollViewer *arranges* its child to at least the viewport - the content reported 900 when the viewport was 900. That is the "a change that ships and does nothing" shape the design system warns about, and the trace that caught it is in the commit message.

## Limits, stated

- Verified at 150% only. The computation reads the layout rather than a constant, so it has no scale in it, but 100% and 200% were not looked at; changing the display scale is a system setting on the founder's machine.
- The resize on Get started is instant and deliberate rather than animated; #83 allowed either.

## Gate

validate.ps1 green on this tree.
