### PR TITLE
drive the real hotkey in the journey harness, silently, and never trust the injector

### DIFF
--- a/.claude/knowledge/INDEX.md
+++ b/.claude/knowledge/INDEX.md
@@ -12,6 +12,7 @@ Read only the files relevant to the task, but read each selected file completely
 | A crash, hang, silent exit, or any "why did it do that" | `diagnostics.md` FIRST, then the matching contract |
 | Any shipped implementation | the always-on rules are already in context; add the matching contracts above |
 | Parity with the macOS app, or "does Windows have X yet" | the catalog first (below), then `mac-parity-audit.md` |
+| Driving the real app in a test - the journey harness, synthetic input, a UAT verdict, "did the hotkey work" | `uat-testing.md`, then `diagnostics.md` for the log it reads |
 | Historical measurements or experiments | Matching file under `../../notes/` |
 
 ## The cross-platform catalog answers parity questions first
@@ -46,3 +47,4 @@ surfaces the row without the whole index. One row per line, every row carries a 
 - [architecture.md](architecture.md) — **when:** architecture, dependency, platform choice, project layout, new module, where does this live, out of process, worker
 - [product-contract.md](product-contract.md) — **when:** product decision, scope, invariant, privacy boundary, are we allowed to, should we ship, release gate, is this a defect
 - [mac-parity-audit.md](mac-parity-audit.md) — **when:** macOS parity, does Windows have, missing feature, the Mac does, on macOS, how does the Mac, deliberately different
+- [uat-testing.md](uat-testing.md) — **when:** journey harness, synthetic input, SendInput, injected input, UAT verdict, did the hotkey work, the harness says, synthetic-hotkey, INSTRUMENT INVALID, WisprEyes, drive the app

--- a/.claude/knowledge/architecture.md
+++ b/.claude/knowledge/architecture.md
@@ -54,7 +54,11 @@ reason but ask rather than assert it, and write the answer here when you get it.
 ## Windows integration
 
 - Audio: WASAPI through a maintained .NET wrapper or a narrow native bridge.
-- Hotkey: `RegisterHotKey` where possible, with a low-level hook only for combinations it cannot express.
+- Hotkey: ONE route, a `WH_KEYBOARD_LL` hook (`WindowsPushToTalkHook`), for every binding. The original
+  intent was `RegisterHotKey` where possible, and it did not survive for a reason worth keeping: push-to-talk
+  needs the key-UP edge and `RegisterHotKey` delivers only the press. `RegisterHotKey` remains in that file
+  as a conflict PROBE - register, unregister, report - and never receives a keystroke, which is why a
+  synthetic press takes exactly the path a finger takes (see `uat-testing.md`).
 - Focus and context: Windows UI Automation with explicit fallbacks and privacy limits.
 - Delivery: clipboard-backed paste through narrowly scoped `SendInput`, with clipboard-only fallback when
   synthetic paste is refused. Two routes, not the macOS cascade of five, and that is deliberate.

--- a/.claude/knowledge/uat-testing.md
+++ b/.claude/knowledge/uat-testing.md
@@ -29,6 +29,13 @@ profile it could not read, a control window that meant nothing: none of these sa
 and a runner must never average them into a pass rate. Exit **2** is a product expectation not met. A red
 row for a scenario the harness could not STAGE is worse than a skip, because it accuses correct code.
 
+**Unknown arguments are refused for the same reason.** Every flag test in the harness is an exact match, so
+a mistyped or joined flag selects nothing and the DEFAULT journey runs. On 2026-09-05 a wrapper passed
+`--english-parakeet,--synthetic-hotkey` as one token and the named-event French journey came back green in
+place of the Parakeet synthetic-hotkey run that was asked for - caught only because the result's `inputKind`
+was read against the request. A green run of the wrong journey is the most expensive kind of pass; the
+harness now refuses (exit 3) before a journey is chosen, and a wrapper should still assert the label.
+
 ## RULE: resolve-the-binding-or-refuse-never-guess
 Ported from the macOS `ptt_binding` contract. Three states, not two: **absent** (no settings file in the
 isolated profile) resolves through the SAME default the app applies, `DictationPreferences.Default`,

