### PR TITLE
build the ITN patterns off the timed path, not inside the 500 ms stage

### DIFF
--- a/src/Production/EnviousWispr.Pipeline/DeterministicTextPipeline.cs
+++ b/src/Production/EnviousWispr.Pipeline/DeterministicTextPipeline.cs
@@ -67,6 +67,11 @@ public sealed class DeterministicTextPipeline
     public DeterministicTextPipeline()
         : this(CreateDefaultSteps())
     {
+        // OFF EVERY TIMED PATH. Inverse text normalisation builds heavy non-backtracking patterns on
+        // first use; paying that here, at construction, keeps it out of the 500 ms ITN stage where a
+        // loaded runner once crossed the timeout and dropped normalisation. The app builds this once
+        // at startup, so a user's first dictation is already warm. Ref: #91, #112.
+        InverseTextNormalizer.Warm();
     }
 
     public DeterministicTextPipeline(IReadOnlyList<IDeterministicTextStep> steps)

--- a/src/Production/EnviousWispr.PostProcessing/InverseTextNormalizer.cs
+++ b/src/Production/EnviousWispr.PostProcessing/InverseTextNormalizer.cs
@@ -1104,9 +1104,28 @@ public static class InverseTextNormalizer
         });
 
     /// <summary>The patterns that still run on the backtracking engine, for the test that keeps that list short.</summary>
+    // BUILDING THE NON-BACKTRACKING PATTERNS COSTS ~257 ms, PAID ONCE PER PROCESS ON THE FIRST CALL.
+    // That construction must never fall inside the pipeline's 500 ms ITN stage: on a loaded CI runner
+    // it crossed the timeout, the stage returned un-normalised text, and the macOS parity oracle
+    // mismatched. Worse for a user, their first dictation on a busy machine could lose ITN the same
+    // way. So the pipeline calls this from its constructor, which runs off every timed path and off
+    // the hotkey path, and the Lazy makes a second pipeline free. Ref: #91, #112.
+    private static readonly Lazy<bool> WarmOnce = new(() =>
+    {
+        _ = Normalize(WarmRepresentative);
+        _ = Normalize(WarmRepresentative, spokenPunctuation: true);
+        return true;
+    });
+
+    private const string WarmRepresentative =
+        "one point five dollars and two cents at half past three on the fourth of july nineteen ninety nine";
+
+    /// <summary>Builds every pattern once, so no later call pays construction inside a timed stage.</summary>
+    public static void Warm() => _ = WarmOnce.Value;
+
     internal static IReadOnlyList<string> BacktrackingPatterns()
     {
-        _ = Normalize("one point five dollars and two cents at half past three on the fourth of july nineteen ninety nine");
+        Warm();
         return Patterns
             .Where(pair => (pair.Value.Options & RegexOptions.NonBacktracking) == 0)
             .Select(pair => pair.Key.Pattern)


### PR DESCRIPTION
## The regression

After #91 merged, main went red intermittently on `SharedParityFixtureMatchesPinnedMacBehaviorAndDocumentedDifferences` (084778a's run), while the next commit passed the full 1196-test suite. Not a flake in the usual sense: **my #91 change caused it.**

The move to a non-backtracking engine made the first `Normalize` call in a process pay ~257 ms to construct the ~40 patterns (measured, five cold processes: 250-263 ms). That cost fell inside the pipeline's 500 ms ITN stage. On a loaded CI runner it crossed the timeout, the stage returned the last valid (un-normalised) text, and the byte-for-byte parity oracle mismatched. The same path means a user's first dictation on a busy machine could silently lose inverse text normalisation.

## The fix

The parameterless `DeterministicTextPipeline` constructor warms the patterns once, via a process-wide `Lazy` in `InverseTextNormalizer.Warm()`. Construction is paid at pipeline creation, which is off every timed stage and off the hotkey path; the app builds this pipeline once at startup (a field), so the first real dictation is already warm.

## Measured, cold process, after the fix

```
ctor(warm) 288 ms | ITN stage 8 ms status Completed | out: call me at 9:15 AM about $25 on the fourth
```

The ~280 ms is now in the constructor; the ITN stage receipt is 8 ms. A 3x-slower runner stays far under 500 ms, so the cold-construction timeout cannot recur. This is the causal fix with the number that shows it, not a green run over an intermittent.

## Gate

validate.ps1 green, 1196 of 1196 ran; ITN and deterministic-pipeline lanes 57/57.