--- a/.claude/knowledge/uat-testing.md
+++ b/.claude/knowledge/uat-testing.md
@@ -1,0 +1,100 @@
+# Driving the real app in a test
+
+**when:** the journey harness, synthetic input, `SendInput`, a UAT verdict, "did the hotkey work", "the
+harness says". Read `diagnostics.md` with this: the log it describes is the oracle everything here reads.
+
+The method is the macOS harness's ("WisprEyes"), arrived at there by brute force over a summer and ported
+here after this machine reproduced its founding failure verbatim. **Make something happen, then read what
+the app said about itself.** Every failure below came from trusting the harness's own account instead.
+
+## RULE: the-app-log-is-the-oracle-and-the-injector-has-no-vote
+A verdict comes from `app.jsonl` (`HotkeyReady`, `DictationRecordingStarted`, `TextDeliveryCompleted`,
+`ApplicationCleanShutdown`) or from the controlled delivery target. It never comes from the harness's
+account of what it did. `SendKey` returns void; `SendInput`'s count is about insertion, not arrival, and a
+value that is present will be read as "the OS said it worked" at 2am. The named-event start
+(`ENVIOUSWISPR_UAT_JOURNEY_START_EVENT`) needs no injection at all and is the default take; injected
+input is ONE narrow declared capability (`--synthetic-hotkey`), not the foundation. macOS has no
+zero-injection start and said this design is the one it would build if starting again.
+
+## RULE: assert-the-payload-before-the-syscall
+Two preconditions in the injector wrapper, before anything leaves the process: the Win64 `INPUT` is 40
+bytes, and the payload is not empty. Nothing downstream - return value, hooks, desktop, foreground,
+timing - can expose a well-formed request for zero movement, because by the time any of them sees it, it
+is a legitimate event. See FACT: six-explanations-one-non-event below for the night this cost.
+
+## RULE: instrument-invalid-is-not-a-product-verdict
+`JourneyExpectationException.Instrument(...)` ends the run with exit code **3** and the words
+`INSTRUMENT INVALID`. A key the resolver would not guess, a payload that failed its precondition, a
+profile it could not read, a control window that meant nothing: none of these say anything about the app,
+and a runner must never average them into a pass rate. Exit **2** is a product expectation not met. A red
+row for a scenario the harness could not STAGE is worse than a skip, because it accuses correct code.
+
+## RULE: resolve-the-binding-or-refuse-never-guess
+Ported from the macOS `ptt_binding` contract. Three states, not two: **absent** (no settings file in the
+isolated profile) resolves through the SAME default the app applies, `DictationPreferences.Default`,
+because a fresh profile really is running F8 with nothing on disk; **valid** is a gesture the app's own
+parser accepts and its own key map (`WindowsVirtualKeyMap`, via `InternalsVisibleTo`) can name;
+**malformed** is refused, because it says nothing about what the app is listening for. A resolver that
+falls back to a hardcoded key presses something nothing is listening for and files the FAIL against the
+product - on macOS, 2026-08-10, on the one branch where a hotkey FAIL was most likely to be believed.
+Configuration and drivability are different questions: the resolver owns the first; a chord it refuses is
+refused because the harness declared it undrivable, and the message says which.
+
+## RULE: a-positive-control-needs-its-negative-half-and-the-window-has-to-mean-something
+`HotkeyReady → DictationRecordingStarted` after a press proves the marker appears when you press. It does
+not prove the marker is absent when you do not, and a marker that can arrive for another reason turns every
+run green. So the synthetic take holds still for a quiet window first and requires the marker ABSENT, then
+presses and requires it PRESENT. And "absent for N" only certifies anything once the same marker has been
+watched arriving in well under N - the run measures press-to-recording latency and refuses to count the
+absence if the window was not comfortably longer. That check is also a drift alarm for start-up latency.
+
+## RULE: declare-the-boundary-before-a-scenario-finds-it
+Single non-modifier keys are drivable: the hook is event-driven and a 0 ms synthetic press lands. A
+modifier-only tap (`Ctrl+Win`, #66) completes on a **40 ms poll** (`HotkeyEdgeTracker` tick), so an
+instant synthetic press can go down and up between two ticks and be seen by nothing - silently,
+intermittently, looking exactly like a flaky hotkey. macOS has the twin: three synthetic presses inside its
+500 ms chain window read as double-then-single EVERY time, written down as a hard limit. If a chord is ever
+driven synthetically: hold well past the tick with margin, budget from the observed TAIL not the mean, and
+log the app-side observed hold against what the injector asked for - a disagreement is the instrument.
+
+## RULE: the-harness-must-not-reach-the-founders-real-data-or-play-sound
+Isolated profile, isolated credential suffix, its own controlled target, clipboard snapshot and restore. It
+refuses to run while an unowned `EnviousWispr.App` exists, because a second low-level hook would also
+receive the injected key and start a REAL take into whatever is focused. **The refusal is by process
+name**; a differently-named build holds the same hook and is invisible to it (macOS identifies by
+executable path for that reason). And the machine is in the founder's home: the fixture is the microphone,
+and the modes that play audio through the speakers are for a free room, not the small hours.
+
+## RULE: read-the-log-during-ordinary-use-before-building-a-driver
+The founder dictates all day and `app.jsonl` carries the whole chain. A staged take proves the path runs;
+an unstaged one proves it on input nobody chose. Check the log for the feature's marker before writing a
+driver for it.
+
+## FACT: one-hotkey-route-verified-by-reading-2026-09-05
+`WindowsPushToTalkHook` detects every press through `WH_KEYBOARD_LL` → `HotkeyEdgeTracker.Process`.
+`RegisterHotKey` appears only in `ProbeConflict()` - register, unregister, return - and never receives a
+keystroke. The hook marshals `Flags` and never inspects it: **no `LLKHF_INJECTED` filter.** So a synthetic
+press takes exactly the path a finger takes, and there is no product decision to make about accepting
+synthetic input. `architecture.md` described the intent ("`RegisterHotKey` where possible"); the code
+chose the hook because push-to-talk needs the key-UP edge. A peer reading the doc inferred two routes.
+Settled by reading the 425-line file, which is cheaper than the dual logging that would have measured it.
+
+## FACT: six-explanations-one-non-event-2026-09-05
+Two sessions (2026-09-04, 05) concluded injected input was inert on this PC and, in order, blamed
+`GameInputSvc`'s invisible foreground window, the tool sandbox, screen lock, UIPI, and hook latency; a
+peer added "read insertion as arrival". **The probe had never injected anything.** It built `INPUT` by
+PowerShell nested assignment (`$mv.mi.dx = 40` writes to a COPY of a value type), so the struct sent was
+`dx=0 dy=0 dwFlags=0` - proven by dumping the bytes, not by story. `SendInput` inserted one valid request
+for nothing and returned 1, correctly. A second helper used a 48-byte struct where Win64 needs 40 and was
+rejected outright. With a C#-built payload: 0 ms time-to-land, 3/3, no hooks; own LL hooks saw the events
+flagged INJECTED; `SetCursorPos` immediate. Input desktop `Default`, session 1, unlocked, no clip, no
+third-party DLL in the process.
+
+**What was right and what was lucky, kept apart.** The bisection with own LL hooks told the truth because
+that probe happened to build its struct in C#; "install hooks to diagnose injection" is the wrong lesson.
+The right ones: build P/Invoke payloads where they mutate in place and ASSERT them (RULE above); ruling
+something out is not finding the cause; find the artifact that is TRUE in one world and FALSE in the
+other instead of re-running the failing action in a changed environment - `OpenInputDesktop` said
+`Default` in one call, where a behavioural retest can succeed for a reason you did not change. And a
+half-result that looks like progress (the service DID hold foreground) is not to be counted.
+Ref: #77 correction, #53, #66 comments of 2026-09-05; probes under the session scratchpad.

--- a/src/Production/EnviousWispr.App/App.xaml.cs
+++ b/src/Production/EnviousWispr.App/App.xaml.cs
@@ -1963,12 +1963,26 @@ public partial class App : Application, IAsyncDisposable
 
             using (startEvent)
             {
-                var started = await Task.Run(
-                        () => startEvent.WaitOne(TimeSpan.FromSeconds(30)))
-                    .ConfigureAwait(false);
-                if (!started || _exitRequested || _disposed)
+                // A HARNESS THAT DRIVES THE REAL HOTKEY NEVER SIGNALS START. It presses the key itself
+                // and asks this method for one thing only: a clean exit it can trigger once the log and
+                // the target have said the take landed. Without that, the only exit left is this wait
+                // timing out, and a slow transcription would then end the app mid-journey and read as
+                // omitted stages - a harness limit reported as a product defect. The exit event is
+                // optional and lives in the same allowlisted scheme as START; when it is configured the
+                // window is long enough that the harness, not this constant, decides when the run ends.
+                TryOpenJourneyUatEvent("ENVIOUSWISPR_UAT_JOURNEY_EXIT_EVENT", out var exitEvent);
+                using (exitEvent)
                 {
-                    return;
+                    var started = await Task.Run(() => exitEvent is null
+                            ? startEvent.WaitOne(TimeSpan.FromSeconds(30))
+                            : WaitHandle.WaitAny(
+                                [startEvent, exitEvent],
+                                TimeSpan.FromSeconds(120)) == 0)
+                        .ConfigureAwait(false);
+                    if (!started || _exitRequested || _disposed)
+                    {
+                        return;
+                    }
                 }
             }
 

--- a/src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj
+++ b/src/Production/EnviousWispr.Services/EnviousWispr.Services.csproj
@@ -5,6 +5,9 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="EnviousWispr.Architecture.Tests" />
+    <!-- The journey harness resolves the recording key through the app's OWN parser and key map, so
+         it can never press a key nothing is listening for. -->
+    <InternalsVisibleTo Include="EnviousWispr.AppJourney.Uat" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/app-journey-uat/JourneyExpectationException.cs
+++ b/tools/app-journey-uat/JourneyExpectationException.cs
@@ -41,4 +41,22 @@ internal sealed class JourneyExpectationException : Exception
         : base(message, innerException)
     {
     }
+
+    /// <summary>The HARNESS could not do its job; nothing here is a verdict about the app.</summary>
+    /// <remarks>
+    /// AN INSTRUMENT FAILURE REPORTED AS A PRODUCT VERDICT IS THE DEFECT CLASS THIS EXISTS TO STOP.
+    /// On 2026-09-04 and 05 two sessions here concluded that injected input was inert on the
+    /// development machine and built five explanations on top of it; the injector had been handed an
+    /// all-zero struct and had never injected anything. The macOS harness carries the same lesson from
+    /// 2026-08-10, when a resolver pressed a key nothing was listening for and the FAIL was believed.
+    ///
+    /// So a refusal to press, a key that could not be resolved, a payload that failed its own
+    /// precondition, or a control window too short to mean anything ends the run with its own exit
+    /// code and the words INSTRUMENT INVALID, and a runner can never average it into a pass rate.
+    /// </remarks>
+    public bool InstrumentInvalid { get; private init; }
+
+    /// <summary>A reason the harness cannot proceed that says nothing about the product.</summary>
+    public static JourneyExpectationException Instrument(string message) =>
+        new(message) { InstrumentInvalid = true };
 }

--- a/tools/app-journey-uat/Program.cs
+++ b/tools/app-journey-uat/Program.cs
@@ -3,9 +3,11 @@ using EnviousWispr.Audio;
 using EnviousWispr.ASR;
 using EnviousWispr.Core.Audio;
 using EnviousWispr.Core.Dictation;
+using EnviousWispr.Core.Input;
 using EnviousWispr.Core.Settings;
 using EnviousWispr.Core.Runtime;
 using EnviousWispr.ModelDelivery;
+using EnviousWispr.Services.Input;
 using EnviousWispr.Services.Runtime;
 using EnviousWispr.Services.Settings;
 using NAudio.Codecs;
@@ -73,6 +75,15 @@ if (headStart && livePreview)
         "--head-start and --live-preview are mutually exclusive: the head start deliberately stands "
             + "down when Live Preview is on, so asking for both asserts a state the app refuses.");
 }
+// THE ONE TAKE THAT PRESSES THE REAL KEY WITHOUT A SOUND. Every other synthetic mode either asks the
+// app to press for itself over a named event, or presses F8 and plays audio through the speakers. This
+// one injects the resolved recording key with the silent fixture as the microphone, so the installed
+// global hook - the path a finger takes - is what starts the take, and nothing is heard in the room.
+// Verdicts come from app.jsonl and the controlled target; the injector's own account is never one.
+var syntheticHotkey = args.Any(argument => string.Equals(
+    argument,
+    "--synthetic-hotkey",
+    StringComparison.OrdinalIgnoreCase));
 var deterministicProfileArgument = ArgumentValue(args, "--deterministic-profile");
 var deterministicProfile = deterministicProfileArgument?.ToLowerInvariant() switch
 {
@@ -161,6 +172,14 @@ if (deterministicProfile != DeterministicJourneyProfile.None &&
 {
     throw new JourneyExpectationException(
         "Deterministic-profile UAT requires --english-parakeet and cannot be combined with local polish, Live Preview, live microphone, Escape Recovery, or failure injection.");
+}
+if (syntheticHotkey &&
+    (liveMicrophone || livePreview || headStart || escapeRecovery || failureMode != JourneyFailureMode.None))
+{
+    throw new JourneyExpectationException(
+        "--synthetic-hotkey drives the installed global hook with the silent reviewed fixture and cannot be "
+            + "combined with live or manual microphone, Live Preview, the head start, Escape Recovery, or "
+            + "failure injection: each of those owns the trigger or the hold in a different way.");
 }
 if (polishProvider == PolishProvider.EgOne)
 {
@@ -357,6 +376,8 @@ using var readyEvent = new EventWaitHandle(false, EventResetMode.ManualReset, re
 using var runtimeEvent = new EventWaitHandle(false, EventResetMode.ManualReset, runtimeEventName);
 using var startEvent = new EventWaitHandle(false, EventResetMode.ManualReset, startEventName);
 using var completeEvent = new EventWaitHandle(false, EventResetMode.ManualReset, completeEventName);
+var exitEventName = $@"Local\EnviousLabs.EnviousWispr.JourneyUat.{runId}.exit";
+using var exitEvent = new EventWaitHandle(false, EventResetMode.ManualReset, exitEventName);
 
 Process? target = null;
 Process? app = null;
@@ -371,6 +392,7 @@ var ownedWorkerCount = 0;
 var ownedPolishWorkerIds = Array.Empty<int>();
 var ownedPolishWorkerCount = 0;
 ClipboardGuard? clipboardGuard = null;
+SyntheticHotkeyEvidence? syntheticHotkeyEvidence = null;
 var usesPublicFixtureJourney = !liveMicrophone &&
     failureMode is JourneyFailureMode.None or JourneyFailureMode.TargetUnavailable;
 
@@ -456,6 +478,12 @@ try
         appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_START_EVENT"] = startEventName;
         appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_COMPLETE_EVENT"] = completeEventName;
         appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_EXIT_AFTER_COMPLETION"] = "1";
+        if (syntheticHotkey)
+        {
+            // START is never signalled in this mode; the harness ends the run through this event once
+            // the log and the target have spoken, and the app's own exit-after-completion does the rest.
+            appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_EXIT_EVENT"] = exitEventName;
+        }
         if (failureMode == JourneyFailureMode.TargetUnavailable)
         {
             appStart.Environment["ENVIOUSWISPR_UAT_JOURNEY_HOLD_MILLISECONDS"] = "2000";
@@ -580,7 +608,20 @@ try
                 clipboardGuard = ClipboardGuard.CaptureOrThrow();
             }
 
-            startEvent.Set();
+            if (syntheticHotkey)
+            {
+                syntheticHotkeyEvidence = DriveSyntheticHotkey(
+                    diagnosticPath,
+                    targetResultPath,
+                    target.MainWindowHandle,
+                    profileDirectory);
+                exitEvent.Set();
+            }
+            else
+            {
+                startEvent.Set();
+            }
+
             if (failureMode == JourneyFailureMode.TargetUnavailable)
             {
                 if (!WaitForDiagnosticEvent(
@@ -768,6 +809,7 @@ try
         provider,
         modelPack,
         acousticProbe,
+        syntheticHotkey = syntheticHotkeyEvidence,
         polish = PolishProviderName(polishProvider),
         polishCompleted = polishEvidence.Completed,
         polishDegraded = polishEvidence.Degraded,
@@ -786,6 +828,7 @@ try
             _ when manualMicrophone => "PhysicalF8-FounderSpeech-ProductionWasapi",
             _ when synthesizedAcoustic => "SyntheticF8-WindowsSpeechPlayback-ProductionWasapi",
             _ when liveMicrophone => "SyntheticF8-ReviewedFixturePlayback-ProductionWasapi",
+            _ when syntheticHotkey => "SyntheticHotkey-InstalledGlobalHook-ReviewedFixtureAudioCapture",
             _ => "NamedEvents-ReviewedFixtureAudioCapture",
         },
         audioCapture = failureMode switch
@@ -850,6 +893,19 @@ finally
         }
     }
 }
+}
+catch (JourneyExpectationException instrument) when (instrument.InstrumentInvalid)
+{
+    // THE HARNESS COULD NOT DO ITS JOB, AND THAT IS NOT A VERDICT ABOUT THE APP. Its own exit code and
+    // its own words, so a runner can never average it into a pass rate or read it as a product FAIL.
+    // The class of defect this stops is written on JourneyExpectationException.Instrument.
+    Console.Error.WriteLine();
+    Console.Error.WriteLine("INSTRUMENT INVALID");
+    Console.Error.WriteLine($"  {instrument.Message}");
+    Console.Error.WriteLine();
+    Console.Error.WriteLine("The harness refused or could not stage this run. Nothing above is evidence about");
+    Console.Error.WriteLine("the product; fix the instrument and run again.");
+    return 3;
 }
 catch (JourneyExpectationException expectation)
 {
@@ -1721,11 +1777,31 @@ static byte[] RepeatPcm(byte[] pcmBytes, int sampleRate, int repetitions)
     return repeated;
 }
 
+/// <summary>Presses or releases one key, and says NOTHING about whether the app saw it.</summary>
+/// <remarks>
+/// THE PAYLOAD IS CHECKED BEFORE THE SYSCALL, BECAUSE NOTHING AFTER IT CAN. On 2026-09-04 and 05 a
+/// probe built its INPUT struct by PowerShell nested assignment, which writes to a copy, and handed
+/// SendInput a well-formed struct requesting nothing. SendInput inserted it and returned 1 - correctly.
+/// Two sessions then concluded injected input was inert on this machine and built five explanations on
+/// a request for zero movement. A 48-byte struct in a second helper was rejected outright for the same
+/// lack of a check. Both are caught here, for someone who never read this.
+///
+/// IT RETURNS VOID ON PURPOSE. SendInput's count is about insertion, not arrival, and a value present
+/// is a value somebody will read as "the OS said it worked". A count mismatch is an instrument failure
+/// and is reported as one; success is only ever established from app.jsonl afterwards.
+/// </remarks>
 static void SendKey(byte virtualKey, bool keyDown)
 {
     if (Marshal.SizeOf<Input>() != 40)
     {
-        throw new JourneyExpectationException("The synthetic keyboard input does not match the Win64 ABI.");
+        throw JourneyExpectationException.Instrument(
+            "The synthetic keyboard input does not match the Win64 ABI (INPUT must be 40 bytes).");
+    }
+
+    if (virtualKey == 0)
+    {
+        throw JourneyExpectationException.Instrument(
+            "Refusing to send an empty keyboard event: no virtual key was resolved.");
     }
 
     var input = new Input
@@ -1740,10 +1816,186 @@ static void SendKey(byte virtualKey, bool keyDown)
             },
         },
     };
+    if (input.Data.Keyboard.VirtualKey == 0 && input.Data.Keyboard.ScanCode == 0)
+    {
+        throw JourneyExpectationException.Instrument(
+            "Refusing to send an empty keyboard event: the payload carries no key.");
+    }
+
     if (NativeMethods.SendInput(1, [input], Marshal.SizeOf<Input>()) != 1)
     {
-        throw new JourneyExpectationException("Synthetic keyboard input was rejected.");
+        throw JourneyExpectationException.Instrument(
+            "Synthetic keyboard input was not inserted into the input stream.");
     }
+}
+
+/// <summary>The take that starts the way a finger starts it, with nothing heard in the room.</summary>
+/// <remarks>
+/// EVERY VERDICT HERE IS READ FROM THE APP'S OWN LOG OR THE TARGET, NEVER FROM THE INJECTOR. This is
+/// the method the macOS harness ("WisprEyes") arrived at after a summer of brute force: make something
+/// happen, then read what the app said about itself. Its failures all came from trusting the harness's
+/// own account instead, and this machine reproduced that failure verbatim on 2026-09-04.
+///
+/// THE CONTROL HAS BOTH HALVES. HotkeyReady proves the hook is installed before anything is pressed; a
+/// quiet window proves DictationRecordingStarted is ABSENT when nothing is pressed; the press proves it
+/// PRESENT; and the observed press-to-marker latency then has to fit comfortably inside the quiet
+/// window, or the absence meant nothing and the run says so. That last check is also a drift alarm: the
+/// day the app gets slower to start a take, this fails loudly instead of the control quietly weakening.
+///
+/// ONE ROUTE, VERIFIED BY READING. WindowsPushToTalkHook detects every press through its low-level
+/// keyboard hook; RegisterHotKey there is a conflict probe that registers and unregisters at once. An
+/// injected key therefore takes the path a finger takes, and the hook does not filter LLKHF_INJECTED.
+///
+/// SINGLE NON-MODIFIER KEYS ONLY. A modifier-only tap completes on a 40 ms poll, so an instant
+/// synthetic press can fall between ticks and vanish - a harness artifact that reads as a flaky hotkey.
+/// That is a declared boundary, refused by the resolver up front, not a scenario to discover at 2am.
+/// </remarks>
+static SyntheticHotkeyEvidence DriveSyntheticHotkey(
+    string diagnosticPath,
+    string targetResultPath,
+    nint targetWindow,
+    string profileDirectory)
+{
+    var quietWindow = TimeSpan.FromSeconds(2);
+    // The app's own default fixture hold (ResolveJourneyUatHoldDuration), so the two fixture-driven
+    // modes differ in their trigger and nothing else.
+    var holdAfterRecording = TimeSpan.FromMilliseconds(150);
+
+    if (!WaitForDiagnosticEvent(diagnosticPath, "HotkeyReady/", TimeSpan.FromSeconds(10)))
+    {
+        throw new JourneyExpectationException(
+            "The app never reported HotkeyReady, so there is no installed hook to press a key for.");
+    }
+
+    var virtualKey = ResolveRecordingVirtualKey(profileDirectory);
+
+    // NEGATIVE HALF: nothing is pressed, so nothing may start.
+    Thread.Sleep(quietWindow);
+    if (ReadDiagnosticEvents(diagnosticPath).Any(value =>
+            value.StartsWith("DictationRecordingStarted/", StringComparison.Ordinal)))
+    {
+        throw new JourneyExpectationException(
+            "A recording started before any key was pressed, so DictationRecordingStarted is not "
+                + "exclusive to the press and this control cannot certify anything.");
+    }
+
+    BringToForeground(targetWindow);
+    Thread.Sleep(250);
+
+    // POSITIVE HALF: the resolved key, held past the moment the app says it is recording.
+    var pressed = Stopwatch.StartNew();
+    SendKey(virtualKey, keyDown: true);
+    var recordingStarted = WaitForDiagnosticEvent(
+        diagnosticPath,
+        "DictationRecordingStarted/",
+        TimeSpan.FromSeconds(3));
+    var pressToRecording = pressed.Elapsed;
+    Thread.Sleep(holdAfterRecording);
+    SendKey(virtualKey, keyDown: false);
+    var heldFor = pressed.Elapsed;
+    if (!recordingStarted)
+    {
+        throw new JourneyExpectationException(
+            "The injected recording key did not start a recording within 3 seconds: the installed hook "
+                + "did not act on it.");
+    }
+
+    // THE QUIET WINDOW HAS TO HAVE MEANT SOMETHING. Absence for N certifies nothing until the same
+    // marker has been watched arriving in well under N.
+    if (pressToRecording * 3 > quietWindow)
+    {
+        throw JourneyExpectationException.Instrument(
+            $"The quiet window ({quietWindow.TotalMilliseconds:F0} ms) is not comfortably longer than the "
+                + $"observed press-to-recording latency ({pressToRecording.TotalMilliseconds:F0} ms), so its "
+                + "absence check meant nothing. Lengthen the window or find out why the app got slower.");
+    }
+
+    if (!WaitForDiagnosticEvent(diagnosticPath, "TextDeliveryCompleted/", TimeSpan.FromSeconds(45)))
+    {
+        throw new JourneyExpectationException(
+            "The synthetic-hotkey take did not reach TextDeliveryCompleted; "
+                + $"events={string.Join(',', ReadDiagnosticEvents(diagnosticPath))}.");
+    }
+
+    var targetObserved = WaitForExpectedTargetResult(targetResultPath, TimeSpan.FromSeconds(5));
+    return new SyntheticHotkeyEvidence(
+        VirtualKey: $"0x{virtualKey:X2}",
+        HeldMilliseconds: (int)heldFor.TotalMilliseconds,
+        QuietWindowMilliseconds: (int)quietWindow.TotalMilliseconds,
+        PressToRecordingMilliseconds: (int)pressToRecording.TotalMilliseconds,
+        TargetObserved: targetObserved);
+}
+
+/// <summary>The key the app is listening for, or a refusal - never a guess.</summary>
+/// <remarks>
+/// PORTED FROM THE macOS HARNESS'S ptt_binding CONTRACT. On 2026-08-10 that harness pressed a key
+/// nothing was listening for and the FAIL was believed, on the one branch where a hotkey FAIL was most
+/// likely to be believed. The defect class is an instrument failure reported as a product verdict, and
+/// the design that stops it has THREE states, not two:
+///   absent    - no settings file in the isolated profile - resolves through the SAME default the app
+///               applies, DictationPreferences.Default, because a fresh profile really is running F8
+///               with nothing on disk, and refusing there would reject a valid configuration;
+///   valid     - a gesture the app's own parser accepts and its own key map can name - the binding;
+///   malformed - anything else - REFUSED, because it says nothing about what the app is using.
+/// The parser and the key map are the app's own (WindowsVirtualKeyMap, through InternalsVisibleTo), so
+/// this cannot decay into a remembered table the way the macOS resolver once did.
+///
+/// CONFIGURATION ONLY. Whether the injector can drive the key is the caller's question. Chords and
+/// modifier taps are refused here because this harness has declared them undrivable, not because they
+/// are misconfigured; the message says which.
+/// </remarks>
+static byte ResolveRecordingVirtualKey(string profileDirectory)
+{
+    var settingsPath = Path.Combine(profileDirectory, "settings.json");
+    string gestureText;
+    if (!File.Exists(settingsPath))
+    {
+        gestureText = DictationPreferences.Default.PushToTalkGesture;
+    }
+    else
+    {
+        var loaded = new JsonSettingsStore(settingsPath).LoadAsync().GetAwaiter().GetResult();
+        if (loaded.Status is not (SettingsLoadStatus.Loaded or SettingsLoadStatus.Migrated))
+        {
+            throw JourneyExpectationException.Instrument(
+                $"The isolated profile's settings could not be read ({loaded.Status}), so the recording "
+                    + "key cannot be established; refusing to guess.");
+        }
+
+        gestureText = loaded.Settings.Preferences.Dictation.PushToTalkGesture;
+    }
+
+    var parsed = HotkeyGestureParser.Parse(gestureText);
+    if (!parsed.Succeeded || parsed.Gesture is null)
+    {
+        throw JourneyExpectationException.Instrument(
+            "The configured recording gesture does not parse with the app's own parser, so nothing can "
+                + "be pressed for it; refusing to guess.");
+    }
+
+    var gesture = parsed.Gesture.Value;
+    if (!WindowsVirtualKeyMap.TryMap(gesture.Key, out var virtualKey))
+    {
+        throw JourneyExpectationException.Instrument(
+            "The configured recording key has no entry in the app's own key map, so nothing can be "
+                + "pressed for it; refusing to guess.");
+    }
+
+    if (gesture.Modifiers != HotkeyModifiers.None || HotkeyEdgeTracker.IsModifierKey(virtualKey))
+    {
+        throw JourneyExpectationException.Instrument(
+            "The recording binding is a chord or a modifier tap. Those complete on a 40 ms poll that an "
+                + "instant synthetic press can fall between, so this harness declares them undrivable "
+                + "rather than report a flaky hotkey. Drive them with a finger.");
+    }
+
+    if (virtualKey is 0 or > 0xFF)
+    {
+        throw JourneyExpectationException.Instrument(
+            "The resolved virtual key is outside the range SendInput takes.");
+    }
+
+    return (byte)virtualKey;
 }
 
 static void RemoveUatDirectory(string path)
@@ -1985,6 +2237,14 @@ static string FailureModeName(JourneyFailureMode failureMode) => failureMode swi
     JourneyFailureMode.TargetUnavailable => "target-unavailable",
     _ => "none",
 };
+
+/// <summary>Content-free evidence of the synthetic-hotkey take: which key, how long, how fast.</summary>
+internal sealed record SyntheticHotkeyEvidence(
+    string VirtualKey,
+    int HeldMilliseconds,
+    int QuietWindowMilliseconds,
+    int PressToRecordingMilliseconds,
+    bool TargetObserved);
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct Input

--- a/tools/app-journey-uat/Program.cs
+++ b/tools/app-journey-uat/Program.cs
@@ -38,6 +38,7 @@ const string ReviewedEnglishFixtureHash =
 // a catch around the parts already found has no end; starting it at the first statement does.
 try
 {
+RequireKnownArguments(args);
 var syntheticMicrophonePlayback = args.Any(argument => string.Equals(
     argument,
     "--live-microphone",
@@ -2055,6 +2056,60 @@ static void BringToForeground(nint window)
         {
             _ = NativeMethods.AttachThreadInput(currentThread, foregroundThread, attach: false);
         }
+    }
+}
+
+/// <summary>Refuses an argument this harness does not know, before any journey is chosen.</summary>
+/// <remarks>
+/// A GREEN RUN OF THE WRONG JOURNEY IS THE MOST EXPENSIVE KIND OF PASS. On 2026-09-05 a wrapper joined
+/// two flags into one token, `--english-parakeet,--synthetic-hotkey`. Every flag test here is an exact
+/// match, so the token matched nothing, the harness ran its DEFAULT named-event journey, and that came
+/// back green - a pass, for a journey nobody had asked for. It was caught only because the result's
+/// `inputKind` label was read against the request. That is the macOS harness's failure mode (b): the
+/// menu path proving the pipeline healthy while saying nothing about the hotkey.
+///
+/// So an unrecognised argument is INSTRUMENT INVALID, exit code 3, and no journey runs. The set below
+/// is the harness's own flags; the `--mode`, `--result` and substring switches in this file belong to
+/// the controlled target's command line and are never accepted here.
+/// </remarks>
+static void RequireKnownArguments(string[] arguments)
+{
+    string[] booleanFlags =
+    [
+        "--live-microphone", "--manual-microphone", "--english-parakeet", "--live-preview",
+        "--head-start", "--escape-recovery", "--synthesized-acoustic", "--synthetic-hotkey",
+    ];
+    string[] valuedFlags =
+    [
+        "--acoustic-gain", "--app-executable", "--deterministic-profile", "--eg1-model", "--eg1-server",
+        "--failure", "--ollama-endpoint", "--ollama-model", "--polish",
+    ];
+    for (var index = 0; index < arguments.Length; index++)
+    {
+        var argument = arguments[index];
+        if (booleanFlags.Contains(argument, StringComparer.OrdinalIgnoreCase))
+        {
+            continue;
+        }
+
+        if (valuedFlags.Contains(argument, StringComparer.OrdinalIgnoreCase))
+        {
+            var value = index + 1 < arguments.Length ? arguments[index + 1] : null;
+            if (value is null || value.StartsWith("--", StringComparison.Ordinal))
+            {
+                throw JourneyExpectationException.Instrument(
+                    $"{argument} needs a value and none followed it; refusing to run a journey other than "
+                        + "the one asked for.");
+            }
+
+            index++;
+            continue;
+        }
+
+        throw JourneyExpectationException.Instrument(
+            $"Unrecognised argument '{argument}'. This harness matches flags exactly and would otherwise run "
+                + "its default journey and report it green; refusing instead. Known flags: "
+                + string.Join(' ', booleanFlags.Concat(valuedFlags)) + ".");
     }
 }
 

--- a/tools/app-journey-uat/README.md
+++ b/tools/app-journey-uat/README.md
@@ -201,3 +201,38 @@ edges and playback source are still synthetic. On the current webcam-microphone 
 fixture and Windows-synthesized sentence were detected by the content-free probe but failed their lexical gates;
 speaker echo suppression is the likely boundary. The `--manual-microphone` mode makes the remaining requirement
 directly runnable, but it is not evidence until a person completes it successfully on the exact candidate build.
+
+## Synthetic hotkey: the installed global hook, without a sound
+
+`--synthetic-hotkey` is the take that starts the way a finger starts it. The reviewed fixture is still the
+microphone, so nothing plays through the speakers, but the harness never signals the START event: it resolves
+the recording key the app is actually listening for, injects that key through `SendInput`, and the app's
+installed `WH_KEYBOARD_LL` hook - the same single route every real press takes - starts and stops the take.
+
+```powershell
+dotnet run --no-build --project .\tools\app-journey-uat\EnviousWispr.AppJourney.Uat.csproj `
+  -c Release -- --english-parakeet --synthetic-hotkey
+```
+
+Every verdict is read from `app.jsonl` and the controlled target, never from the injector. The control has
+both halves: `HotkeyReady` must be logged before anything is pressed; a two-second quiet window must show
+`DictationRecordingStarted` ABSENT; the press must make it PRESENT within three seconds; and the observed
+press-to-recording latency must fit comfortably inside the quiet window, or the run refuses to count the
+absence. The result adds a content-free `syntheticHotkey` object: the virtual key, how long it was held, the
+quiet window, the press-to-recording latency, and whether the target observed the phrase.
+
+The recording key is resolved through the app's own parser and key map from the isolated profile, in three
+states: no settings file resolves to the app's default (`F8`, `DictationPreferences.Default`); a gesture the
+app accepts is the binding; anything else is refused. Chords and modifier taps are refused as a declared
+boundary - their gesture completes on a 40 ms poll that an instant synthetic press can fall between - and
+that refusal says so rather than reporting a flaky hotkey.
+
+**Exit codes.** `0` is a pass. `2` is `JOURNEY EXPECTATION NOT MET`: the app did not do what the journey
+required. `3` is `INSTRUMENT INVALID`: the harness could not stage or trust the run - a key it would not
+guess, a payload that failed its own precondition, a control window that meant nothing - and **nothing in a
+code-3 run is evidence about the product.** A runner must never average it into a pass rate.
+
+This mode cannot be combined with live or manual microphone, Live Preview, the head start, Escape Recovery, or
+failure injection, each of which owns the trigger or the hold differently. It refuses to run while an unowned
+EnviousWispr instance exists, because a second low-level hook would also receive the injected key and start a
+real take. It proves the installed hook and the real key path; it still does not prove the microphone.

--- a/tools/app-journey-uat/README.md
+++ b/tools/app-journey-uat/README.md
@@ -230,7 +230,11 @@ that refusal says so rather than reporting a flaky hotkey.
 **Exit codes.** `0` is a pass. `2` is `JOURNEY EXPECTATION NOT MET`: the app did not do what the journey
 required. `3` is `INSTRUMENT INVALID`: the harness could not stage or trust the run - a key it would not
 guess, a payload that failed its own precondition, a control window that meant nothing - and **nothing in a
-code-3 run is evidence about the product.** A runner must never average it into a pass rate.
+code-3 run is evidence about the product.** A runner must never average it into a pass rate. An unrecognised
+argument is also code 3: the harness matches flags exactly, so a mistyped or joined flag would otherwise select
+the default journey and report it green in place of the one requested - which is exactly what happened on
+2026-09-05 when a wrapper passed `--english-parakeet,--synthetic-hotkey` as one token. Read the result's
+`inputKind` against what you asked for; the harness now refuses before it can happen.
 
 This mode cannot be combined with live or manual microphone, Live Preview, the head start, Escape Recovery, or
 failure injection, each of which owns the trigger or the hold differently. It refuses to run while an unowned

--- a/tools/app-journey-uat/README.md
+++ b/tools/app-journey-uat/README.md
@@ -236,6 +236,11 @@ the default journey and report it green in place of the one requested - which is
 2026-09-05 when a wrapper passed `--english-parakeet,--synthetic-hotkey` as one token. Read the result's
 `inputKind` against what you asked for; the harness now refuses before it can happen.
 
+Running from a git worktree: the model packs are not in git, so bring them in as **hard links or real files,
+never symlinks** - .NET reports `FileInfo.Length` of 0 for a symlink, so the Parakeet `Int8Complete` probe
+correctly refuses a pack made of them ("the gitignored Parakeet quantized model is required"). Measured
+2026-09-05: the same file read 0 bytes as a symlink and 652,183,999 as a hard link.
+
 This mode cannot be combined with live or manual microphone, Live Preview, the head start, Escape Recovery, or
 failure injection, each of which owns the trigger or the hold differently. It refuses to run while an unowned
 EnviousWispr instance exists, because a second low-level hook would also receive the injected key and start a


### PR DESCRIPTION
## What this proves

A dictation can now be started **through the real hotkey path, synthetically, with nothing heard in the room** — and the harness can say so with evidence it did not write itself. Run twice on this machine, once per final-ASR engine, so the only thing that differed between the known-good named-event journey and these was the trigger.

| | Whisper (default French path) | Parakeet (`--english-parakeet`) |
|---|---|---|
| exit code / wall | **0** / 16 s | **0** / 8 s |
| `HotkeyReady` before any press | yes | yes |
| quiet window, nothing pressed → `DictationRecordingStarted` | **absent** for 2000 ms | **absent** for 2000 ms |
| injected key (resolved from the app's own default) | `F8` / `0x77` | `F8` / `0x77` |
| press → `DictationRecordingStarted`, via the installed `WH_KEYBOARD_LL` hook | **108 ms** | **109 ms** |
| held | 264 ms | 267 ms |
| `TextDeliveryCompleted` → controlled target observed the phrase | yes | yes |
| `ApplicationCleanShutdown`, owned worker cleaned up | yes | yes |
| provider / pack | CUDA / quantized | CUDA / full precision |

The press-to-recording latency is engine-independent, as it should be: it measures the hook, not the model. Content-free evidence rides in the result as `"syntheticHotkey":{"VirtualKey":"0x77","HeldMilliseconds":…,"QuietWindowMilliseconds":2000,"PressToRecordingMilliseconds":…,"TargetObserved":true}` beside `inputKind: SyntheticHotkey-InstalledGlobalHook-ReviewedFixtureAudioCapture`.

## How

- **`--synthetic-hotkey`** in `tools/app-journey-uat`. The reviewed fixture is still the microphone; START is never signalled; the key is resolved and injected; the app's hook does the rest. Verdicts come from `app.jsonl` and the target only.
- **Both halves of the control.** Absent-before, present-after, and the observed latency must fit comfortably inside the quiet window or the run refuses to count the absence (also a start-up drift alarm).
- **`SendKey` asserts its payload before the syscall** (40 bytes, not empty) and **returns void**. A count mismatch is an instrument failure, not evidence.
- **`INSTRUMENT INVALID`, exit 3**, distinct from `JOURNEY EXPECTATION NOT MET`, exit 2. A key the resolver would not guess, a payload that failed its precondition, a control window that meant nothing, **an argument the harness does not recognise** — none of it is a verdict about the app, and a runner cannot average it into a pass rate.
- **Unknown arguments are refused before a journey is chosen.** Every flag test is an exact match, so a joined or mistyped flag used to select the *default* journey and report it green. That happened during this work (`--english-parakeet,--synthetic-hotkey` as one token) and was caught only by reading the result label. Verified three ways on the machine: the joined token, a typo, and `--polish` with no value each exit 3 without touching the running app.
- **Three-state binding resolver** (`absent` → the app's default; `valid` → the binding; `malformed` → refuse), through the app's own `HotkeyGestureParser` and `WindowsVirtualKeyMap` (`InternalsVisibleTo`), so it cannot decay into a remembered table. Chords and modifier taps are refused as a **declared boundary** — their gesture completes on a 40 ms poll an instant press can fall between.
- **App: one optional allowlisted event**, `ENVIOUSWISPR_UAT_JOURNEY_EXIT_EVENT`, in the existing UAT-gated flow, so the harness ends the run when the evidence is in rather than when a 30 s constant fires. No change to the normal production path.
- **One route, verified by reading, not grep absence.** `RegisterHotKey` in `WindowsPushToTalkHook` is a conflict probe that registers and unregisters at once; every press, real or injected, goes through the low-level hook, which does not filter `LLKHF_INJECTED`. `architecture.md` now says so and why the original intent did not survive (push-to-talk needs the key-UP edge).

## Why now

On 2026-09-04/05 two sessions concluded injected input was inert on this machine and built five explanations on a probe whose `INPUT` struct had been zero-filled by a PowerShell value-type copy; `SendInput` inserted a request for nothing and returned 1, correctly. `uat-testing.md` records the discipline this PR encodes — the log is the oracle, assert the payload, instrument ≠ product, negative half, declared boundaries, refuse what you do not recognise — and that night as its founding FACT. The #77 "injected input is inert" comment is corrected on the issue.

## Limits, stated

- Single non-modifier keys only. `Ctrl+Win` (#66) is refused by design until its poll-window timing is driven deliberately (hold past the tick with margin, budget from the tail, compare app-observed hold to requested).
- Proves the installed hook and the real key path. Does **not** prove the microphone; `--manual-microphone` remains the physical acceptance.
- Refuses to run beside an unowned `EnviousWispr.App` (a second hook would also take the key). That refusal is by process name; a differently named build would be invisible to it.
- Two runs, one machine, CUDA. A worktree needs its model packs as hard links or real files, not symlinks — the README says why.

## Gate

`validate.ps1` green on this tree: 34/34 portable contract tests, 1196/1196 architecture tests (1192 passed, 4 pre-existing skips), every harness built, bundled runtime worker launch validated. CI is the merge gate; not to be merged before it is green on the final commit.

Refs #53, #66, #77.
